### PR TITLE
[MobileClient] Fix drop-in UI initialization from awsconfiguration.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
   * AWS IoT SDK for Android now supports MQTT over TLS with X.509 client certificate authentication on port 443. Previously this combination of protocol and authentication mechanism was only supported on port 8883. `connectUsingALPN()` method allows developers to connect to AWS IoT using client certificate authentication on port 443. Please look at [this blog](https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/) for more details.
   * **Breaking Change:** Please note that the type of aws-android-sdk-iot artifact is being changed from a`jar` to an `aar`. Also note that the `aar` artifacts needs to be explicitly specified in the dependency as `implementation ("com.amazonaws:aws-android-sdk-iot:2.12.+@aar") { transitive =true }` on some of the older versions of gradle.
 
+### Bug Fixes
+
+* **AWS Mobile Client**
+  * Fixed a bug when initializing drop-in UI that caused the Facebook, Google, or Userpools provider to not be instantiated.
+
+### Misc. Updates
+
+* Model updates for the following services
+  * AWS IoT
+  * Amazon Transcribe
+
+## [Release 2.12.7](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.12.7)
+
 ### Enhancements
 
 * **AWS Mobile Client**


### PR DESCRIPTION
The assignment of awsconfiguration was postponed in the latest changes causing the `registerConfigSignInProviders()` method to stop adding the correct signinproviders during intialization.