### PR TITLE
Fix cognito userpools username null in custom auth flow fixes #583

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
@@ -2757,7 +2757,7 @@ public class CognitoUser {
         Map<String, String> authenticationParameters = authenticationDetails.getAuthenticationParameters();
         if (clientSecret != null &&
             authenticationParameters.get(CognitoServiceConstants.AUTH_PARAM_SECRET_HASH) == null) {
-            secretHash = CognitoSecretHash.getSecretHash(usernameInternal, clientId, clientSecret);
+            secretHash = CognitoSecretHash.getSecretHash(authenticationDetails.getUserId(), clientId, clientSecret);
             authenticationParameters.put(CognitoServiceConstants.AUTH_PARAM_SECRET_HASH, secretHash);
         }
         authRequest.setAuthParameters(authenticationDetails.getAuthenticationParameters());


### PR DESCRIPTION
The custom flow starts, but fails to set the username in the initial request. This pull request does not change the internal username variable to limit the impact of this change.