### PR TITLE
Verify also if clientSecret isn't an empty string avoid UnsupportedOperationException

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java
@@ -2921,7 +2921,7 @@ public class CognitoUser {
          * the secret hash is not passed in.
          */
         Map<String, String> authenticationParameters = authenticationDetails.getAuthenticationParameters();
-        if (clientSecret != null &&
+        if (clientSecret != null && !clientSecret.isEmpty() &&
             authenticationParameters.get(CognitoServiceConstants.AUTH_PARAM_SECRET_HASH) == null) {
             secretHash = CognitoSecretHash.getSecretHash(authenticationDetails.getUserId(), clientId, clientSecret);
             authenticationParameters.put(CognitoServiceConstants.AUTH_PARAM_SECRET_HASH, secretHash);


### PR DESCRIPTION
I'm trying to create CognitoUserPool using the awsconfiguration.json file passing the instance of AWSConfiguration instead of creating CognitoUserPool passing all ids on the constructor.

With this constructor 
`/**
     * Constructs a user-pool with default {@link ClientConfiguration}.
     *
     * @param context               REQUIRED: Android application context.
     * @param awsConfiguration      REQUIRED: Holds the configuration read from awsconfiguration.json
     */
    public CognitoUserPool(Context context, AWSConfiguration awsConfiguration) `

Our pool doesn't have the AppClientSecret so we don't pass it on the awsconfiguration file, but this constructor will try to read the property and add an empty string case it not found the property.

`this.clientSecret = userPoolConfiguration.optString("AppClientSecret");`

Then when we go to the initiateCustomAuthRequest it throws an exception when try to add a null or empty secret hash

*Issue #, if available:*

*Description of changes:*

Verify also if the string is not empty

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
