### PR TITLE
[Core] AWSKeyValuestore bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 * **AWS Core**
   * Fixed support for EU (Stockholm) region - `eu-north-1` by adding to `RegionDefaults`. See [issue #797](https://github.com/aws-amplify/aws-sdk-android/issues/797)
+  * Fixed a bug where a stringSet stored in `SharedPreferences` cannot be migrated to the `AWSKeyValueStore`.
+  * Propagate the exception when loading/creating the encryption key fails while trying to persist data through `AWSKeyValueStore`.
 
 ## [Release 2.12.6](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.12.6)
 

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
@@ -431,6 +431,7 @@ public class CognitoCachingCredentialsProvider
             registerIdentityChangedListener(listener);
         } catch (Exception ex) {
             Log.e(TAG, "Error in initializing the CognitoCachingCredentialsProvider. " + ex);
+            throw new IllegalStateException("Error in initializing the CognitoCachingCredentialsProvider. ", ex);
         }
     }
 

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 
+import com.amazonaws.auth.policy.actions.SecurityTokenServiceActions;
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
 import com.amazonaws.util.Base64;
@@ -27,7 +28,9 @@ import java.security.Key;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -315,6 +318,17 @@ public class AWSKeyValueStore {
                 } else if (map.get(spKey) instanceof Integer) {
                     Integer intValue = sharedPreferences.getInt(spKey, 0);
                     put(spKey, String.valueOf(intValue));
+                } else if (map.get(spKey) instanceof Set) {
+                    Set<String> stringSet = (Set<String>) map.get(spKey);
+                    StringBuilder stringBuilder = new StringBuilder();
+                    Iterator<String> setIterator = stringSet.iterator();
+                    while (setIterator.hasNext())  {
+                        stringBuilder.append(setIterator.next());
+                        if (setIterator.hasNext()) {
+                            stringBuilder.append(",");
+                        }
+                    }
+                    put(spKey, stringBuilder.toString());
                 }
 
                 // Remove the key since key.encrypted is written.

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 
-import com.amazonaws.auth.policy.actions.SecurityTokenServiceActions;
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
 import com.amazonaws.util.Base64;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider10.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider10.java
@@ -58,8 +58,8 @@ class KeyProvider10 implements KeyProvider {
                     return secretKey;
                 }
             } catch (Exception ex) {
-                logger.error("Error occurred while getting the key." + ex);
-                return null;
+                logger.error("Error in loading the key from keystore.");
+                throw new IllegalStateException(ex);
             }
         }
     }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
@@ -92,7 +92,7 @@ public class KeyProvider18 implements KeyProvider {
                 }
             } catch (Exception ex) {
                 logger.error("Error in getting the key.", ex);
-                return null;
+                throw new IllegalStateException(ex);
             }
         }
     }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
@@ -62,7 +62,7 @@ class KeyProvider23 implements KeyProvider {
                 }
             } catch (Exception ex) {
                 logger.error("Error in accessing the Android KeyStore.", ex);
-                return null;
+                throw new IllegalStateException(ex);
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1) Fixed a bug where a stringSet stored in `SharedPreferences` cannot be migrated to the `AWSKeyValueStore`.
2) Propagate the exception when loading/creating the encryption key fails while trying to persist data through `AWSKeyValueStore`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
