### PR TITLE
Update AwsIotEndpointUtility.java

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AwsIotEndpointUtility.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AwsIotEndpointUtility.java
@@ -91,7 +91,7 @@ public final class AwsIotEndpointUtility {
         String endpointWithoutPort = stripPort(endpoint);
         validateIotEndpoint(endpointWithoutPort);
         String[] splits = splitEndpoint(endpointWithoutPort);
-
+        int offset = splits.length == ENDPOINT_CN_ATS_SPLIT_SIZE?(ENDPOINT_REGION_OFFSET+1):ENDPOINT_REGION_OFFSET;
         return Region.getRegion(Regions.fromName(splits[ENDPOINT_REGION_OFFSET]));
     }
 

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AwsIotEndpointUtility.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AwsIotEndpointUtility.java
@@ -92,7 +92,7 @@ public final class AwsIotEndpointUtility {
         validateIotEndpoint(endpointWithoutPort);
         String[] splits = splitEndpoint(endpointWithoutPort);
         int offset = splits.length == ENDPOINT_CN_ATS_SPLIT_SIZE?(ENDPOINT_REGION_OFFSET+1):ENDPOINT_REGION_OFFSET;
-        return Region.getRegion(Regions.fromName(splits[ENDPOINT_REGION_OFFSET]));
+        return Region.getRegion(Regions.fromName(splits[offset]));
     }
 
     /**


### PR DESCRIPTION

When I use this endpoint like "xxxxx.ats.iot.cn-north-1.amazonaws.com.cn", `Region.getRegion` throws an exception __Cannot create enum from iot value__.
It was later found that the intercepted region by split endpoint was incorrect, it returned "iot" instead of "cn-north-1";