### PR TITLE
[AWSMobileClient] Fix the object lifecycle of hostedUI

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/Auth.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/Auth.java
@@ -643,7 +643,7 @@ public final class Auth {
      *     web interface is launched on Chrome Custom Tabs. The user credentials will be required to
      *     authenticate.
      *     <b>Note</b>: This SDK uses OAuth Code-Grant flow with PKCE, for authentication. To get
-     *     tokens after successful user authentication, the Amazom Cognito Auth returns the
+     *     tokens after successful user authentication, the Amazon Cognito Auth returns the
      *     authentication code through the redirect uri. Call {@link Auth#getTokens(Uri)} to
      *     get tokens from the authentication code. <i>Uri</i> is the redirect uri with the
      *     authentication code.

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientNetworkIssueTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientNetworkIssueTest.java
@@ -166,7 +166,7 @@ public class AWSMobileClientNetworkIssueTest extends AWSMobileClientTestBase {
         awsKeyValueStore.put(AWSMobileClient.PROVIDER_KEY, AWSMobileClient.getInstance().getLoginKey());
         awsKeyValueStore.put(AWSMobileClient.TOKEN_KEY, getValidJWT(-3600L));
         awsKeyValueStore.put(AWSMobileClient.IDENTITY_ID_KEY, "");
-        writeUserpoolsTokens(appContext, auth.getConfiguration().optJsonObject("CognitoUserPool").getString("AppClientId"), username, -3600L);
+        writeUserPoolsTokens(appContext, auth.getConfiguration().optJsonObject("CognitoUserPool").getString("AppClientId"), username, -3600L);
         setField(auth.userpool, CognitoUserPool.class, "client", mockLowLevel);
         try {
             auth.getUserAttributes();
@@ -185,7 +185,7 @@ public class AWSMobileClientNetworkIssueTest extends AWSMobileClientTestBase {
         awsKeyValueStore.put(AWSMobileClient.PROVIDER_KEY, AWSMobileClient.getInstance().getLoginKey());
         awsKeyValueStore.put(AWSMobileClient.TOKEN_KEY, getValidJWT(-3600L));
         awsKeyValueStore.put(AWSMobileClient.IDENTITY_ID_KEY, "");
-        writeUserpoolsTokens(appContext, auth.getConfiguration().optJsonObject("CognitoUserPool").getString("AppClientId"), username, -3600L);
+        writeUserPoolsTokens(appContext, auth.getConfiguration().optJsonObject("CognitoUserPool").getString("AppClientId"), username, -3600L);
         Field f1 = CognitoUserPool.class.getDeclaredField("client");
         f1.setAccessible(true);
         f1.set(auth.userpool, mockLowLevel);

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTest.java
@@ -387,7 +387,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
     public void testSignInWaitOIDC() throws Exception {
         final AtomicReference<Boolean> hasWaited = new AtomicReference<Boolean>();
         hasWaited.set(false);
-       // writeUserpoolsTokens(appContext, auth.getConfiguration().optJsonObject("CognitoUserPool").getString("AppClientId"), USERNAME, 3600L);
+       // writeUserPoolsTokens(appContext, auth.getConfiguration().optJsonObject("CognitoUserPool").getString("AppClientId"), USERNAME, 3600L);
         setTokensDirectly(appContext, AWSMobileClient.getInstance().getLoginKey(), "fakeToken", "someIdentityId");
         listener = new UserStateListener() {
             @Override
@@ -463,8 +463,8 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
         }
     }
 
-    // Changing a password tends to have a rate limit that exceeds test timeout
-//    @Test
+    @Ignore("Changing a password tends to have a rate limit that exceeds test timeout")
+    @Test
     public void testChangePassword() throws Exception {
         Thread.sleep(THROTTLED_DELAY);
         auth.changePassword(PASSWORD, NEW_PASSWORD);
@@ -724,7 +724,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
 
         auth.signOut();
 
-        writeUserpoolsTokens(appContext, clientId, username, accessTokenA, idTokenA, refreshTokenA);
+        writeUserPoolsTokens(appContext, clientId, username, accessTokenA, idTokenA, refreshTokenA);
         auth.mStore.set(AWSMobileClient.PROVIDER_KEY, auth.userpoolsLoginKey);
         auth.mStore.set(AWSMobileClient.TOKEN_KEY, accessTokenA);
 
@@ -732,7 +732,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
 
         auth.signOut(SignOutOptions.builder().signOutGlobally(true).build());
 
-        writeUserpoolsTokens(appContext, clientId, username, accessTokenA, idTokenA, refreshTokenA);
+        writeUserPoolsTokens(appContext, clientId, username, accessTokenA, idTokenA, refreshTokenA);
         auth.mStore.set(AWSMobileClient.PROVIDER_KEY, auth.userpoolsLoginKey);
         auth.mStore.set(AWSMobileClient.TOKEN_KEY, accessTokenA);
 

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTestBase.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTestBase.java
@@ -48,7 +48,7 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
         awsKeyValueStore.put(AWSMobileClient.IDENTITY_ID_KEY, identityId);
     }
 
-    public static void writeUserpoolsTokens(final Context appContext, final String clientId, final String username, final long expiryFromNow) {
+    public static void writeUserPoolsTokens(final Context appContext, final String clientId, final String username, final long expiryFromNow) {
         // Store tokens in shared preferences
         final AWSKeyValueStore awsKeyValueStore = new AWSKeyValueStore(appContext,
                 "CognitoIdentityProviderCache",
@@ -60,7 +60,7 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
         awsKeyValueStore.put(storeFieldPrefix + "refreshToken", "DummyRefresh");
     }
 
-    public static void writeUserpoolsTokens(final Context appContext,
+    public static void writeUserPoolsTokens(final Context appContext,
                                             final String clientId,
                                             final String userId,
                                             final String accessToken,
@@ -99,7 +99,7 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
         return accessToken_p1_Base64 + "." + accessToken_p2_Base64 + "." + accessToken_p3_Base64;
     }
 
-    protected void verifyTokens(Tokens tokens) {
+    void verifyTokens(Tokens tokens) {
         assertNotNull(tokens);
         Token accessToken = tokens.getAccessToken();
         assertNotNull(accessToken);
@@ -111,7 +111,7 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
         assertNotNull(refreshToken);
     }
 
-    protected void initializeAWSMobileClient(final Context appContext,
+    AWSMobileClient initializeAWSMobileClient(final Context appContext,
                                              final UserState userState) {
         // Expect the UserState to be SIGNED_OUT
         final CountDownLatch waitForAWSMobileClientToBeInitialized = new CountDownLatch(1);
@@ -135,5 +135,7 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
         } catch (Exception ex) {
             ex.printStackTrace();
         }
+
+        return AWSMobileClient.getInstance();
     }
 }

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1627,6 +1627,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     }
 
     private void _getHostedUITokens(final Callback<Tokens> callback) {
+        hostedUI = hostedUI.getCurrentUser();
         hostedUI.setAuthHandler(new AuthHandler() {
             @Override
             public void onSuccess(AuthUserSession session) {

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -258,8 +258,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     AWSMobileClientCognitoIdentityProvider provider;
     DeviceOperations mDeviceOperations;
     AmazonCognitoIdentityProvider userpoolLL;
-    private Auth hostedUIJSONConfigured;
-    private Auth hostedUI;
+    Auth hostedUI;
     OAuth2Client mOAuth2Client;
     String mUserPoolPoolId;
 
@@ -608,7 +607,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
             throw new IllegalStateException("User pool Id must be available through user pool setting");
         }
 
-        hostedUIJSONConfigured = getHostedUI(hostedUIJSON)
+        hostedUI = getHostedUI(hostedUIJSON)
                 .setPersistenceEnabled(mIsPersistenceEnabled)
                 .setAuthHandler(new AuthHandler() {
                     @Override
@@ -955,7 +954,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         final Map<String, String> details = getSignInDetailsMap();
         final String providerKey = details.get(PROVIDER_KEY);
         final String token = details.get(TOKEN_KEY);
-        final SignInMode signInMode = getSignInMode();
         final String identityId = _getCachedIdentityId();
 
         final boolean federationEnabled = isFederationEnabled();
@@ -1023,7 +1021,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         } else if (hasUsefulToken && userpool != null) {
             Tokens tokens = null;
             String idToken = null;
-            Exception userpoolsException = null;
+            Exception userPoolsException = null;
             try {
                 tokens = getTokens(false);
                 idToken = tokens.getIdToken().getTokenString();
@@ -1048,14 +1046,14 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
             } catch (Exception e) {
                 Log.w(TAG, tokens == null ? "Tokens are invalid, please sign-in again." :
                         "Failed to federate the tokens", e);
-                userpoolsException = e;
+                userPoolsException = e;
             } finally {
                 UserState userState = UserState.SIGNED_IN;
-                if (isSignedOutRelatedException(userpoolsException)) {
+                if (isSignedOutRelatedException(userPoolsException)) {
                     userState = UserState.SIGNED_OUT_USER_POOLS_TOKENS_INVALID;
                 }
                 final UserStateDetails userStateDetails = new UserStateDetails(userState, details);
-                userStateDetails.setException(userpoolsException);
+                userStateDetails.setException(userPoolsException);
                 return userStateDetails;
             }
         } else {
@@ -1246,7 +1244,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
             if (mOAuth2Client != null) {
                 mOAuth2Client.signOut();
             }
-            hostedUI = null;
         }
         mStore.set(HOSTED_UI_KEY, hostedUIJSON);
         setUserState(getUserStateDetails(false));


### PR DESCRIPTION
*Issue #, if available:*

#888
#873

*Description of changes:*

The changes include expanding the lifecycle of `hostedUI` object to be created when `initialize` is called and not destroy it when `signOut` is called.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
