### PR TITLE
Gson fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Misc. Updates
 
+- **Amazon S3**
+  - Added serialized name annotation to `TransferNetworkConnectionType` enum values and added instrumentation tests.
+  
 - Model updates for the following services
   - Amazon Cognito Identity Provider
 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferNetworkConnectionType.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferNetworkConnectionType.java
@@ -19,6 +19,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +31,7 @@ public enum TransferNetworkConnectionType {
     /**
      * Any connection
      */
+    @SerializedName("ANY")
     ANY() {
         @Override
         protected boolean verify(NetworkInfo networkInfo) {
@@ -40,6 +42,7 @@ public enum TransferNetworkConnectionType {
     /**
      * Wifi only
      */
+    @SerializedName("WIFI")
     WIFI() {
         @Override
         protected boolean verify(NetworkInfo networkInfo) {
@@ -51,6 +54,7 @@ public enum TransferNetworkConnectionType {
     /**
      * Mobile only
      */
+    @SerializedName("MOBILE")
     MOBILE() {
         @Override
         protected boolean verify(NetworkInfo networkInfo) {

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/mobileconnectors/s3/transferutility/GsonSerializationTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/mobileconnectors/s3/transferutility/GsonSerializationTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.mobileconnectors.s3.transferutility;
+
+import com.google.gson.Gson;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class GsonSerializationTest {
+
+    private static Gson gson = new Gson();
+
+    @Test
+    public void testTransferNetworkConnectionTypeSerialization() {
+        String typeAny = gson.toJson(TransferNetworkConnectionType.ANY);
+        String typeWifi = gson.toJson(TransferNetworkConnectionType.WIFI);
+        String typeMobile = gson.toJson(TransferNetworkConnectionType.MOBILE);
+
+        assertEquals("\"ANY\"", typeAny);
+        assertEquals("\"WIFI\"", typeWifi);
+        assertEquals("\"MOBILE\"", typeMobile);
+    }
+
+    @Test
+    public void testTransferNetworkConnectionTypeDeserialization() {
+        TransferNetworkConnectionType anyType = gson.fromJson("\"ANY\"", TransferNetworkConnectionType.class);
+        TransferNetworkConnectionType wifiType = gson.fromJson("\"WIFI\"", TransferNetworkConnectionType.class);
+        TransferNetworkConnectionType mobileType = gson.fromJson("\"MOBILE\"", TransferNetworkConnectionType.class);
+
+        assertEquals(TransferNetworkConnectionType.ANY, anyType);
+        assertEquals(TransferNetworkConnectionType.WIFI, wifiType);
+        assertEquals(TransferNetworkConnectionType.MOBILE, mobileType);
+    }
+
+    @Test
+    public void testTransferUtilityOptionsSerialization() {
+        String jsonOptions = gson.toJson(new TransferUtilityOptions());
+
+        assertThat(jsonOptions, containsString("\"transferServiceCheckTimeInterval\":" +
+                TransferUtilityOptions.getDefaultCheckTimeInterval()));
+        assertThat(jsonOptions, containsString("\"transferThreadPoolSize\":" +
+                TransferUtilityOptions.getDefaultThreadPoolSize()));
+        assertThat(jsonOptions, containsString("\"transferNetworkConnectionType\":" +
+                "\"" + TransferUtilityOptions.getDefaultTransferNetworkConnectionType() + "\""));
+    }
+
+    @Test
+    public void testTransferUtilityOptionsDeserialization() {
+        final String jsonOptions = "{" +
+                "\"transferServiceCheckTimeInterval\":6000," +
+                "\"transferThreadPoolSize\":10," +
+                "\"transferNetworkConnectionType\":\"ANY\"" +
+                "}";
+
+        TransferUtilityOptions tuOptions = gson.fromJson(jsonOptions, TransferUtilityOptions.class);
+
+        assertEquals(6000,
+                tuOptions.getTransferServiceCheckTimeInterval());
+        assertEquals(10,
+                tuOptions.getTransferThreadPoolSize());
+        assertEquals(TransferNetworkConnectionType.ANY,
+                tuOptions.getTransferNetworkConnectionType());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-android/issues/1093

*Description of changes:*
Added Serialized names to transfer connection type enum values to prevent gson from inconsistently interpreting it as an integer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
