### PR TITLE
[Urgent] [Pinpoint Android SDK] Add missing "withAttributes" to Event payload while generating PutEventsRequest

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
@@ -583,6 +583,7 @@ public class EventRecorder {
                 .withClientSdkVersion(internalEvent.getSdkVersion())
                 .withEventType(internalEvent.getEventType())
                 .withMetrics(internalEvent.getAllMetrics())
+                .withAttributes(internalEvent.getAllAttributes())
                 .withSdkName(internalEvent.getSdkName())
                 .withSession(session)
                 .withTimestamp(DateUtils.formatISO8601Date(new Date(internalEvent.getEventTimestamp())));


### PR DESCRIPTION
In EventRecorder.java class, when converting to Event to submit to Pinpoint, the Event payload is missing `attributes` due to lack of copying `attributes` from the AnalyticsEvent.