### PR TITLE
Update AWSIotMqttManager to respect the SDK's global time offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * **AWS Core**
   * Fixed support for EU (Stockholm) region - `eu-north-1` by adding to `RegionDefaults`. See [issue #797](https://github.com/aws-amplify/aws-sdk-android/issues/797)
 
+* **AWS IoT**
+  * Fixed the timestamp used for signing requests to AWS IoT by accounting for the offset specified in `SDKGlobalConfiguration`. See [issue #814](https://github.com/aws-amplify/aws-sdk-android/issues/814)
+
 ## [Release 2.12.6](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.12.6)
 
 ### Misc. Updates

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -21,6 +21,7 @@ import android.os.HandlerThread;
 import android.os.Looper;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Region;
 import com.amazonaws.util.StringUtils;
@@ -795,7 +796,7 @@ public class AWSIotMqttManager {
                 try {
                     final String mqttWebSocketURL = signer.getSignedUrl(endpointWithHttpPort, 
                         clientCredentialsProvider.getCredentials(),
-                        System.currentTimeMillis());
+                        System.currentTimeMillis() - SDKGlobalConfiguration.getGlobalTimeOffset() * MILLIS_IN_ONE_SECOND);
 
                     final MqttConnectOptions options = new MqttConnectOptions();
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-amplify/aws-sdk-android/issues/814

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
