### PR TITLE
[Core] Remove call to setkeySize in KeyProvider18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,16 @@ commands:
             # This is required becaused AWSCore has a compileOnly
             # dependency on API Level 23.
             sudo yes | sdkmanager "platforms;android-23"
+  setup_android_platform18:
+    description: >-
+      setup android platform 18
+    steps:
+      - run:
+          name: download android platform 18
+          command: |
+            # This is required becaused AWSCore has a compileOnly
+            # dependency on API Level 18.
+            sudo yes | sdkmanager "platforms;android-18"
   skip_test_job:
     description: >-
       check if the test job can be skipped
@@ -288,6 +298,7 @@ jobs:
       - checkout
       - generate_gradle_wrapper
       - setup_android_platform23
+      - setup_android_platform18
       - run:
           name: build the whole project
           command: |
@@ -334,7 +345,40 @@ jobs:
       - run:
           name: build the whole project
           command: |
-            bash gradlew :aws-android-sdk-core:build  -x test   
+            bash gradlew :aws-android-sdk-core:build  -x test
+
+  build_api18:
+    working_directory: ~/code
+    docker:
+      - image: circleci/android:api-27-alpha
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - skip_job_if_required      
+      - checkout
+      - generate_gradle_wrapper
+      - run:
+          name: download android-18
+          command:
+            sudo yes | sdkmanager "platforms;android-18"
+      - run:
+          name: install python3-pip
+          command: |
+            sudo apt-get update
+            sudo apt-get -y install python3-pip            
+      - run:
+          name: install json parser
+          command: sudo pip3 install demjson           
+      - run:
+          name: update code for API 18
+          command: |
+            python3 CircleciScripts/replace_android18.py "$(pwd)"
+            rm aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
+            cat aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
+      - run:
+          name: build the whole project
+          command: |
+            export ANDROID_API_LEVEL=18; bash gradlew :aws-android-sdk-core:build -x test
 
   unittest:
     working_directory: ~/code
@@ -350,6 +394,7 @@ jobs:
       - skip_test_job
       - generate_gradle_wrapper
       - setup_android_platform23
+      - setup_android_platform18
       - run:
           name: run unit tests
           command: |
@@ -485,7 +530,7 @@ jobs:
       - run:
           name: Install Android build tools
           command: |
-            sudo yes | /usr/local/bin/sdkmanager "platforms;android-21" "platforms;android-23" "platforms;android-27" "build-tools;27.0.1"  "extras;google;m2repository" "extras;android;m2repository"
+            sudo yes | /usr/local/bin/sdkmanager "platforms;android-18" "platforms;android-21" "platforms;android-23" "platforms;android-27" "build-tools;27.0.1"  "extras;google;m2repository" "extras;android;m2repository"
             /usr/local/bin/sdkmanager --update
       - run:
           name: Install GPG
@@ -660,6 +705,7 @@ jobs:
       - skip_test_job      
       - configure_aws
       - setup_android_platform23
+      - setup_android_platform18
       - run: 
           name: install python3-pip
           command: |
@@ -717,6 +763,7 @@ jobs:
       - skip_test_job      
       - configure_aws     
       - setup_android_platform23
+      - setup_android_platform18
       - run:
           name: checkout sample applications
           command: |
@@ -1019,6 +1066,7 @@ jobs:
       - skip_test_job      
       - configure_aws
       - setup_android_platform23
+      - setup_android_platform18
       - run: 
           name: install python3-pip
           command: |
@@ -1150,7 +1198,11 @@ workflows:
       - build_api10:
           filters:
             branches:
-              ignore: bump_sdk_version                  
+              ignore: bump_sdk_version
+      - build_api18:
+          filters:
+            branches:
+              ignore: bump_sdk_version                     
       - unittest:
           filters:
             branches:
@@ -1466,6 +1518,7 @@ workflows:
       - merge_to_master:
           requires:
             - build_api10
+            - build_api18
             - build       
             - unittest
             - post_integrationtest
@@ -1476,6 +1529,7 @@ workflows:
       - prepare_release_sdk:
           requires:
             - build_api10
+            - build_api18
             - build       
             - unittest
             - post_integrationtest
@@ -1496,7 +1550,13 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^(release|beta)_v[0-9]+.[0-9]+.[0-9]+$/              
+              only: /^(release|beta)_v[0-9]+.[0-9]+.[0-9]+$/
+      - build_api18:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^(release|beta)_v[0-9]+.[0-9]+.[0-9]+$/                
       - unittest:
           filters:
             branches:
@@ -1809,6 +1869,7 @@ workflows:
             - unittest
             - post_integrationtest
             - build_api10
+            - build_api18
           filters:
             branches:
               ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Release 2.13.5](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.5)
 
+### Bug Fixes
+
+* **AWS Core Runtime**
+  * Fixed a bug where generating RSA keys for encryption of the credentials failed due to `setKeySize(int)` method not available in Android API level 18. See [issue #964](https://github.com/aws-amplify/aws-sdk-android/issues/964) for details.
+
 ### Misc. Updates
 
 * Model updates for the following services

--- a/CircleciScripts/replace_android18.py
+++ b/CircleciScripts/replace_android18.py
@@ -8,7 +8,7 @@ root = sys.argv[1]
 replaces = [
     {
         "match" : 'android-23', 
-        "replace" : 'android-10',
+        "replace" : 'android-18',
         "files" : [
             "aws-android-sdk-core/build.gradle"
         ]       
@@ -23,10 +23,6 @@ with open(AWSKeyValueStoreFile, 'r') as myfile:
     pattern = r'//@apiLevel23Start[\s\S]*?//@apiLevel23End'
     repl = r""
     newcontent = re.sub(pattern, repl, content)    
-    
-  
-    pattern = r'//@apiLevel18Start[\s\S]*?//@apiLevel18End'
-    repl = r""
-    newcontent = re.sub(pattern, repl, newcontent)    
+     
 with open(AWSKeyValueStoreFile,"w") as myfile:
     myfile.write(newcontent)

--- a/aws-android-sdk-core/build.gradle
+++ b/aws-android-sdk-core/build.gradle
@@ -26,12 +26,14 @@ dependencies {
 // The following command (is idempotent)
 // removes the libs folder, creates libs folder and
 // creates a symbolic link to android-23.jar.
-task myTask(type:Exec) {
+task getApi23(type:Exec) {
+    print 'Creating a symlink for Android API Level 23.'
     workingDir '.'
     commandLine 'sh', '-c', "rm -rf libs && mkdir libs && ln -s $System.env.ANDROID_HOME/platforms/android-23/android.jar libs/android-23.jar"
 }
 
-compileJava.dependsOn(myTask)
+
+compileJava.dependsOn(getApi23)
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazonaws.internal.keyvaluestore;
 
 import android.content.Context;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider10.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider10.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazonaws.internal.keyvaluestore;
 
 import android.content.Context;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazonaws.internal.keyvaluestore;
 
 import android.content.Context;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
@@ -8,19 +8,14 @@ import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
 import com.amazonaws.util.Base64;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.security.Key;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Calendar;
 
 import javax.crypto.Cipher;
-import javax.crypto.CipherInputStream;
-import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -31,7 +26,8 @@ import javax.security.auth.x500.X500Principal;
  * It generates a AES 256-bit symmetric key which is
  * used to encrypt the data. It also generates a master
  * key using RSA provided by AndroidKeyStore and uses
- * the RSA key to encrypt the AES key.
+ * the RSA key to encrypt the AES key. The size of the
+ * RSA key is 2048 bits by default.
  *
  * Once the AES key is encrypted with the RSA key, the
  * encrypted AES key is stored in SharedPreferences.
@@ -52,7 +48,6 @@ public class KeyProvider18 implements KeyProvider {
     static final String KEY_ALGORITHM_RSA = "RSA";
     static final String CIPHER_RSA_MODE = "RSA/ECB/PKCS1Padding";
     static final String CIPHER_PROVIDER_NAME_FOR_RSA = "AndroidOpenSSL";
-    static final int RSA_KEY_SIZE = 2048;
 
     static final String ENCRYPTED_AES_KEY = "AesGcmNoPadding18-encrypted-encryption-key";
 
@@ -151,7 +146,6 @@ public class KeyProvider18 implements KeyProvider {
                     .setSerialNumber(BigInteger.TEN)
                     .setStartDate(start.getTime())
                     .setEndDate(end.getTime())
-                    .setKeySize(RSA_KEY_SIZE)
                     .build();
             KeyPairGenerator kpg = KeyPairGenerator.getInstance(
                     KEY_ALGORITHM_RSA,

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.amazonaws.internal.keyvaluestore;
 
 import android.content.Context;


### PR DESCRIPTION
*Issue #, if available:*

#964 

*Description of changes:*

`setKeySize` is not available in API Level 18. The default key size used by RSA in `KeyPairGeneratorSpec` is 2048 when not specified. This change will use the default of 2048 in all API levels (18-22).

Added build automation for verifying if the fix works for API 18-22.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
