### PR TITLE
Use intent to pass custom flags

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/Auth.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/Auth.java
@@ -63,7 +63,7 @@ public final class Auth {
     /**
      * Bundle containing customization flags for chrome custom tab
      */
-    private final Bundle extraCustomBundle;
+    private final Bundle customTabExtras;
 
     /**
      * This identifies the settings for additional userPool features.
@@ -150,7 +150,7 @@ public final class Auth {
                  final boolean advancedSecurityDataCollectionFlag,
                  final String identityProvider,
                  final String idpIdentifier,
-                 final Bundle extraCustomBundle) {
+                 final Bundle customTabExtras) {
         this.context = context;
         this.appWebDomain = appWebDomain;
         this.appId = appId;
@@ -165,7 +165,7 @@ public final class Auth {
         this.advancedSecurityDataCollectionFlag = advancedSecurityDataCollectionFlag;
         this.identityProvider = identityProvider;
         this.idpIdentifier = idpIdentifier;
-        this.extraCustomBundle = extraCustomBundle;
+        this.customTabExtras = customTabExtras;
         getCurrentUser();
     }
 
@@ -233,7 +233,7 @@ public final class Auth {
         /**
          * Bundle of flags to customize chrome custom tab UI
          */
-        private Bundle mExtraCustomBundle;
+        private Bundle mCustomTabsExtras;
 
         /**
          * Flag indicating if data collection for advanced security mode is enabled.
@@ -418,12 +418,12 @@ public final class Auth {
          * <p>
          *     Optional. Set a bundle to customize UI
          * </p>
-         * @param mExtraCustomBundle Optional: Pass to chrome custom tab a bundle of customization flags
+         * @param mCustomTabsExtras Optional: Pass to chrome custom tab a bundle of customization flags
          * @return A reference to this builder.
          */
         @SuppressWarnings("checkstyle:hiddenfield")
-        public Builder setExtraCustomBundle(final Bundle mExtraCustomBundle) {
-            this.mExtraCustomBundle = mExtraCustomBundle;
+        public Builder setCustomTabsExtras(final Bundle mCustomTabsExtras) {
+            this.mCustomTabsExtras = mCustomTabsExtras;
             return this;
         }
 
@@ -445,7 +445,7 @@ public final class Auth {
                     this.mAdvancedSecurityDataCollectionFlag,
                     this.mIdentityProvider,
                     this.mIdpIdentifier,
-                    this.mExtraCustomBundle);
+                    this.mCustomTabsExtras);
         }
 
 
@@ -590,8 +590,8 @@ public final class Auth {
     /**
      * @return Extra customization bundle for this {@link Auth} instance.
      */
-    public Bundle getExtraCustomBundle() {
-        return extraCustomBundle;
+    public Bundle getCustomTabExtras() {
+        return customTabExtras;
     }
 
     /**

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/Auth.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/Auth.java
@@ -19,6 +19,7 @@ package com.amazonaws.mobileconnectors.cognitoauth;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Bundle;
 import android.util.Patterns;
 
 import com.amazonaws.mobileconnectors.cognitoauth.exceptions.AuthInvalidParameterException;
@@ -58,6 +59,11 @@ public final class Auth {
      * Identity provider (idp) identifier, works as an alias to the real idp
      */
     private final String idpIdentifier;
+
+    /**
+     * Bundle containing customization flags for chrome custom tab
+     */
+    private final Bundle extraCustomBundle;
 
     /**
      * This identifies the settings for additional userPool features.
@@ -143,7 +149,8 @@ public final class Auth {
                  final AuthHandler userHandler,
                  final boolean advancedSecurityDataCollectionFlag,
                  final String identityProvider,
-                 final String idpIdentifier) {
+                 final String idpIdentifier,
+                 final Bundle extraCustomBundle) {
         this.context = context;
         this.appWebDomain = appWebDomain;
         this.appId = appId;
@@ -158,6 +165,7 @@ public final class Auth {
         this.advancedSecurityDataCollectionFlag = advancedSecurityDataCollectionFlag;
         this.identityProvider = identityProvider;
         this.idpIdentifier = idpIdentifier;
+        this.extraCustomBundle = extraCustomBundle;
         getCurrentUser();
     }
 
@@ -221,6 +229,11 @@ public final class Auth {
          * Idp identifier for the userPool.
          */
         private String mIdpIdentifier;
+
+        /**
+         * Bundle of flags to customize chrome custom tab UI
+         */
+        private Bundle mExtraCustomBundle;
 
         /**
          * Flag indicating if data collection for advanced security mode is enabled.
@@ -401,6 +414,20 @@ public final class Auth {
         }
 
         /**
+         * Sets customization bundle. This allow to customize chrome custom tab.
+         * <p>
+         *     Optional. Set a bundle to customize UI
+         * </p>
+         * @param mExtraCustomBundle Optional: Pass to chrome custom tab a bundle of customization flags
+         * @return A reference to this builder.
+         */
+        @SuppressWarnings("checkstyle:hiddenfield")
+        public Builder setExtraCustomBundle(final Bundle mExtraCustomBundle) {
+            this.mExtraCustomBundle = mExtraCustomBundle;
+            return this;
+        }
+
+        /**
          * Instantiates {@link Auth} with the set options.
          * @return {@link Auth}.
          */
@@ -417,7 +444,8 @@ public final class Auth {
                     this.mUserHandler,
                     this.mAdvancedSecurityDataCollectionFlag,
                     this.mIdentityProvider,
-                    this.mIdpIdentifier);
+                    this.mIdpIdentifier,
+                    this.mExtraCustomBundle);
         }
 
 
@@ -557,6 +585,13 @@ public final class Auth {
      */
     public String getIdpIdentifier() {
         return idpIdentifier;
+    }
+
+    /**
+     * @return Extra customization bundle for this {@link Auth} instance.
+     */
+    public Bundle getExtraCustomBundle() {
+        return extraCustomBundle;
     }
 
     /**

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -531,8 +531,8 @@ public class AuthClient {
     	try {
 	        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(mCustomTabsSession);
 	        mCustomTabsIntent = builder.build();
-	        if(pool.getExtraCustomBundle() != null)
-	            mCustomTabsIntent.intent.putExtras(pool.getExtraCustomBundle());
+	        if(pool.getCustomTabExtras() != null)
+	            mCustomTabsIntent.intent.putExtras(pool.getCustomTabExtras());
 	        mCustomTabsIntent.intent.setPackage(ClientConstants.CHROME_PACKAGE);
 	        mCustomTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
 	        mCustomTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -531,6 +531,8 @@ public class AuthClient {
     	try {
 	        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(mCustomTabsSession);
 	        mCustomTabsIntent = builder.build();
+	        if(pool.getExtraCustomBundle() != null)
+	            mCustomTabsIntent.intent.putExtras(pool.getExtraCustomBundle());
 	        mCustomTabsIntent.intent.setPackage(ClientConstants.CHROME_PACKAGE);
 	        mCustomTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
 	        mCustomTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);


### PR DESCRIPTION
Allow customisation of chrome custom tab by passing a Bundle to [CustomTabsIntent](https://developer.android.com/reference/android/support/customtabs/CustomTabsIntent)

Example (Kotlin):
```
builder.setExtraCustomBundle(Bundle().apply {
    putInt(EXTRA_TOOLBAR_COLOR, ContextCompat.getColor(context, R.color.primary))
})
```

Sorry for the approximative naming & javadoc

Thanks
