### PR TITLE
[S3] Fix testRoundTrip to wait for lifecycle configuration to be created

### DIFF
--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/LifecycleVersioningIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/LifecycleVersioningIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 
 package com.amazonaws.services.s3;
 
+import android.util.Log;
+
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
@@ -29,19 +31,24 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 public class LifecycleVersioningIntegrationTest extends S3IntegrationTestBase {
 
     private static final String BUCKET_NAME =
             "lifecycle-versioning-integration-test-"
                     + System.currentTimeMillis();
 
+    private static final String TAG = LifecycleVersioningIntegrationTest.class.getSimpleName();
+
     @BeforeClass
     public static void setUp() throws Exception {
         setUpCredentials();
-        s3 = new AmazonS3Client(credentials);
-        s3.setRegion(Region.getRegion(Regions.US_WEST_2));
+        s3 = new AmazonS3Client(credentials, Region.getRegion(Regions.US_WEST_2));
 
         s3.createBucket(BUCKET_NAME);
+        S3IntegrationTestBase.waitForBucketCreation(BUCKET_NAME);
+        assertTrue(BUCKET_NAME + " should exist.", s3.doesBucketExist(BUCKET_NAME));
 
         s3.setBucketVersioningConfiguration(
                 new SetBucketVersioningConfigurationRequest(
@@ -80,8 +87,7 @@ public class LifecycleVersioningIntegrationTest extends S3IntegrationTestBase {
                                 .withNoncurrentVersionExpirationInDays(60)
                         ));
 
-        BucketLifecycleConfiguration result =
-                s3.getBucketLifecycleConfiguration(BUCKET_NAME);
+        BucketLifecycleConfiguration result = waitForBucketLifecycleConfigurationCreated(BUCKET_NAME);
 
         Assert.assertEquals(2, result.getRules().size());
 
@@ -94,5 +100,29 @@ public class LifecycleVersioningIntegrationTest extends S3IntegrationTestBase {
         Assert.assertEquals(StorageClass.Glacier, result.getRules().get(1)
                 .getNoncurrentVersionTransition().getStorageClass());
         Assert.assertEquals(60, result.getRules().get(1).getNoncurrentVersionExpirationInDays());
+    }
+
+    /**
+     * waiting a lifecycle configuration become deleted When exceed the poll
+     * time, will throw Max poll time exceeded exception
+     */
+    private static BucketLifecycleConfiguration waitForBucketLifecycleConfigurationCreated(String bucketName)
+            throws Exception {
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + (10 * 60 * 1000);
+        int hits = 0;
+        while (System.currentTimeMillis() < endTime) {
+            BucketLifecycleConfiguration bucketLifecycleConfiguration = null;
+
+            if ((bucketLifecycleConfiguration = s3.getBucketLifecycleConfiguration(bucketName)) == null) {
+                Log.d(TAG, "Waiting for BucketLifecycleConfiguration for bucket: " + bucketName + " to be created.");
+                Thread.sleep(1000);
+                hits = 0;
+            }
+            if (hits++ == 10)
+                return bucketLifecycleConfiguration;
+        }
+        maxPollTimeExceeded();
+        return null;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Creation of bucket and BucketLifecycleConfiguration takes more time and needs a polling mechanism to check until the configuration is created.

Ran the tests with this change and it passed locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
