### PR TITLE
Fixed response unmarshalling with gzip encoding

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -17,7 +17,9 @@
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-cognito/aws-android-sdk-cognito.iml" filepath="$PROJECT_DIR$/aws-android-sdk-cognito/aws-android-sdk-cognito.iml" />
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-cognitoauth/aws-android-sdk-cognitoauth.iml" filepath="$PROJECT_DIR$/aws-android-sdk-cognitoauth/aws-android-sdk-cognitoauth.iml" />
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-cognitoidentityprovider/aws-android-sdk-cognitoidentityprovider.iml" filepath="$PROJECT_DIR$/aws-android-sdk-cognitoidentityprovider/aws-android-sdk-cognitoidentityprovider.iml" />
+      <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-cognitoidentityprovider-test/aws-android-sdk-cognitoidentityprovider-test.iml" filepath="$PROJECT_DIR$/aws-android-sdk-cognitoidentityprovider-test/aws-android-sdk-cognitoidentityprovider-test.iml" />
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-comprehend/aws-android-sdk-comprehend.iml" filepath="$PROJECT_DIR$/aws-android-sdk-comprehend/aws-android-sdk-comprehend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-comprehend-test/aws-android-sdk-comprehend-test.iml" filepath="$PROJECT_DIR$/aws-android-sdk-comprehend-test/aws-android-sdk-comprehend-test.iml" />
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-connect/aws-android-sdk-connect.iml" filepath="$PROJECT_DIR$/aws-android-sdk-connect/aws-android-sdk-connect.iml" />
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-connect-test/aws-android-sdk-connect-test.iml" filepath="$PROJECT_DIR$/aws-android-sdk-connect-test/aws-android-sdk-connect-test.iml" />
       <module fileurl="file://$PROJECT_DIR$/aws-android-sdk-core/aws-android-sdk-core.iml" filepath="$PROJECT_DIR$/aws-android-sdk-core/aws-android-sdk-core.iml" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Release 2.14.1](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.14.1)
 
+### Bug Fixes
+
+- **AWS Core Runtime**
+  - Fixed response unmarshalling when response is gzip encoded without a CRC32 checksum. Also fixes bug decoding Kinesis responses with GZIP encoding.
+
 ### Misc. Updates
 
 - Model updates for the following services

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This section describes how you can compile the SDK source code on your own.
 
 2. When building the [Core module](https://github.com/aws-amplify/aws-sdk-android/blob/master/aws-android-sdk-core/build.gradle#L32), it requires the following:
    2.1 Environment variable `ANDROID_HOME` to be set in order to find the `android-23.jar`.
-   2.2 Environemnt variable `ANDROID_PLATFORM` to be set to the platform number (`10` through `28` and above)
+   2.2 Environment variable `ANDROID_PLATFORM` to be set to the platform number (`10` through `28` and above)
 
 For command line approach, you can build the source via Gradle, which can be downloaded and installed from [here](https://gradle.org/install/).
 After installing Gradle, clone this repository and run

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/http/JsonResponseHandler.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/http/JsonResponseHandler.java
@@ -86,7 +86,6 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
         log.trace("Parsing service response JSON");
 
         final String crc32Checksum = response.getHeaders().get("x-amz-crc32");
-        CRC32ChecksumCalculatingInputStream crc32ChecksumInputStream = null;
 
         // Get the raw content input stream to calculate the crc32 checksum on
         // gzipped data.
@@ -99,13 +98,21 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
         log.debug("CRC32Checksum = " + crc32Checksum);
         log.debug("content encoding = " + response.getHeaders().get("Content-Encoding"));
 
+        boolean isGzipEncoded = "gzip".equals(response.getHeaders().get("Content-Encoding"));
+
+        CRC32ChecksumCalculatingInputStream checksumCalculatingInputStream = null;
+
+        // Handle various combinations of GZIP encoding and CRC checksums. Some services (e.g.,
+        // DynamoDB) return a checksum with gzip encoding, some do not. We'll also cover the case
+        // where a service returns a checksum for non-gzip encoding. The default case (not gzip
+        // encoded, no checksum) is already handled: we'll just operate on the raw content stream.
         if (crc32Checksum != null) {
-            crc32ChecksumInputStream = new CRC32ChecksumCalculatingInputStream(content);
-            if ("gzip".equals(response.getHeaders().get("Content-Encoding"))) {
-                content = new GZIPInputStream(crc32ChecksumInputStream);
-            } else {
-                content = crc32ChecksumInputStream;
-            }
+            checksumCalculatingInputStream = new CRC32ChecksumCalculatingInputStream(content);
+            content = checksumCalculatingInputStream;
+        }
+
+        if (isGzipEncoded) {
+            content = new GZIPInputStream(content);
         }
 
         final AwsJsonReader jsonReader = JsonUtils.getJsonReader(new InputStreamReader(content,
@@ -118,9 +125,9 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
 
             final T result = responseUnmarshaller.unmarshall(unmarshallerContext);
 
-            if (crc32Checksum != null) {
+            if (checksumCalculatingInputStream != null) {
                 final long serverSideCRC = Long.parseLong(crc32Checksum);
-                final long clientSideCRC = crc32ChecksumInputStream.getCRC32Checksum();
+                final long clientSideCRC = checksumCalculatingInputStream.getCRC32Checksum();
                 if (clientSideCRC != serverSideCRC) {
                     throw new CRC32MismatchException(
                             "Client calculated crc32 checksum didn't match that calculated by server side");
@@ -129,7 +136,7 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
 
             awsResponse.setResult(result);
 
-            final Map<String, String> metadata = new HashMap<String, String>();
+            final Map<String, String> metadata = new HashMap<>();
             metadata.put(ResponseMetadata.AWS_REQUEST_ID,
                     response.getHeaders().get("x-amzn-RequestId"));
             awsResponse.setResponseMetadata(new ResponseMetadata(metadata));

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/http/JsonResponseHandler.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/http/JsonResponseHandler.java
@@ -136,7 +136,7 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
 
             awsResponse.setResult(result);
 
-            final Map<String, String> metadata = new HashMap<>();
+            final Map<String, String> metadata = new HashMap<String, String>();
             metadata.put(ResponseMetadata.AWS_REQUEST_ID,
                     response.getHeaders().get("x-amzn-RequestId"));
             awsResponse.setResponseMetadata(new ResponseMetadata(metadata));

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/auth/AWS3SignerTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/auth/AWS3SignerTest.java
@@ -36,8 +36,7 @@ import java.net.URISyntaxException;
 public class AWS3SignerTest {
 
     /**
-     * A previously computed AWS3 HTTP authorization header from a Coral
-     * Explorer request.
+     * A previously computed AWS3 HTTP authorization header
      */
     private static final String EXPECTED_AUTHORIZATION_HEADER =
             "AWS3 AWSAccessKeyId=access,Algorithm=HmacSHA256," +

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/auth/policy/PolicyReaderTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/auth/policy/PolicyReaderTest.java
@@ -341,13 +341,12 @@ public class PolicyReaderTest {
     }
 
     /**
-     * This test case was written as result of the following tt
+     * This test case was written as result of the tt0030871921 
      *
-     * @see https://tt.amazon.com/0030871921 When a service is mentioned in the
-     *      principal, we always try to figure out the service from
-     *      <code>com.amazonaws.auth.policy.Principal.Services</code> enum. For
-     *      new services introduced, if the enum is not updated, then the
-     *      parsing fails.
+     * When a service is mentioned in the principal, we always try to figure
+     * out the service from
+     * <code>com.amazonaws.auth.policy.Principal.Services</code> enum. For new
+     * services introduced, if the enum is not updated, then the parsing fails.
      */
     @Test
     public void testPrincipalWithServiceNotInServicesEnum() {

--- a/aws-android-sdk-kinesis-test/src/androidTest/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/KinesisRecorderIntegrationTest.java
+++ b/aws-android-sdk-kinesis-test/src/androidTest/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/KinesisRecorderIntegrationTest.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.CognitoCachingCredentialsProvider;
 import com.amazonaws.regions.Regions;
@@ -41,7 +42,9 @@ import com.amazonaws.services.kinesis.model.StreamDescription;
 import com.amazonaws.util.StringUtils;
 
 import org.json.JSONException;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -60,65 +63,60 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
     // Constants for Kinesis tests
     private static final String DATA_STRING_PREFIX = "KinesisData";
     private static final String DELIMITER = "/";
+    private static final int NUM_SHARDS = 5;
 
-    // directory where Kinesis Recorder saves records
-    private File directory;
-    private static final String DIR_NAME = "KinesisRecorderDirectory";
     private static final String STREAM_NAME = "Android_" + TAG;
 
+    // directory where Kinesis Recorder saves records
+    private static final String DIR_NAME = "KinesisRecorderDirectory";
+    private File directory;
+
+    private AmazonKinesisClient client;
     private KinesisRecorder recorder;
-    private boolean initCompleted = false;
     private final Set<String> dataRecordSet = new HashSet<String>();
     private List<Shard> shards;
-    private AmazonKinesisClient client;
+
+    // Create the stream for our tests once
+    @BeforeClass
+    public static void createStream() throws InterruptedException, JSONException {
+        AmazonKinesisClient client = makeClient();
+
+        boolean streamIsCreated = false;
+        do {
+            try {
+                Log.d(TAG, "Creating stream, this may take some time");
+                client.createStream(STREAM_NAME, NUM_SHARDS);
+                streamIsCreated = true;
+                Log.d(TAG, "Stream is created.");
+            } catch (ResourceInUseException re) {
+                // if stream exists, try to delete it and create it again
+                Log.d(TAG, "Stream already exists. Deleting...");
+                waitUntilStreamIsDeleted(client);
+            }
+        } while (!streamIsCreated);
+
+    }
 
     @Before
     public void setup() throws InterruptedException, JSONException {
+        client = makeClient();
 
-        Context appContext = InstrumentationRegistry.getTargetContext();
-        if (!initCompleted) {
-            AWSCredentialsProvider provider = new CognitoCachingCredentialsProvider(appContext,
-                    getPackageConfigure().getString("identity_pool_id"), Regions.US_EAST_1);
-
-            client = new AmazonKinesisClient(provider);
-
-            int numShards = 5;
-
-            // Create the stream for our tests
-            boolean streamIsCreated = false;
-            do {
-                try {
-                    Log.d(TAG, "Creating stream, this may take some time");
-                    client.createStream(STREAM_NAME, numShards);
-                    Log.d(TAG, "Stream created, getting shards");
-                    shards = getShardsAfterStreamIsReady(numShards);
-                    streamIsCreated = true;
-                    Log.d(TAG, "Stream is created.");
-                } catch (ResourceInUseException re) {
-                    // if stream exists, try to delete it and create it again
-                    Log.d(TAG, "Stream already exists. Deleting...");
-                    waitUntilStreamIsDeleted();
-                } catch (LimitExceededException e) {
-                    Log.d(TAG, "limit exceeded, going to retry with less shards");
-                    if (numShards > 1) {
-                        numShards--;
-                    } else {
-                        throw e;
-                    }
-                }
-            } while (!streamIsCreated);
-
-            directory = new File(appContext.getApplicationContext().getFilesDir(), DIR_NAME);
-            directory.mkdir();
-            recorder = new KinesisRecorder(directory, Regions.US_EAST_1, provider);
-            initCompleted = true;
+        try {
+            shards = getShardsAfterStreamIsReady(client, NUM_SHARDS);
+        } catch (LimitExceededException e) {
+            Log.d(TAG, "limit exceeded, make sure test account hasn't exceeded shard limit");
+            throw e;
         }
+
+        directory = makeDirectory();
+        recorder = makeRecorder(directory, false);
     }
+
     @Test
     public void testPut() {
         // batch 5 records with 5 partition keys
         int i = 0;
-        for (i = 0; i < 5; i++) {
+        for (; i < 5; i++) {
             String dataStr = DATA_STRING_PREFIX + DELIMITER + String.valueOf(i);
             dataRecordSet.add(dataStr);
             recorder.saveRecord(dataStr.getBytes(StringUtils.UTF8), STREAM_NAME);
@@ -264,7 +262,73 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
 
     }
 
-    private List<Shard> getShardsAfterStreamIsReady(int numShards)
+    private void readRecordsFromKinesis(Set partitionKeys) {
+        for (Shard shard : shards) {
+            String shardId = shard.getShardId();
+            Log.d(TAG, "Reading from shard: " + shardId);
+
+            GetShardIteratorRequest getShardIterRq = new GetShardIteratorRequest();
+            getShardIterRq.setStreamName(STREAM_NAME);
+            getShardIterRq.setShardId(shardId);
+            getShardIterRq.setShardIteratorType(ShardIteratorType.TRIM_HORIZON);
+
+            GetShardIteratorResult getShardIterRslt = client.getShardIterator(getShardIterRq);
+
+            GetRecordsRequest getRecordsRq = new GetRecordsRequest();
+            getRecordsRq.setShardIterator(getShardIterRslt.getShardIterator());
+            getRecordsRq.setLimit(100);
+
+            GetRecordsResult getRecordResult = client.getRecords(getRecordsRq);
+
+            int currShardResultCount = 0;
+            for (Record r : getRecordResult.getRecords()) {
+                String recordStr = new String(r.getData().array(), StringUtils.UTF8);
+                ++currShardResultCount;
+                Log.d(TAG, "Retrieved a total of " + currShardResultCount + " records from shard "
+                        + shardId);
+                if (partitionKeys != null && dataRecordSet.contains(recordStr)) {
+                    String partitionKey = r.getPartitionKey();
+                    assertTrue("There are duplicated partition keys", !partitionKeys.contains(partitionKey));
+                    partitionKeys.add(partitionKey);
+                }
+                dataRecordSet.remove(recordStr);
+            }
+        }
+
+        assertTrue(dataRecordSet.isEmpty());
+    }
+
+    // Static utility methods
+
+    private static AmazonKinesisClient makeClient() throws JSONException {
+        AmazonKinesisClient client = new AmazonKinesisClient(makeCredentialsProvider());
+        return client;
+    }
+
+    private static KinesisRecorder makeRecorder(File directory, boolean gzipEnabled) throws JSONException {
+        KinesisRecorderConfig recorderConfig = new KinesisRecorderConfig();
+        recorderConfig.getClientConfiguration().setEnableGzip(gzipEnabled);
+        KinesisRecorder recorder = new KinesisRecorder(directory, Regions.US_EAST_1,
+                makeCredentialsProvider(), recorderConfig);
+        return recorder;
+    }
+
+    private static AWSCredentialsProvider makeCredentialsProvider() throws JSONException {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        String identityPoolId = getPackageConfigure().getString("identity_pool_id");
+        AWSCredentialsProvider provider = new CognitoCachingCredentialsProvider(appContext,
+                identityPoolId, Regions.US_EAST_1);
+        return provider;
+    }
+
+    private static File makeDirectory() {
+        Context appContext = InstrumentationRegistry.getTargetContext();
+        File directory = new File(appContext.getApplicationContext().getFilesDir(), DIR_NAME);
+        directory.mkdir();
+        return directory;
+    }
+
+    private static List<Shard> getShardsAfterStreamIsReady(AmazonKinesisClient client, int numShards)
             throws InterruptedException {
         long giveUpTimeMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(45);
         while (System.currentTimeMillis() < giveUpTimeMillis) {
@@ -281,7 +345,7 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
         return null;
     }
 
-    private boolean waitUntilStreamIsDeleted() {
+    private static boolean waitUntilStreamIsDeleted(AmazonKinesisClient client) {
         // delete stream
         int retries = 1;
         while (true) {
@@ -296,6 +360,7 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
                 }
             }
         }
+
         // wait till stream is deleted
         retries = 1;
         while (true) {
@@ -309,43 +374,13 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
                     return true;
                 }
             }
+
             retries++;
             if (retries > 30) {
                 throw new RuntimeException(
-                        "Stream still exists after deleting.  Consider refactoring incase of eventual consistency");
+                        "Stream still exists after deleting. Consider refactoring in case of eventual consistency");
             }
         }
     }
 
-    private void readRecordsFromKinesis(Set partitionKeys) {
-        for (Shard shard : shards) {
-            String shardId = shard.getShardId();
-            Log.d(TAG, "Reading from shard: " + shardId);
-            GetShardIteratorRequest getShardIterRq = new GetShardIteratorRequest();
-            getShardIterRq.setStreamName(STREAM_NAME);
-            getShardIterRq.setShardId(shardId);
-            getShardIterRq.setShardIteratorType(ShardIteratorType.TRIM_HORIZON);
-            GetShardIteratorResult getShardIterRslt = client.getShardIterator(getShardIterRq);
-            GetRecordsRequest getRecordsRq = new GetRecordsRequest();
-            getRecordsRq.setShardIterator(getShardIterRslt.getShardIterator());
-            getRecordsRq.setLimit(100);
-            GetRecordsResult getRecordResult = client.getRecords(getRecordsRq);
-            int currShardResultCount = 0;
-            for (Record r : getRecordResult.getRecords()) {
-                String recordStr = new String(r.getData().array(), StringUtils.UTF8);
-                ++currShardResultCount;
-                Log.d(TAG, "Retrieved a total of " + currShardResultCount + " records from shard "
-                        + shardId);
-                if(partitionKeys != null && dataRecordSet.contains(recordStr)) {
-                    String partitionKey = r.getPartitionKey();
-                    assertTrue("There are duplicated partition keys", !partitionKeys.contains(partitionKey));
-                    partitionKeys.add(partitionKey);
-                }
-                dataRecordSet.remove(recordStr);
-
-            }
-        }
-
-        assertTrue(dataRecordSet.isEmpty());
-    }
 }

--- a/aws-android-sdk-kinesis-test/src/androidTest/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/KinesisRecorderIntegrationTest.java
+++ b/aws-android-sdk-kinesis-test/src/androidTest/java/com/amazonaws/mobileconnectors/kinesis/kinesisrecorder/KinesisRecorderIntegrationTest.java
@@ -212,6 +212,8 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
 
     @Test
     public void testPutWithGzip() {
+        boolean wasGzipEnabled = recorder.getKinesisRecorderConfig().getClientConfiguration().isEnableGzip();
+
         recorder.getKinesisRecorderConfig().getClientConfiguration().setEnableGzip(true);
 
         // batch 25 records with 5 partition keys. A large payload is necessary to trigger a gzip
@@ -257,6 +259,9 @@ public class KinesisRecorderIntegrationTest extends KinesisRecorderIntegrationTe
             readRecordsFromKinesis(partitionKeys);
             assertTrue("Still missing records from shards.", dataRecordSet.isEmpty());
         }
+
+        recorder.getKinesisRecorderConfig().getClientConfiguration().setEnableGzip(wasGzipEnabled);
+
     }
 
     private List<Shard> getShardsAfterStreamIsReady(int numShards)


### PR DESCRIPTION
Fixed response unmarshalling when response is gzip encoded without a CRC32
checksum. Also fixes bug decoding Kinesis responses with GZIP encoding.

Additionally:
- Removed internal reference
- Removed internal reference
- Added missing modules to modules.xml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
