### PR TITLE
[finishes #167549816] User internal username for computing secret hash that is passed in challenge response

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserIntegrationTest.java
+++ b/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserIntegrationTest.java
@@ -73,6 +73,7 @@ public class CognitoUserIntegrationTest extends CognitoUserPoolsIntegrationTestB
             @Override
             public void getAuthenticationDetails(AuthenticationContinuation authenticationContinuation, String userId) {
                 final HashMap<String, String> authParameters = new HashMap<>();
+                // This is a passwordless flow, hance passing a dummy password.
                 AuthenticationDetails authenticationDetails = new AuthenticationDetails(customAuthUsername, "", authParameters, null);
                 authenticationContinuation.setAuthenticationDetails(authenticationDetails);
                 authenticationContinuation.continueTask();
@@ -108,7 +109,7 @@ public class CognitoUserIntegrationTest extends CognitoUserPoolsIntegrationTestB
         }
 
         assertEquals(1, userSessions.size());
-
+        // Verify that the sign-in was successful
         verifyCognitoUserSessionForSignedInUser(userSessions.get(0));
     }
 

--- a/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserIntegrationTest.java
+++ b/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserIntegrationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.mobileconnectors.cognitoidentityprovider;
+
+import android.util.Log;
+
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.AuthenticationContinuation;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.AuthenticationDetails;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.ChallengeContinuation;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.MultiFactorAuthenticationContinuation;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.AuthenticationHandler;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoServiceConstants;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CognitoUserIntegrationTest extends CognitoUserPoolsIntegrationTestBase {
+
+    private CognitoUserPool cognitoUserPool;
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        cognitoUserPool = super.getCustomAuthUserPool();
+        cognitoUserPool.getCurrentUser().signOut();
+        verifyCognitoUserSessionForSignedOutUser();
+    }
+
+    @Test
+    public void testCustomAuth(){
+        final CountDownLatch signInLatch = new CountDownLatch(1);
+        final ArrayList<CognitoUserSession> userSessions = new ArrayList();
+
+        AuthenticationHandler authenticationHandler = new AuthenticationHandler() {
+            @Override
+            public void onSuccess(CognitoUserSession userSession, CognitoDevice newDevice) {
+                userSessions.add(userSession);
+                signInLatch.countDown();
+            }
+
+            @Override
+            public void getAuthenticationDetails(AuthenticationContinuation authenticationContinuation, String userId) {
+                final HashMap<String, String> authParameters = new HashMap<>();
+                AuthenticationDetails authenticationDetails = new AuthenticationDetails(customAuthUsername, "", authParameters, null);
+                authenticationContinuation.setAuthenticationDetails(authenticationDetails);
+                authenticationContinuation.continueTask();
+            }
+
+            @Override
+            public void getMFACode(MultiFactorAuthenticationContinuation continuation) {
+                fail("Tests are not configured to work with MFA. " +
+                        "Either create a CognitoUserPool without MFA or update the test.");
+                signInLatch.countDown();
+            }
+
+            @Override
+            public void authenticationChallenge(ChallengeContinuation continuation) {
+                Log.d(TAG, "Yo, Authentication Chanllenge is called Passwordless");
+                continuation.setChallengeResponse(CognitoServiceConstants.CHLG_RESP_ANSWER, "1133");
+                continuation.continueTask();
+            }
+
+            @Override
+            public void onFailure(Exception exception) {
+                fail("Error while signing-in. " + exception.getLocalizedMessage());
+                signInLatch.countDown();
+            }
+        };
+
+        cognitoUserPool.getUser(customAuthUsername).getSessionInBackground(authenticationHandler);
+
+        try {
+            signInLatch.await(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(1, userSessions.size());
+
+        verifyCognitoUserSessionForSignedInUser(userSessions.get(0));
+    }
+
+
+    private void verifyCognitoUserSessionForSignedOutUser() {
+        try {
+            cognitoUserPool.getCurrentUser().getCachedSession();
+            fail("Error in verifying the Cognito User Session for the signed-out user.");
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private void verifyCognitoUserSessionForSignedInUser(final CognitoUserSession userSession) {
+        try {
+            assertNotNull(userSession);
+
+            assertTrue(userSession.isValid());
+            assertTrue(userSession.isValidForThreshold());
+
+            assertNotNull(userSession.getAccessToken());
+            assertNotNull(userSession.getAccessToken().getExpiration());
+            assertNotNull(userSession.getAccessToken().getJWTToken());
+            assertNotNull(userSession.getAccessToken().getUsername());
+
+            assertNotNull(userSession.getIdToken());
+            assertNotNull(userSession.getIdToken().getExpiration());
+            assertNotNull(userSession.getIdToken().getJWTToken());
+
+            assertNotNull(userSession.getRefreshToken());
+            assertNotNull(userSession.getRefreshToken().getToken());
+        } catch (Exception ex) {
+            fail("Error in verifying the Cognito User Session for the signed-in user. " + ex);
+        }
+    }
+}

--- a/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserIntegrationTest.java
+++ b/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserIntegrationTest.java
@@ -49,6 +49,15 @@ public class CognitoUserIntegrationTest extends CognitoUserPoolsIntegrationTestB
         verifyCognitoUserSessionForSignedOutUser();
     }
 
+    void tearDown() {
+        try {
+            cognitoUserPool.awsKeyValueStore.clear();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail ("Error in wiping off data stored on disk by CognitoUserPools." + ex);
+        }
+    }
+
     @Test
     public void testCustomAuth(){
         final CountDownLatch signInLatch = new CountDownLatch(1);

--- a/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPoolsIntegrationTestBase.java
+++ b/aws-android-sdk-cognitoidentityprovider-test/src/androidTest/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPoolsIntegrationTestBase.java
@@ -16,28 +16,21 @@
 package com.amazonaws.mobileconnectors.cognitoidentityprovider;
 
 import android.content.Context;
-import android.os.Build;
 import android.support.test.InstrumentationRegistry;
-import android.util.Log;
 
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.AuthenticationContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.AuthenticationDetails;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.ChallengeContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.MultiFactorAuthenticationContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.AuthenticationHandler;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.testutils.AWSTestBase;
 
 import org.json.JSONObject;
 
-import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.*;
 
 public abstract class CognitoUserPoolsIntegrationTestBase extends AWSTestBase {
@@ -47,6 +40,10 @@ public abstract class CognitoUserPoolsIntegrationTestBase extends AWSTestBase {
     private String userName;
     private String password;
     private String userEmail;
+    protected static final int TIMEOUT_IN_SECONDS = 60;
+
+    private CognitoUserPool customAuthUserPool;
+    protected String customAuthUsername;
 
     private JSONObject getPackageConfigure()  {
         return getPackageConfigure("CognitoUserPools");
@@ -62,7 +59,13 @@ public abstract class CognitoUserPoolsIntegrationTestBase extends AWSTestBase {
             cognitoUserPool = new CognitoUserPool(appContext,
                     getPackageConfigure().getString("UserPoolId"),
                     getPackageConfigure().getString("AppClientId"),
-                    getPackageConfigure().getString("AppClientSecret"));
+                    getPackageConfigure().getString("AppClientSecret"), Regions.US_EAST_1);
+
+            customAuthUsername = getPackageConfigure().getString("customAuthUserName");
+            customAuthUserPool = new CognitoUserPool(appContext,
+                    getPackageConfigure().getString("customAuthPoolId"),
+                    getPackageConfigure().getString("customAuthAppClientId"),
+                    getPackageConfigure().getString("customAuthAppClientSecret"), Regions.US_EAST_1);
         } catch (Exception ex) {
             fail("Error in reading CognitoUserPools test configuration. Please check " + super.TEST_CONFIGURATION_FILENAME + " file."
                     + ex);
@@ -118,7 +121,7 @@ public abstract class CognitoUserPoolsIntegrationTestBase extends AWSTestBase {
         });
 
         try {
-            signInLatch.await(60, TimeUnit.SECONDS);
+            signInLatch.await(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -146,6 +149,11 @@ public abstract class CognitoUserPoolsIntegrationTestBase extends AWSTestBase {
 
     public CognitoUserPool getUserPool() {
         return cognitoUserPool;
+    }
+
+
+    public CognitoUserPool getCustomAuthUserPool() {
+        return customAuthUserPool;
     }
 
     public CognitoUser getUser() {

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
@@ -2650,7 +2650,8 @@ public class CognitoUser {
             };
         } else {
             final ChallengeContinuation challengeContinuation = new ChallengeContinuation(
-                    cognitoUser, context, usernameInternal, clientId, secretHash, challenge,
+                    cognitoUser, context, usernameInternal, clientId,
+                    CognitoSecretHash.getSecretHash(usernameInternal, clientId, clientSecret), challenge,
                     runInBackground, callback);
             nextTask = new Runnable() {
                 @Override


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-amplify/aws-sdk-android/issues/889

*Description of changes:*
Challenge Response that is passed to cognito with a call to [`respondToAuthChalllenge`](https://github.com/aws-amplify/aws-sdk-android/blob/ada672f3d2dc432d7979c33e5afd4fdfbb2be9ba/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/AmazonCognitoIdentityProviderClient.java#L4835) needs username and a secretHash if client secret was generated for the App client. There are two different usernames that are being used in the SDK. There is an external username or one that is supplied by the user. There is an internal username which corresponds to the external username. SecretHash must be computed using the username that is passed to the challenge response. In other words, username and secret hash must correspond. For the custom auth flow, username being passed was internal username(aka UserSub) whereas the secretHash was computed using the external username provided by the user(the user facing username). This led to failure in hash verification. This PR addresses the inconsistency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
