### PR TITLE
Fix integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.15.2](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.15.2)
+
+### Bug Fixes
+- **AWS Mobile Client**
+  - Fix issue where MobileClient would return invalid tokens after initialization when using Hosted UI.
+    See [issue #873](https://github.com/aws-amplify/aws-sdk-android/issues/873) and
+    [issue #888](https://github.com/aws-amplify/aws-sdk-android/issues/888)
+
 ## [Release 2.15.1](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.15.1)
 
 ### Bug Fixes

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientPersistenceWithRestartabilityTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientPersistenceWithRestartabilityTest.java
@@ -37,10 +37,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -395,7 +399,7 @@ public class AWSMobileClientPersistenceWithRestartabilityTest extends AWSMobileC
     public void testHostedUIObjectNotNullAfterAppRestarted() {
         auth = initializeAWSMobileClient(appContext, UserState.SIGNED_OUT);
         auth.signOut();
-        mockRestartingApp();
+        mockRestartingApp(UserState.SIGNED_OUT);
         assertNotNull(auth.hostedUI);
     }
 
@@ -403,18 +407,17 @@ public class AWSMobileClientPersistenceWithRestartabilityTest extends AWSMobileC
     public void testHostedUIGetTokens() throws Exception {
         auth = initializeAWSMobileClient(appContext, UserState.SIGNED_OUT);
         mockHostedUISignIn();
-        auth.getTokens();
+        Tokens tokens = auth.getTokens(false);
+        assertNotNull(tokens);
     }
 
     @Test
     public void testHostedUIGetTokensAfterAppRestarted() throws Exception {
         auth = initializeAWSMobileClient(appContext, UserState.SIGNED_OUT);
-
         mockHostedUISignIn();
-        auth.getTokens();
-
-        mockRestartingApp();
-        assertNotNull(auth.getTokens());
+        mockRestartingApp(UserState.SIGNED_IN);
+        Tokens tokens = auth.getTokens(false);
+        assertNotNull(tokens);
     }
 
     private void signInAndVerifySignIn() {
@@ -470,34 +473,42 @@ public class AWSMobileClientPersistenceWithRestartabilityTest extends AWSMobileC
         }
     }
 
+    // Note that most tests create valid JWT tokens with expiry dates in the past. However, because
+    // we want to assert that HostedUI can get tokens, without making a network call to refresh a
+    // session, we're going to mock up valid session data, and ensure we call `getTokens` with
+    // `waitForSignIn = false`.
     private void mockHostedUISignIn() throws JSONException {
         AuthUserSession authUserSession = new AuthUserSession(
-                new IdToken(getValidJWT(-3600L)),
-                new AccessToken(getValidJWT(-3600L)),
-                new RefreshToken(getValidJWT(-360000L)));
+                new IdToken(getValidJWT(3600L)),
+                new AccessToken(getValidJWT(3600L)),
+                new RefreshToken(getValidJWT(360000L)));
+
+        Context targetContext = InstrumentationRegistry.getTargetContext();
 
         AWSKeyValueStore storeForHostedUI = new AWSKeyValueStore(
-                InstrumentationRegistry.getTargetContext(),
+                targetContext,
                 "CognitoIdentityProviderCache",
                 true);
 
+        final Set<String> scopes = new HashSet<String>(Arrays.asList("profile", "openid", "email"));
+
         LocalDataManager.cacheSession(storeForHostedUI,
-                InstrumentationRegistry.getTargetContext(),
+                targetContext,
                 getPackageConfigure("cognitoauth").getString("AppClientId"),
                 getPackageConfigure("cognitoauth").getString("Username"),
                 authUserSession,
-                null);
+                scopes);
 
         // Set the AWSMobileClient metadata that is specific to HostedUI
         auth.mStore.set(FEDERATION_ENABLED_KEY, "true");
         auth.mStore.set(HOSTED_UI_KEY, "dummyJson");
         auth.mStore.set(SIGN_IN_MODE, SignInMode.HOSTED_UI.toString());
         auth.mStore.set(PROVIDER_KEY, auth.getLoginKey());
-        auth.mStore.set(TOKEN_KEY, getValidJWT(-3600L));
+        auth.mStore.set(TOKEN_KEY, getValidJWT(3600L));
     }
 
-    private void mockRestartingApp() {
+    private void mockRestartingApp(UserState expectedUserState) {
         auth = null;
-        auth = initializeAWSMobileClient(appContext, UserState.SIGNED_OUT);
+        auth = initializeAWSMobileClient(appContext, expectedUserState);
     }
 }


### PR DESCRIPTION
- Reworked HostedUI mocking to set a valid local session, so that we can assert
  for the existence of tokens without actually attempting to validate the
  session over the network.
- Also restored overridden fields on AWSMobileClient singleton, since we can't
  guarantee the order of test invocation and don't know that other tests will
  properly reinitialize mobile client and all its fields.
- Updated CHANGELOG

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
