### PR TITLE
Remove trailing zeros before putting frame into SDK

### DIFF
--- a/aws-android-sdk-kinesisvideo/src/androidTest/java/com/amazonaws/services/kinesisvideo/KinesisVideoFrameTest.java
+++ b/aws-android-sdk-kinesisvideo/src/androidTest/java/com/amazonaws/services/kinesisvideo/KinesisVideoFrameTest.java
@@ -6,9 +6,12 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
+import android.support.test.runner.AndroidJUnit4;
+
 import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_NONE;
 import static junit.framework.Assert.assertEquals;
 
+@RunWith(AndroidJUnit4.class)
 public class KinesisVideoFrameTest {
     @Test
     public void testTrailingZeroRemoved() {

--- a/aws-android-sdk-kinesisvideo/src/androidTest/java/com/amazonaws/services/kinesisvideo/KinesisVideoFrameTest.java
+++ b/aws-android-sdk-kinesisvideo/src/androidTest/java/com/amazonaws/services/kinesisvideo/KinesisVideoFrameTest.java
@@ -1,0 +1,25 @@
+package com.amazonaws.services.kinesisvideo;
+
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_NONE;
+import static junit.framework.Assert.assertEquals;
+
+public class KinesisVideoFrameTest {
+    @Test
+    public void testTrailingZeroRemoved() {
+        byte[] rawData = new byte[] {1, 2, 3, 0, 0, 0, 0, 0};
+        KinesisVideoFrame frame = new KinesisVideoFrame(0, FRAME_FLAG_NONE, 0,
+                0, 1, ByteBuffer.wrap(rawData));
+        assertEquals(3, frame.getSize());
+        byte[] actualDataPassed = new byte[frame.getSize()];
+        frame.getData().get(actualDataPassed);
+        for (int i = 0; i < actualDataPassed.length; i++) {
+            assertEquals(rawData[i], actualDataPassed[i]);
+        }
+    }
+}

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrame.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrame.java
@@ -69,6 +69,9 @@ public class KinesisVideoFrame {
         mPresentationTs = presentationTs;
         mDuration = duration;
         mData = requireNonNull(data);
+        // In some devices encoder would generate frames with more than 3 trailing zeros
+        // which is not allowed by AnnexB specification
+        removeTrailingZeros();
     }
 
     public int getIndex() {
@@ -115,5 +118,14 @@ public class KinesisVideoFrame {
                 .append(", mFlags=").append(mFlags).append(", mDecodingTs=").append(mDecodingTs)
                 .append(", mPresentationTs=").append(mPresentationTs).append(", mDuration=").append(mDuration)
                 .append(", mData=").append(mData).append("}").toString();
+    }
+
+    private void removeTrailingZeros() {
+        for (int index = mData.limit() - 1; index > mData.position(); index--) {
+            if (mData.get(index) != 0) {
+                mData.limit(index + 1);
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
581, 909
*Description of changes:*
The fix is removing the trailing zeros from encoder output which shows up in some android devices. The multiple trailing zeros were causing 0x3200000d for Kinesis Video.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
