### PR TITLE
Added exception handler for getCurrentUser in CognitoUserPool

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
@@ -484,11 +484,15 @@ public class CognitoUserPool {
         final String csiLastUserKey = "CognitoIdentityProvider." + clientId + ".LastAuthUser";
 
         if (awsKeyValueStore.contains(csiLastUserKey)) {
-            return getUser(awsKeyValueStore.get(csiLastUserKey));
-        } else {
-            return getUser();
+            try {
+                return getUser(awsKeyValueStore.get(csiLastUserKey));
+            } catch (Exception e) {
+                //  Exception like javax.crypto.AEADBadTagException
+            }
         }
+        return getUser();
     }
+
 
     /**
      * Returns a {@link CognitoUser} with no username set.


### PR DESCRIPTION
*Description of changes:* Added exception handler for CognitoUserPool when getting current user and  javax.crypto.AEADBadTagException or other crash occurs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.