### PR TITLE
[S3][TransferUtility] Register TransferListener before submitting a transfer job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Release 2.13.5](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.5)
 
+### Bug Fixes
+
+* **Amazon S3**
+  * Fix a bug where the `TransferListener` is not triggered when the preferred network type is not available. See [issue #958](https://github.com/aws-amplify/aws-sdk-android/issues/958) for details.
+
 ### Misc. Updates
 
 * Model updates for the following services

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
@@ -389,8 +389,11 @@ public class TransferUtility {
             file.delete();
         }
 
+        // Creating the observer before the job is submitted because the listener needs to be registered
+        // with TransferStatusUpdater when the job is being submitted.
+        TransferObserver transferObserver = new TransferObserver(recordId, dbUtil, bucket, key, file, listener);
         submitTransferJob(TRANSFER_ADD, recordId);
-        return new TransferObserver(recordId, dbUtil, bucket, key, file, listener);
+        return transferObserver;
     }
 
     /**
@@ -551,8 +554,11 @@ public class TransferUtility {
             recordId = Integer.parseInt(uri.getLastPathSegment());
         }
 
+        // Creating the observer before the job is submitted because the listener needs to be registered
+        // with TransferStatusUpdater when the job is being submitted.
+        TransferObserver transferObserver = new TransferObserver(recordId, dbUtil, bucket, key, file, listener);
         submitTransferJob(TRANSFER_ADD, recordId);
-        return new TransferObserver(recordId, dbUtil, bucket, key, file, listener);
+        return transferObserver;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

#958 

*Description of changes:*

* **Amazon S3**
  * Fix a bug where the `TransferListener` is not triggered when the preferred network type is not available. See [issue #958](https://github.com/aws-amplify/aws-sdk-android/issues/958) for details.

Creating the observer before the job is submitted because the listener needs to be registered with `TransferStatusUpdater` when the job is being submitted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
