### PR TITLE
Fix GetObject tests to use SigV4 constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.15.0](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.15.0)
+
+### Mis. Updates
+
+- **Breaking Changes**
+  - Removed deprecated SDKGlobalConfiguration options:
+    - `ENABLE_S3_SIGV4_SYSTEM_PROPERTY`
+    - `ENFORCE_S3_SIGV4_SYSTEM_PROPERTY`
+
 ## [Release 2.14.2](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.14.2)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ private class S3Example extends AsyncTask<Void,Void,Void>{
                 Regions.SELECT_YOUR_REGION // Region enum
             );
 
-            AmazonS3Client s3Client = new AmazonS3Client(credentialsProvider);
+            AmazonS3Client s3Client = new AmazonS3Client(credentialsProvider, Regions.getRegion(Regions.SELECT_YOUR_REGION));
             File fileToUpload = YOUR_FILE;
             //(Replace "MY-BUCKET" with your S3 bucket name, and "MY-OBJECT-KEY" with whatever you would like to name the file in S3)
             PutObjectRequest putRequest = new PutObjectRequest("MY-BUCKET", "MY-OBJECT-KEY",

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
@@ -89,36 +89,6 @@ public class SDKGlobalConfiguration {
             "com.amazonaws.regions.RegionUtils.disableRemote";
 
     /**
-     * By default, the AmazonS3Client will continue to use the legacy S3Signer
-     * to authenticate requests it makes to S3 in regions that support the older
-     * protocol. Setting this property to anything other than null will cause
-     * the client to upgrade to Signature Version 4 whenever it has been
-     * configured with an explicit region (which is a required parameter for
-     * Signature Version 4). The client will continue to use the older signature
-     * protocol when not configured with a region to avoid breaking existing
-     * applications.
-     * <p>
-     * Signature Version 4 is more secure than the legacy S3Signer, but requires
-     * calculating a SHA-256 hash of the entire request body which can be
-     * expensive for large upload requests.
-     */
-    @Deprecated
-    public static final String ENABLE_S3_SIGV4_SYSTEM_PROPERTY =
-            "com.amazonaws.services.s3.enableV4";
-
-    /**
-     * Like {@link #ENABLE_S3_SIGV4_SYSTEM_PROPERTY}, but causes the client to
-     * always use Signature Version 4, assuming a region of
-     * &quot;us-east-1&quot; if no explicit region has been configured. This
-     * guarantees that the more secure authentication protocol will be used, but
-     * will cause authentication failures in code that accesses buckets in
-     * regions other than US Standard without explicitly configuring a region.
-     */
-    @Deprecated
-    public static final String ENFORCE_S3_SIGV4_SYSTEM_PROPERTY =
-            "com.amazonaws.services.s3.enforceV4";
-
-    /**
      * The default size of the buffer when uploading data from a stream. A
      * buffer of this size will be created and filled with the first bytes from
      * a stream being uploaded so that any transmit errors that occur in that

--- a/aws-android-sdk-ddb-mapper-test/src/androidTest/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBS3IntegrationTestBase.java
+++ b/aws-android-sdk-ddb-mapper-test/src/androidTest/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBS3IntegrationTestBase.java
@@ -42,10 +42,8 @@ public abstract class DynamoDBS3IntegrationTestBase extends DynamoDBIntegrationT
     @BeforeClass
     public static void setUp() throws Exception {
         DynamoDBIntegrationTestBase.setUp();
-        s3East = new AmazonS3Client(credentials);
-        s3East.setRegion(Region.getRegion(Regions.US_EAST_1));
-        s3West = new AmazonS3Client(credentials);
-        s3West.setRegion(Region.getRegion(Regions.US_WEST_2));
+        s3East = new AmazonS3Client(credentials, Region.getRegion(Regions.US_EAST_1));
+        s3West = new AmazonS3Client(credentials, Region.getRegion(Regions.US_WEST_2));
 
         createBucket(s3East, EAST_BUCKET);
         createBucket(s3West, WEST_BUCKET);

--- a/aws-android-sdk-ddb-mapper-test/src/androidTest/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/S3ClientCacheIntegrationTest.java
+++ b/aws-android-sdk-ddb-mapper-test/src/androidTest/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/S3ClientCacheIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.mobileconnectors.s3.transfermanager.TransferManager;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.Region;
 
@@ -57,11 +58,17 @@ public class S3ClientCacheIntegrationTest {
     @Test
     public void testUserProvidedClients() {
         S3ClientCache s3cc = new S3ClientCache(credentials);
-        AmazonS3Client s3East1 = new AmazonS3Client(credentials);
+        AmazonS3Client s3East1 = new AmazonS3Client(credentials,
+                com.amazonaws.regions.Region.getRegion(Regions.US_EAST_1));
+
         s3East1.setRegion(Region.US_Standard.toAWSRegion());
-        AmazonS3Client s3West1 = new AmazonS3Client(credentials);
+        AmazonS3Client s3West1 = new AmazonS3Client(credentials,
+                com.amazonaws.regions.Region.getRegion(Regions.US_WEST_1));
+
         s3West1.setRegion(Region.US_West.toAWSRegion());
-        AmazonS3Client s3West2 = new AmazonS3Client(credentials);
+        AmazonS3Client s3West2 = new AmazonS3Client(credentials,
+                com.amazonaws.regions.Region.getRegion(Regions.US_WEST_2));
+
         s3West2.setRegion(Region.US_West_2.toAWSRegion());
 
         s3cc.useClient(s3East1);
@@ -88,7 +95,8 @@ public class S3ClientCacheIntegrationTest {
         TransferManager tmEast1 = s3cc.getTransferManager(Region.US_Standard);
         assertNotNull(tmEast1);
 
-        AmazonS3Client newS3East = new AmazonS3Client(credentials);
+        AmazonS3Client newS3East = new AmazonS3Client(credentials,
+                com.amazonaws.regions.Region.getRegion(Regions.US_EAST_1));
         newS3East.setRegion(Region.US_Standard.toAWSRegion());
         s3cc.useClient(newS3East); // should remove old TM
 
@@ -101,7 +109,8 @@ public class S3ClientCacheIntegrationTest {
     @Test
     public void testBadClientCache() {
         S3ClientCache s3cc = new S3ClientCache(credentials);
-        AmazonS3Client notAnAWSEndpoint = new AmazonS3Client(credentials);
+        AmazonS3Client notAnAWSEndpoint = new AmazonS3Client(credentials,
+                com.amazonaws.regions.Region.getRegion(Regions.US_EAST_1));
         notAnAWSEndpoint.setEndpoint("i.am.an.invalid.aws.endpoint.com");
         try {
             s3cc.useClient(notAnAWSEndpoint);
@@ -114,9 +123,10 @@ public class S3ClientCacheIntegrationTest {
     }
 
     @Test
-    public void testNonExistantRegion() {
+    public void testNonExistentRegion() {
         S3ClientCache s3cc = new S3ClientCache(credentials);
-        AmazonS3Client notAnAWSEndpoint = new AmazonS3Client(credentials);
+        AmazonS3Client notAnAWSEndpoint = new AmazonS3Client(credentials,
+                com.amazonaws.regions.Region.getRegion(Regions.US_EAST_1));
         notAnAWSEndpoint.setEndpoint("s3-mordor.amazonaws.com");
         try {
             s3cc.useClient(notAnAWSEndpoint);

--- a/aws-android-sdk-ddb-mapper/src/test/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/S3LinkTest.java
+++ b/aws-android-sdk-ddb-mapper/src/test/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/S3LinkTest.java
@@ -27,6 +27,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.mobileconnectors.s3.transfermanager.TransferManager;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.AccessControlList;
@@ -63,9 +64,11 @@ public class S3LinkTest
     @Before
     public void setUp() {
         AWSCredentials credentials = new BasicAWSCredentials("mock", "mock");
+        StaticCredentialsProvider s3CredentialProvider = new StaticCredentialsProvider(credentials);
+
         mockDDB = EasyMock.createMock(AmazonDynamoDB.class);
         mockS3 = EasyMock.createMock(AmazonS3Client.class);
-        mapper = new DynamoDBMapper(mockDDB, new StaticCredentialsProvider(credentials));
+        mapper = new DynamoDBMapper(mockDDB, s3CredentialProvider);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -268,9 +271,13 @@ public class S3LinkTest
     @Test
     public void testGetURL() {
 
-        AmazonS3Client realS3 = new AmazonS3Client();
+        AWSCredentials credentials = new BasicAWSCredentials("mock", "mock");
+        StaticCredentialsProvider s3CredentialProvider = new StaticCredentialsProvider(credentials);
+        AmazonS3Client realS3 = new AmazonS3Client(s3CredentialProvider,
+                com.amazonaws.regions.Region.getRegion(Regions.US_WEST_2));
+
         mapper.getS3ClientCache().useClient(realS3);
-        S3Link link = mapper.createS3Link(bucket, key);
+        S3Link link = mapper.createS3Link(Region.US_West_2, bucket, key);
 
         URL createdURL = realS3.getUrl(bucket, key);
         URL retrievedURL = link.getUrl();
@@ -280,9 +287,13 @@ public class S3LinkTest
 
     @Test
     public void testGetTransferManager() {
-        AmazonS3Client realS3 = new AmazonS3Client();
+        AWSCredentials credentials = new BasicAWSCredentials("mock", "mock");
+        StaticCredentialsProvider s3CredentialProvider = new StaticCredentialsProvider(credentials);
+        AmazonS3Client realS3 = new AmazonS3Client(s3CredentialProvider,
+                com.amazonaws.regions.Region.getRegion(Regions.US_WEST_2));
+
         mapper.getS3ClientCache().useClient(realS3);
-        S3Link link = mapper.createS3Link(bucket, key);
+        S3Link link = mapper.createS3Link(Region.US_West_2, bucket, key);
 
         TransferManager tm = link.getTransferManager();
 

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/BucketNameValidationIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/BucketNameValidationIntegrationTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.fail;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 
 import org.junit.Test;
 
@@ -37,7 +39,8 @@ public class BucketNameValidationIntegrationTest {
 
     private final AWSCredentials fakeCredentials =
             new BasicAWSCredentials("fakeAccessKey", "fakeSecretKey");
-    private final AmazonS3 s3 = new AmazonS3Client(fakeCredentials);
+    private final AmazonS3 s3 =
+            new AmazonS3Client(fakeCredentials, Region.getRegion(Regions.DEFAULT_REGION));
 
     /**
      * Tests that the bucket names that don't follow S3's recommended

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/CleanupBucketIntegrationTests.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/CleanupBucketIntegrationTests.java
@@ -23,10 +23,9 @@ public class CleanupBucketIntegrationTests extends AWSTestBase {
     private AmazonS3 s3;
 
     @Before
-    public void setup() throws FileNotFoundException, IOException {
+    public void setup() {
         setUpCredentials();
-        s3 = new AmazonS3Client(credentials);
-        s3.setRegion(Region.getRegion(Regions.US_WEST_1));
+        s3 = new AmazonS3Client(credentials, Region.getRegion(Regions.US_WEST_1));
     }
 
     @Test

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/GetObjectIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/GetObjectIntegrationTest.java
@@ -449,7 +449,7 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     @Ignore("causes a dns exception in some cases")
     @Test
     public void testNonUsRegionBucketNamesWithPeriods() {
-        final AmazonS3 regionalClient = new AmazonS3Client(credentials);
+        final AmazonS3 regionalClient = new AmazonS3Client(credentials, Region.getRegion(Regions.SA_EAST_1));
         regionalClient.setEndpoint("s3-sa-east-1.amazonaws.com");
         final String regionalBucketName = bucketName + ".with.periods.regional";
         try {
@@ -517,7 +517,8 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     public void testGetObjectWithClientSetToNullBeforeReadingFromInputStream()
             throws Exception {
 
-        AmazonS3 s3Local = new AmazonS3Client(credentials);
+        // Matches the default client set up in S3IntegrationTestBase
+        AmazonS3 s3Local = new AmazonS3Client(credentials, Region.getRegion(Regions.US_WEST_1));
 
         final S3Object obj = s3Local.getObject(bucketName, key);
 
@@ -559,9 +560,11 @@ public class GetObjectIntegrationTest extends S3IntegrationTestBase {
     @Test
     public void testRequesterPays() throws InterruptedException {
 
-        final AmazonS3Client requester = new AmazonS3Client(
-                new PropertiesFileCredentialsProvider(
-                        requesterPaysCredentialsFilePath));
+        PropertiesFileCredentialsProvider requesterPaysCredentialsProvider =
+                new PropertiesFileCredentialsProvider(requesterPaysCredentialsFilePath);
+
+        final AmazonS3Client requester = new AmazonS3Client(requesterPaysCredentialsProvider,
+                Region.getRegion(Regions.DEFAULT_REGION));
 
         final Owner owner = requester.getS3AccountOwner();
         final String id = owner.getId();

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/PresignedUrlIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/PresignedUrlIntegrationTest.java
@@ -23,6 +23,8 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.auth.STSSessionCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.internal.MD5DigestCalculatingInputStream;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
@@ -101,17 +103,6 @@ public class PresignedUrlIntegrationTest extends S3IntegrationTestBase {
      */
     @Test
     public void testSpecialKeys() throws Exception {
-        // SigV2
-        System.clearProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY);
-        goTestSpecialKeys();
-
-        // SigV4
-        System.setProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY, "true");
-        goTestSpecialKeys();
-        System.clearProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY);
-    }
-
-    private void goTestSpecialKeys() throws Exception {
         List<String> keys = SpecialObjectKeyNameGenerator.initAllSpecialKeyNames();
 
         s3.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(false));
@@ -353,17 +344,12 @@ public class PresignedUrlIntegrationTest extends S3IntegrationTestBase {
         final String key = "presign-url-sts-test";
 
         STSSessionCredentialsProvider provider = new STSSessionCredentialsProvider(credentials);
-        AmazonS3Client s3WithSts = new AmazonS3Client(provider);
+        AmazonS3Client s3WithSts = new AmazonS3Client(provider,
+                Region.getRegion(Regions.US_WEST_2));
         s3WithSts.setEndpoint(S3_REGIONAL_ENDPOINT);
         s3WithSts.putObject(virtHostBucketName, key, file);
 
-        // SigV2
         testGetUrl(s3WithSts, virtHostBucketName, key);
-
-        // SigV4
-        System.setProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY, "true");
-        testGetUrl(s3WithSts, virtHostBucketName, key);
-        System.clearProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY);
     }
 
     /*

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3InterruptIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3InterruptIntegrationTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.amazonaws.AbortedException;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.internal.crypto.CryptoTestUtils;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -51,14 +53,15 @@ public class S3InterruptIntegrationTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        s3 = new AmazonS3Client(awsTestCredentials());
+        s3 = new AmazonS3Client(awsTestCredentials(), Region.getRegion(Regions.DEFAULT_REGION));
         tryCreateBucket(s3, TEST_BUCKET);
     }
 
     @AfterClass
     public static void cleanup() throws Exception {
         if (cleanup) {
-            final AmazonS3Client s3 = new AmazonS3Client(awsTestCredentials());
+            final AmazonS3Client s3 = new AmazonS3Client(awsTestCredentials(),
+                    Region.getRegion(Regions.DEFAULT_REGION));
             deleteBucketAndAllContents(s3, TEST_BUCKET);
         }
         s3.shutdown();

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3SkipByteDigestIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3SkipByteDigestIntegrationTest.java
@@ -20,6 +20,8 @@ import static com.amazonaws.services.s3.internal.crypto.CryptoTestUtils.deleteBu
 import static com.amazonaws.services.s3.internal.crypto.CryptoTestUtils.tempBucketName;
 import static com.amazonaws.services.s3.internal.crypto.CryptoTestUtils.tryCreateBucket;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.testutils.util.ConstantInputStream;
@@ -45,14 +47,15 @@ public class S3SkipByteDigestIntegrationTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        s3 = new AmazonS3Client(awsTestCredentials());
+        s3 = new AmazonS3Client(awsTestCredentials(), Region.getRegion(Regions.DEFAULT_REGION));
         tryCreateBucket(s3, TEST_BUCKET);
     }
 
     @AfterClass
     public static void cleanup() throws Exception {
         if (cleanup) {
-            final AmazonS3Client s3 = new AmazonS3Client(awsTestCredentials());
+            final AmazonS3Client s3 = new AmazonS3Client(awsTestCredentials(),
+                    Region.getRegion(Regions.DEFAULT_REGION));
             deleteBucketAndAllContents(s3, TEST_BUCKET);
         }
         s3.shutdown();

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/STSIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/STSIntegrationTest.java
@@ -94,8 +94,7 @@ public class STSIntegrationTest extends S3IntegrationTestBase {
         tempData = tempDataBuffer(1000);
 
         STSSessionCredentialsProvider provider = new STSSessionCredentialsProvider(credentials);
-        s3 = new AmazonS3Client(provider);
-        s3.setRegion(Region.getRegion(Regions.US_WEST_2));
+        s3 = new AmazonS3Client(provider, Region.getRegion(Regions.US_WEST_2));
         s3.createBucket(bucketName);
 
         ObjectMetadata metadata = null;

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/V1BucketAddressingIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/V1BucketAddressingIntegrationTest.java
@@ -19,6 +19,8 @@ import com.amazonaws.DefaultRequest;
 import com.amazonaws.Request;
 import com.amazonaws.http.ExecutionContext;
 import com.amazonaws.http.HttpMethodName;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.internal.Constants;
 import com.amazonaws.services.s3.internal.S3ErrorResponseHandler;
 import com.amazonaws.services.s3.internal.S3XmlResponseHandler;
@@ -118,7 +120,7 @@ public class V1BucketAddressingIntegrationTest extends S3IntegrationTestBase {
      */
     @SuppressWarnings("static-access")
     private void createV1AddressedBucket(String bucketName) throws Exception {
-        new AmazonS3Client(AWSTestBase.credentials) {
+        new AmazonS3Client(AWSTestBase.credentials, Region.getRegion(Regions.DEFAULT_REGION)) {
             public void createV1AddressedBucket(String bucketName) throws Exception {
                 final Request<Void> request = new DefaultRequest<Void>(
                         Constants.S3_SERVICE_DISPLAY_NAME);

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/model/GeneratePresignedUrlRequestIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/model/GeneratePresignedUrlRequestIntegrationTest.java
@@ -60,8 +60,7 @@ public class GeneratePresignedUrlRequestIntegrationTest extends AWSTestBase {
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 	    setUpCredentials();			
-	    s3Client = new AmazonS3Client(credentials);
-	    s3Client.setRegion(Region.getRegion(Regions.US_WEST_2));
+	    s3Client = new AmazonS3Client(credentials, Region.getRegion(Regions.US_WEST_2));
 	    s3Client.createBucket(BUCKET_NAME);
 		
 	    int poll = 0;

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/Amazons3ClientTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/Amazons3ClientTest.java
@@ -47,7 +47,7 @@ public class Amazons3ClientTest {
     @Before
     public void setup() {
         creds = new BasicAWSCredentials("accessKey", "secretKey");
-        s3 = new AmazonS3Client(creds);
+        s3 = new AmazonS3Client(creds, Region.getRegion(Regions.US_EAST_1));
         accelerateOption = S3ClientOptions.builder().setAccelerateModeEnabled(true).build();
     }
 
@@ -190,29 +190,65 @@ public class Amazons3ClientTest {
         assertTrue(request.getResourcePath().contains(key));
     }
 
+    /**
+     * Remove this when we remove the no-arg constructor. Since this unit test doesn't hit the
+     * service, it won't trigger any alerts about using SigV2.
+     */
     @Test
+    @Deprecated
     public void testConstructorWithBasicAwsCredentials() {
         creds = new BasicAWSCredentials("accessKey", "secretKey");
         s3 = new AmazonS3Client(creds);
         assertNotNull(s3);
     }
 
+    /**
+     * Remove this when we remove the no-arg constructor. Since this unit test doesn't hit the
+     * service, it won't trigger any alerts about using SigV2.
+     */
     @Test
+    @Deprecated
     public void testDefaultConstructor() {
         s3 = new AmazonS3Client();
         assertNotNull(s3);
     }
 
+    /**
+     * Remove this when we remove the no-region constructor. Since this unit test doesn't hit the
+     * service, it won't trigger any alerts about using SigV2.
+     */
     @Test
+    @Deprecated
     public void testConstructorWithBasicAwsCredentialsAndClientConfiguration() {
         creds = new BasicAWSCredentials("accessKey", "secretKey");
         s3 = new AmazonS3Client(creds, new ClientConfiguration());
         assertNotNull(s3);
     }
 
+    /**
+     * Remove this when we remove the no-region constructor. Since this unit test doesn't hit the
+     * service, it won't trigger any alerts about using SigV2.
+     */
     @Test
+    @Deprecated
     public void testConstructorWithClientConfiguration() {
         s3 = new AmazonS3Client(new ClientConfiguration());
+        assertNotNull(s3);
+    }
+
+    @Test
+    public void testConstructorWithCredentialsAndRegion() {
+        creds = new BasicAWSCredentials("accessKey", "secretKey");
+        Region defaultRegion = Region.getRegion(Regions.DEFAULT_REGION);
+        s3 = new AmazonS3Client(creds, defaultRegion);
+        assertNotNull(s3);
+    }
+
+    @Test
+    public void testConstructorWithCredentialsRegionAndClientConfiguration() {
+        creds = new BasicAWSCredentials("accessKey", "secretKey");
+        Region defaultRegion = Region.getRegion(Regions.DEFAULT_REGION);
+        s3 = new AmazonS3Client(creds, defaultRegion, new ClientConfiguration());
         assertNotNull(s3);
     }
 

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/DefaultSigningMethodTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/DefaultSigningMethodTest.java
@@ -16,7 +16,6 @@
 package com.amazonaws.services.s3;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -67,78 +66,58 @@ public class DefaultSigningMethodTest {
         }
     }
 
-    /** Clear system properties */
-    @Before
-    @After
-    public void clearFlags() {
-        System.clearProperty("com.amazonaws.services.s3.enforceV4");
-        System.clearProperty("com.amazonaws.services.s3.enableV4");
-    }
-
     /**
-     * Tests that BJS endpoint always defaults to SigV4.
+     * Tests that BJS endpoint always defaults to SigV4. Remove this when we remove the no-arg
+     * constructor.
      */
     @Test
+    @Deprecated
     public void testBJSDefaultSigning() {
         final AmazonS3Client s3 = new AmazonS3Client();
         s3.setEndpoint("s3.cn-north-1.amazonaws.com.cn");
         assertSigV4WithRegion(s3, "cn-north-1");
-
-        // Using any of the system props should not affect the default
-        System.setProperty("com.amazonaws.services.s3.enforceV4", "true");
-        assertSigV4WithRegion(s3, "cn-north-1");
-        System.setProperty("com.amazonaws.services.s3.enableV4", "true");
-        assertSigV4WithRegion(s3, "cn-north-1");
     }
 
     /**
-     * Tests the behavior when using S3 standard endpoint with explicit region.
+     * Tests the behavior when using S3 standard endpoint with explicit region. Remove this when we
+     * remove the no-arg constructor.
      */
     @Test
+    @Deprecated
     public void testStandardEndpointWithRegionOverride() {
         final AmazonS3Client s3 = new AmazonS3Client();
-        // Explicitly setting a regionName, now it defaults to sigv2, but sigv4
-        // is allowed to be turned on by enforceV4.
+        // Explicitly setting a regionName
         s3.setEndpoint("s3.amazonaws.com", "s3", "us-west-1");
 
-        // Default to SigV2
+        // Default to SigV4 if providing region
         assertSigV4WithRegion(s3, "us-west-1");
-        // "Enforce" v4 signing should work.
-        System.setProperty("com.amazonaws.services.s3.enforceV4", "true");
-        assertSigV4WithRegion(s3, "us-west-1");
+
         s3.setEndpoint("s3.amazonaws.com", "s3", "eu-west-1");
         assertSigV4WithRegion(s3, "eu-west-1");
     }
 
     /**
-     * Tests that other endpoints always defaults to SigV2, and can be changed
-     * by system property.
+     * Tests that other endpoints always uses SigV4 if we override via system property
      */
     @Test
     public void testOtherRegionDefaultSigning() {
-        testSigV4WithRegionDefaultSigning("s3-external-1.amazonaws.com", "us-east-1");
-        testSigV4WithRegionDefaultSigning("s3-us-west-2.amazonaws.com", "us-west-2");
-        testSigV4WithRegionDefaultSigning("s3-us-west-1.amazonaws.com", "us-west-1");
-        testSigV4WithRegionDefaultSigning("s3-eu-west-1.amazonaws.com", "eu-west-1");
-        testSigV4WithRegionDefaultSigning("s3-ap-southeast-1.amazonaws.com", "ap-southeast-1");
-        testSigV4WithRegionDefaultSigning("s3-ap-southeast-2.amazonaws.com", "ap-southeast-2");
-        testSigV4WithRegionDefaultSigning("s3-ap-northeast-1.amazonaws.com", "ap-northeast-1");
-        testSigV4WithRegionDefaultSigning("s3-sa-east-1.amazonaws.com", "sa-east-1");
+        assertReturnsSigV4IfRegionProvided("s3-external-1.amazonaws.com", "us-east-1");
+        assertReturnsSigV4IfRegionProvided("s3-us-west-2.amazonaws.com", "us-west-2");
+        assertReturnsSigV4IfRegionProvided("s3-us-west-1.amazonaws.com", "us-west-1");
+        assertReturnsSigV4IfRegionProvided("s3-eu-west-1.amazonaws.com", "eu-west-1");
+        assertReturnsSigV4IfRegionProvided("s3-ap-southeast-1.amazonaws.com", "ap-southeast-1");
+        assertReturnsSigV4IfRegionProvided("s3-ap-southeast-2.amazonaws.com", "ap-southeast-2");
+        assertReturnsSigV4IfRegionProvided("s3-ap-northeast-1.amazonaws.com", "ap-northeast-1");
+        assertReturnsSigV4IfRegionProvided("s3-sa-east-1.amazonaws.com", "sa-east-1");
     }
 
-    private void testSigV4WithRegionDefaultSigning(String endpoint, String expectedRegionName) {
-        clearFlags();
+    /**
+     * Remove when we remove the no-arg AmazonS3Client constructor
+     */
+    @Deprecated
+    private void assertReturnsSigV4IfRegionProvided(String endpoint, String expectedRegionName) {
         final AmazonS3Client s3 = new AmazonS3Client();
         s3.setEndpoint(endpoint);
-        assertSigV4WithRegion(s3, expectedRegionName);
-
-        // Enforce SigV4 should change the default
-        System.setProperty("com.amazonaws.services.s3.enforceV4", "true");
-        assertSigV4WithRegion(s3, expectedRegionName);
-        clearFlags();
-
-        // Enable SigV4 should also work
-        System.setProperty("com.amazonaws.services.s3.enableV4", "true");
         assertSigV4WithRegion(s3, expectedRegionName);
     }
 

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/TransferUtilityTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/TransferUtilityTest.java
@@ -21,8 +21,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.mobile.config.AWSConfiguration;
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferUtility;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.internal.Constants;
 
 import org.json.JSONException;
@@ -64,7 +68,9 @@ public class TransferUtilityTest {
             fail("Error in constructing AWSConfiguration." + e.getLocalizedMessage());
         }
 
-        AmazonS3Client s3 = new AmazonS3Client();
+        AWSCredentials creds = new BasicAWSCredentials("accessKey", "secretKey");
+        Region region = Region.getRegion(Regions.DEFAULT_REGION);
+        AmazonS3Client s3 = new AmazonS3Client(creds, region);
 
         TransferUtility.builder()
                 .context(RuntimeEnvironment.application.getApplicationContext())
@@ -102,7 +108,9 @@ public class TransferUtilityTest {
             fail("Error in constructing AWSConfiguration." + e.getLocalizedMessage());
         }
 
-        AmazonS3Client s3 = new AmazonS3Client();
+        AWSCredentials creds = new BasicAWSCredentials("accessKey", "secretKey");
+        Region region = Region.getRegion(Regions.DEFAULT_REGION);
+        AmazonS3Client s3 = new AmazonS3Client(creds, region);
 
         TransferUtility.builder()
                 .context(RuntimeEnvironment.application.getApplicationContext())
@@ -139,7 +147,9 @@ public class TransferUtilityTest {
             fail("Error in constructing AWSConfiguration." + e.getLocalizedMessage());
         }
 
-        AmazonS3Client s3 = new AmazonS3Client();
+        AWSCredentials creds = new BasicAWSCredentials("accessKey", "secretKey");
+        Region region = Region.getRegion(Regions.DEFAULT_REGION);
+        AmazonS3Client s3 = new AmazonS3Client(creds, region);
 
         TransferUtility.builder()
                 .context(RuntimeEnvironment.application.getApplicationContext())

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/internal/AWSS3V4SignerTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/internal/AWSS3V4SignerTest.java
@@ -51,17 +51,6 @@ import java.util.List;
 
 public class AWSS3V4SignerTest {
 
-    @Before
-    public void setup() {
-        System.setProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY, "true");
-
-    }
-
-    @After
-    public void teardown() {
-        System.clearProperty(SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY);
-    }
-
     @Test
     public void testSignPutObject() throws URISyntaxException {
         final AWSS3V4Signer signer = new S3SignerWithDateOverride(new Date(1431115356859L));


### PR DESCRIPTION
*Issue #, if available:*

For backwards compatibility, the  no-arg constructor for `AmazonS3Client` uses SigV2 signing unless overridden. As this signing method is deprecated and on a removal path by the S3 service, we want to migrate our integration tests to not use it. 

We made this migration initially, but forgot a couple of instances of the no-arg constructor that were in use by tests. This change migrates documentation and one of the missed tests.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
