### PR TITLE
[KinesisVideo] Fix integration tests

### DIFF
--- a/aws-android-sdk-kinesisvideo-archivedmedia/build.gradle
+++ b/aws-android-sdk-kinesisvideo-archivedmedia/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 11
+        minSdkVersion 21
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
@@ -25,14 +25,19 @@ android {
         abortOnError false
     }
 
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+    }
+
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    api (project(":aws-android-sdk-core")){
+    api (project(":aws-android-sdk-core")) {
         exclude group: "com.google.android", module: "android"
     }
+    implementation project(":aws-android-sdk-kinesisvideo")
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation project(":aws-android-sdk-testutils")

--- a/aws-android-sdk-kinesisvideo-archivedmedia/src/androidTest/java/com/amazonaws/services/kinesisvideoarchivedmedia/KinesisVideoArchivedMediaIntegrationTestBase.java
+++ b/aws-android-sdk-kinesisvideo-archivedmedia/src/androidTest/java/com/amazonaws/services/kinesisvideoarchivedmedia/KinesisVideoArchivedMediaIntegrationTestBase.java
@@ -20,6 +20,9 @@ import org.json.JSONObject;
 import org.junit.Before;
 
 import java.io.IOException;
+
+import com.amazonaws.services.kinesisvideo.AWSKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AWSKinesisVideoClient;
 import com.amazonaws.testutils.AWSTestBase;
 
 public abstract class KinesisVideoArchivedMediaIntegrationTestBase extends AWSTestBase {
@@ -27,6 +30,8 @@ public abstract class KinesisVideoArchivedMediaIntegrationTestBase extends AWSTe
     /** Package name in testconfiguration.json */
     protected static final String PACKAGE_NAME = InstrumentationRegistry.getTargetContext().
             getResources().getString(R.string.package_name);
+
+    protected static AWSKinesisVideo kvClient;
 
     public static JSONObject getPackageConfigure()  {
         return getPackageConfigure(PACKAGE_NAME);
@@ -39,5 +44,6 @@ public abstract class KinesisVideoArchivedMediaIntegrationTestBase extends AWSTe
     @Before
     public void setUp() throws IOException {
         setUpCredentials();
+        kvClient = new AWSKinesisVideoClient(credentials);
     }
 }

--- a/aws-android-sdk-kinesisvideo/src/androidTest/java/com/amazonaws/services/kinesisvideo/KinesisVideoIntegrationTest.java
+++ b/aws-android-sdk-kinesisvideo/src/androidTest/java/com/amazonaws/services/kinesisvideo/KinesisVideoIntegrationTest.java
@@ -51,8 +51,10 @@ public class KinesisVideoIntegrationTest extends KinesisVideoIntegrationTestBase
             currentNextToken = listStreamsResult.getNextToken();
 
             for (StreamInfo info : listStreamsResult.getStreamInfoList()) {
-                kvClient.deleteStream(new DeleteStreamRequest()
-                        .withStreamARN(info.getStreamARN()));
+                if (info.getStreamName().startsWith(streamPrefix)) {
+                    kvClient.deleteStream(new DeleteStreamRequest()
+                            .withStreamARN(info.getStreamARN()));
+                }
             }
         } while (currentNextToken != null);
     }


### PR DESCRIPTION
Improve stream deletion logic because tests are run in parallel
Add back the stream creation when testing KinesisVideoArchivedMedia