### PR TITLE
Fix hosted ui error callback issue #328 #871

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.13.2](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.2)
+
+* **Amazon Cognito Auth**
+  * Fixed erroneous user cancelled error when redirecting back to app. See [issue #328](https://github.com/aws-amplify/aws-sdk-android/issues/328), [issue #871](https://github.com/aws-amplify/aws-sdk-android/issues/871)
+
 ## [Release 2.13.1](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.1)
 
 ### Enhancements

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/ClientConstants.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/ClientConstants.java
@@ -24,6 +24,7 @@ package com.amazonaws.mobileconnectors.cognitoauth.util;
 @SuppressWarnings("checkstyle:javadocmethod")
 public abstract class ClientConstants {
     public static final String APP_LAST_AUTH_USER = "LastAuthUser";
+    public static final String APP_HAS_RECIEVED_REDIRECT = "HasReceivedRedirect";
     public static final String APP_LOCAL_CACHE = "CognitoIdentityProviderCache";
     public static final String APP_LOCAL_CACHE_KEY_PREFIX = "CognitoIdentityProvider";
     public static final String AUTH_RESPONSE_TYPE_CODE = "code";

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/LocalDataManager.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/LocalDataManager.java
@@ -513,4 +513,35 @@ public final class LocalDataManager {
         stringSet.addAll(Arrays.asList(stringArray));
         return stringSet;
     }
+
+    public static void cacheHasReceivedRedirect(AWSKeyValueStore awsKeyValueStore, Context context, String clientId, boolean hasReceivedRedirect) {
+        if (context == null || clientId == null) {
+            throw new InvalidParameterException(
+                    "Application context, and application domain cannot be null");
+        }
+
+        try {
+            String hasReceivedRedirectKey = String.format(Locale.US, "%s.%s.%s",
+                    ClientConstants.APP_LOCAL_CACHE_KEY_PREFIX, clientId, ClientConstants.APP_HAS_RECIEVED_REDIRECT);
+            awsKeyValueStore.put(hasReceivedRedirectKey, hasReceivedRedirect ? "true" : "false");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed while writing to SharedPreferences", e);
+        }
+    }
+
+    public static boolean hasReceivedRedirect(AWSKeyValueStore awsKeyValueStore, Context context, String clientId) {
+        if (context == null || clientId == null) {
+            throw new InvalidParameterException(
+                    "Application context, and application domain cannot be null");
+        }
+
+        try {
+            String hasReceivedRedirectKey = String.format(Locale.US, "%s.%s.%s",
+                    ClientConstants.APP_LOCAL_CACHE_KEY_PREFIX, clientId, ClientConstants.APP_HAS_RECIEVED_REDIRECT);
+            return "true".equals(awsKeyValueStore.get(hasReceivedRedirectKey));
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read from SharedPreferences", e);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Persist the flag that indicates is a redirect has been received from Amazon Cognito for Cognito Hosted UI.

LocalDataManager has been extended to provide read and write methods for this flag.