### PR TITLE
Add AWSConfiguration(JSONObject) constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.13.6](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.6)
+
+### New Features
+
+* **AWS Core Runtime**
+  * Add `AWSConfiguration(JSONObject)` constructor to construct a `AWSConfiguration` object from the configuration passed via a `JSONObject`.
+
 ## [Release 2.13.5](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.13.5)
 
 ### Bug Fixes

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/mobile/config/AWSConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/mobile/config/AWSConfiguration.java
@@ -12,6 +12,7 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 package com.amazonaws.mobile.config;
 
 import android.content.Context;
@@ -34,6 +35,19 @@ public class AWSConfiguration {
 
     private JSONObject mJSONObject;
     private String configName; // "Default" or something else like "Backup"
+
+    /**
+     * Construct an AWSConfiguration object based on the JSONObject passed in.
+     *
+     * @param jsonObject contains the configuration information
+     */
+    public AWSConfiguration(JSONObject jsonObject) {
+        if (jsonObject == null) {
+            throw new IllegalArgumentException("JSONObject cannot be null.");
+        }
+
+        this.mJSONObject = jsonObject;
+    }
 
     /**
      * Constructs an AWSConfiguration object

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/mobile/config/AWSConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/mobile/config/AWSConfiguration.java
@@ -42,10 +42,22 @@ public class AWSConfiguration {
      * @param jsonObject contains the configuration information
      */
     public AWSConfiguration(JSONObject jsonObject) {
+        this(jsonObject, DEFAULT);
+    }
+
+    /**
+     * Construct an AWSConfiguration object based on the JSONObject passed in.
+     *
+     * @param jsonObject contains the configuration information
+     * @param configName name of the configuration,
+     *                   "Default" or something else like "Backup"
+     */
+    public AWSConfiguration(JSONObject jsonObject, String configName) {
         if (jsonObject == null) {
             throw new IllegalArgumentException("JSONObject cannot be null.");
         }
 
+        this.configName = configName;
         this.mJSONObject = jsonObject;
     }
 

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/mobile/config/AWSConfigurationTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/mobile/config/AWSConfigurationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazonaws.mobile.config;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class AWSConfigurationTest {
+
+    @Test
+    public void testAWSConfigurationWithJSONObject() {
+        JSONObject jsonObject;
+        try {
+            jsonObject = new JSONObject("{\n" +
+                    "  \"UserAgent\": \"aws-amplify-cli/0.1.0\",\n" +
+                    "  \"Version\": \"1.0\",\n" +
+                    "  \"IdentityManager\": {\n" +
+                    "    \"Default\": {}\n" +
+                    "  },\n" +
+                    "  \"AppSync\": {\n" +
+                    "    \"Default\": {\n" +
+                    "      \"ApiUrl\": \"redacted\",\n" +
+                    "      \"Region\": \"redacted\",\n" +
+                    "      \"AuthMode\": \"API_KEY\",\n" +
+                    "      \"ApiKey\": \"da2-xyz\",\n" +
+                    "      \"ClientDatabasePrefix\": \"redacted\"\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"CredentialsProvider\": {\n" +
+                    "    \"CognitoIdentity\": {\n" +
+                    "      \"Default\": {\n" +
+                    "        \"PoolId\": \"redacted\",\n" +
+                    "        \"Region\": \"redacted\"\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}");
+
+            AWSConfiguration awsConfiguration = new AWSConfiguration(jsonObject);
+            assertNotNull(awsConfiguration);
+
+            assertNotNull(awsConfiguration.optJsonObject("AppSync"));
+            assertEquals("API_KEY", awsConfiguration.optJsonObject("AppSync").get("AuthMode"));
+        } catch (JSONException e) {
+            fail("Error in constructing AWSConfiguration." + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void testAWSConfigurationWithNullJSONObject() {
+        try {
+            JSONObject jsonObject = null;
+            new AWSConfiguration(jsonObject);
+            fail("No exception thrown when a null JSONObject is passed in.");
+        } catch (RuntimeException e) {
+            assertEquals("JSONObject cannot be null.", e.getLocalizedMessage());
+        }
+    }
+}

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/mobile/config/AWSConfigurationTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/mobile/config/AWSConfigurationTest.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.mobile.config;
 
+
+import com.amazonaws.auth.CognitoCredentialsProvider;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -25,40 +28,55 @@ import static org.junit.Assert.fail;
 
 public class AWSConfigurationTest {
 
+    private static final String jsonString = "{\n" +
+            "  \"UserAgent\": \"aws-amplify-cli/0.1.0\",\n" +
+            "  \"Version\": \"1.0\",\n" +
+            "  \"IdentityManager\": {\n" +
+            "    \"Default\": {}\n" +
+            "  },\n" +
+            "  \"AppSync\": {\n" +
+            "    \"Default\": {\n" +
+            "      \"ApiUrl\": \"redacted\",\n" +
+            "      \"Region\": \"us-east-1\",\n" +
+            "      \"AuthMode\": \"API_KEY\",\n" +
+            "      \"ApiKey\": \"da2-xyz\",\n" +
+            "      \"ClientDatabasePrefix\": \"redacted\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"CredentialsProvider\": {\n" +
+            "    \"CognitoIdentity\": {\n" +
+            "      \"Default\": {\n" +
+            "        \"PoolId\": \"redacted\",\n" +
+            "        \"Region\": \"us-east-1\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
     @Test
     public void testAWSConfigurationWithJSONObject() {
-        JSONObject jsonObject;
         try {
-            jsonObject = new JSONObject("{\n" +
-                    "  \"UserAgent\": \"aws-amplify-cli/0.1.0\",\n" +
-                    "  \"Version\": \"1.0\",\n" +
-                    "  \"IdentityManager\": {\n" +
-                    "    \"Default\": {}\n" +
-                    "  },\n" +
-                    "  \"AppSync\": {\n" +
-                    "    \"Default\": {\n" +
-                    "      \"ApiUrl\": \"redacted\",\n" +
-                    "      \"Region\": \"redacted\",\n" +
-                    "      \"AuthMode\": \"API_KEY\",\n" +
-                    "      \"ApiKey\": \"da2-xyz\",\n" +
-                    "      \"ClientDatabasePrefix\": \"redacted\"\n" +
-                    "    }\n" +
-                    "  },\n" +
-                    "  \"CredentialsProvider\": {\n" +
-                    "    \"CognitoIdentity\": {\n" +
-                    "      \"Default\": {\n" +
-                    "        \"PoolId\": \"redacted\",\n" +
-                    "        \"Region\": \"redacted\"\n" +
-                    "      }\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    "}");
+            JSONObject jsonObject = new JSONObject(jsonString);
 
             AWSConfiguration awsConfiguration = new AWSConfiguration(jsonObject);
             assertNotNull(awsConfiguration);
 
             assertNotNull(awsConfiguration.optJsonObject("AppSync"));
-            assertEquals("API_KEY", awsConfiguration.optJsonObject("AppSync").get("AuthMode"));
+            assertEquals("API_KEY", awsConfiguration.optJsonObject("AppSync").getString("AuthMode"));
+        } catch (JSONException e) {
+            fail("Error in constructing AWSConfiguration." + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void testCognitoCachingCredentialsProviderWithAWSConfiguration() {
+        try {
+            JSONObject jsonObject = new JSONObject(jsonString);
+
+            AWSConfiguration awsConfiguration = new AWSConfiguration(jsonObject);
+            assertNotNull(awsConfiguration);
+            CognitoCredentialsProvider cognitoCredentialsProvider = new CognitoCredentialsProvider(awsConfiguration);
+            assertNotNull(cognitoCredentialsProvider);
         } catch (JSONException e) {
             fail("Error in constructing AWSConfiguration." + e.getLocalizedMessage());
         }
@@ -70,7 +88,7 @@ public class AWSConfigurationTest {
             JSONObject jsonObject = null;
             new AWSConfiguration(jsonObject);
             fail("No exception thrown when a null JSONObject is passed in.");
-        } catch (RuntimeException e) {
+        } catch (IllegalArgumentException e) {
             assertEquals("JSONObject cannot be null.", e.getLocalizedMessage());
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add `AWSConfiguration(JSONObject)` constructor to construct a `AWSConfiguration` object from the configuration passed via a `JSONObject`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
