### PR TITLE
[Pinpoint] Keep events in local database when there is a SocketException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## [Release 2.13.2](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.2)
 
+### Bug Fixes
+
 * **Amazon Cognito Auth**
   * Fixed erroneous user cancelled error when redirecting back to app. See [issue #328](https://github.com/aws-amplify/aws-sdk-android/issues/328), [issue #871](https://github.com/aws-amplify/aws-sdk-android/issues/871)
+
+* **Amazon Pinpoint**
+  * Added `SocketException` to the list of client exceptions where the events submitted to Amazon Pinpoint will be saved in the local database. See [issue #773](https://github.com/aws-amplify/aws-sdk-android/issues/773).
 
 ## [Release 2.13.1](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.1)
 

--- a/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SubmitEventsIntegrationTest.java
+++ b/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SubmitEventsIntegrationTest.java
@@ -151,6 +151,7 @@ public class SubmitEventsIntegrationTest extends AWSTestBase {
         assertEquals(0, pinpointManager.getAnalyticsClient().getAllEvents().size());
     }
 
+    @Test
     public void testSubmitEventsNetworkDisconnectAndReconnect() {
         Log.d(TAG, "Events in database before calling recordEvent(): " +
                 pinpointManager.getAnalyticsClient().getAllEvents().size());

--- a/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SubmitEventsIntegrationTest.java
+++ b/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SubmitEventsIntegrationTest.java
@@ -151,7 +151,6 @@ public class SubmitEventsIntegrationTest extends AWSTestBase {
         assertEquals(0, pinpointManager.getAnalyticsClient().getAllEvents().size());
     }
 
-    @Test
     public void testSubmitEventsNetworkDisconnectAndReconnect() {
         Log.d(TAG, "Events in database before calling recordEvent(): " +
                 pinpointManager.getAnalyticsClient().getAllEvents().size());


### PR DESCRIPTION
*Issue #, if available:*

#773

*Description of changes:*

Keep events in local database when there is a SocketException


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
