### PR TITLE
Update federatedSignIn to immediately contact service; refresh Google…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Release 2.12.7](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.12.7)
 
+### Enhancements
+
+* **AWS Mobile Client**
+  * Updated `federatedSignIn()` method to contact the service immediately to validate tokens. The `signIn()` method will also attempt to federated immediately when applicable. See [issue #800](https://github.com/aws-amplify/aws-sdk-android/issues/800)
+  * Fix Google or Facebook refresh when using the drop-in UI. See [issue #809](https://github.com/aws-amplify/aws-sdk-android/issues/809), [issue #700](https://github.com/aws-amplify/aws-sdk-android/issues/700)
+  * Annotated methods that are designed to be called from UI thread or from a background thread with @AnyThread and @WorkerThread, respectively.
+
 ### Bug Fixes
 
 * **AWS Core**

--- a/aws-android-sdk-auth-google/src/main/java/com/amazonaws/mobile/auth/google/GoogleSignInProvider.java
+++ b/aws-android-sdk-auth-google/src/main/java/com/amazonaws/mobile/auth/google/GoogleSignInProvider.java
@@ -110,8 +110,8 @@ public class GoogleSignInProvider implements SignInProvider, SignInPermissionsHa
 
     /**
      * Constructor. Builds the Google Api Client.
-     * @param context context.
-     * @param configuration the AWS Configuration.
+     * @param activityContext context.
+     * @param awsConfig the AWS Configuration.
      */
     @Override
     public void initialize(@NonNull final Context activityContext, 

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/UserStateDetails.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/UserStateDetails.java
@@ -17,7 +17,6 @@
 
 package com.amazonaws.mobile.client;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class UserStateDetails {


### PR DESCRIPTION
…/Facebook from drop-in UI

Updated `federatedSignIn()` method to contact the service immediately to validate tokens. The `signIn()` method will also attempt to federated immediately when applicable. See [issue #800](https://github.com/aws-amplify/aws-sdk-android/issues/800)
Fix Google or Facebook refresh when using the drop-in UI. See [issue #809](https://github.com/aws-amplify/aws-sdk-android/issues/809), [issue #700](https://github.com/aws-amplify/aws-sdk-android/issues/700)
Annotated methods that are designed to be called from UI thread or from a background thread with @AnyThread and @WorkerThread, respectively.