### PR TITLE
Remove uitest from integration test list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1257,7 +1257,6 @@ workflows:
             - CognitoAuth
             - Core
             - CognitoIdentityProvider
-            - uitest
       - uitest:
           requires:
             - build


### PR DESCRIPTION
UI tests are still flaky and are not a reliable sign of failure.