### PR TITLE
Optimize Kinesis for multiple mixed stream records (Fix Issue #340)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ android:
     - build-tools-24.0.2
     - build-tools-19.1.0
     - android-11
+    - android-15
 sudo: true
 script:
     - sudo rm /etc/mavenrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
     - android-15
 sudo: true
 script:
-    - sudo rm /etc/mavenrc
+    - sudo rm -f /etc/mavenrc
     - export MAVEN_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m"
     - mvn clean install -Dmaven.javadoc.skip=true cobertura:cobertura
 

--- a/aws-android-sdk-kinesis/src/main/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/FileRecordStore.java
+++ b/aws-android-sdk-kinesis/src/main/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/FileRecordStore.java
@@ -56,7 +56,7 @@ class FileRecordStore {
     /**
      * Creates the FileRecordStore.
      *
-     * @param recorderDirectory The directory (which the FileRecordStore is only
+     * @param workDirectory The directory (which the FileRecordStore is only
      *            used for the KinesisRecorder) to use to store requests in
      * @param recordFileName Name of the record file
      * @param maxStorageSize Maximum storage size in bytes

--- a/aws-android-sdk-kinesis/src/main/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/KinesisStreamRecordSender.java
+++ b/aws-android-sdk-kinesis/src/main/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/KinesisStreamRecordSender.java
@@ -54,7 +54,7 @@ class KinesisStreamRecordSender implements RecordSender {
      *
      * @param client an {@link AmazonKinesis} client
      * @param userAgent user agent string to be set in each request
-     * @param config the Kinesis recorder config.
+     * @param partitionKey the Kinesis partition key.
      */
     public KinesisStreamRecordSender(AmazonKinesis client, String userAgent,
             String partitionKey) {


### PR DESCRIPTION
**Issue**

Kinesis Firehose takes a very long time to batch and submit records when records from multiple streams are mixed in the record store.

**Description**

Our Android client is submitting data to 14 different Firehose streams. The records are saved into the Kinesis recordStore as soon as they're generated. This result in a fragmented recordStore (i.e. 3 records from stream1, followed by 1 record from stream2, followed by 2 records from stream3).

The way submitAll() works is that it batches consecutive records belonging to one stream, submits them, then grabs the next batch of consecutive records belonging to another stream. This works well when the records are sorted by stream name. But as one can image, in a fragmented record store, this produces a lot of batches with very few records. This causes submitAllRecords() to run for a long time consuming device CPU and power, and very little bandwidth. In our case, it can run for more than an hour.

**Offered Solution**

We can minimize the number of batches being sent by grouping records of the same stream together before sending. We can do so efficiently by iterating through the records in the recordStore and saving them in a batch buffer according to their respective stream. Once the maximum batch size is reached for any of the stream batches, it gets submitted.