### PR TITLE
change the project type of aws-android-sdk-sqs-test from app to libarary

### DIFF
--- a/aws-android-sdk-sqs-test/build.gradle
+++ b/aws-android-sdk-sqs-test/build.gradle
@@ -1,13 +1,10 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'com.android.library'
 android {
     compileSdkVersion 27
 
 
 
     defaultConfig {
-        applicationId "com.amazonaws.sqs.test"
         minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
@@ -33,7 +30,6 @@ dependencies {
     }
 
     androidTestImplementation project(":aws-android-sdk-testutils")
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }

--- a/aws-android-sdk-sqs-test/src/main/res/values/strings.xml
+++ b/aws-android-sdk-sqs-test/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">testapp</string>
-    <string name="action_settings">Settings</string>
+    <string name="app_name">aws-android-sdk-sqs-test</string>
+    <string name="package_name">sqs</string>
 </resources>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
change the project type of aws-android-sdk-sqs-test from app to libarary so that we can run the module test on device farm in the same way with other modules

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
