### PR TITLE
[TransferUtility] Added integration test for uploading in unreliable network

### DIFF
--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/SocketTimeoutIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/SocketTimeoutIntegrationTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.amazonaws.mobileconnectors.s3.transferutility;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3IntegrationTestBase;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.SocketTimeoutException;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Mock S3 client that throws SocketTimeoutException
+ * to trigger an upload failure
+ */
+class SocketTimeoutMockS3Client extends AmazonS3Client {
+    private boolean transferEnabled;
+
+    public SocketTimeoutMockS3Client(AWSCredentials credentials, Region region) {
+        super(credentials, region);
+        transferEnabled = false;
+    }
+
+    public void setTransferEnabled(boolean enable) {
+        transferEnabled = enable;
+    }
+
+    @Override
+    public PutObjectResult putObject(PutObjectRequest putObjectRequest)
+            throws AmazonClientException, AmazonServiceException {
+        if (transferEnabled) {
+            return super.putObject(putObjectRequest);
+        } else {
+            throw new AmazonClientException(new SocketTimeoutException());
+        }
+    }
+
+    @Override
+    public UploadPartResult uploadPart(UploadPartRequest uploadPartRequest)
+            throws AmazonClientException, AmazonServiceException {
+        if (transferEnabled) {
+            return super.uploadPart(uploadPartRequest);
+        } else {
+            throw new AmazonClientException(new SocketTimeoutException());
+        }
+    }
+}
+
+public class SocketTimeoutIntegrationTest extends S3IntegrationTestBase {
+    /** The bucket created and used by these tests */
+    private static final String bucketName = "amazon-transfer-util-integ-test-" + new Date().getTime();
+
+    /** Instrumentation test context */
+    private static Context context = InstrumentationRegistry.getContext();
+
+    /** Mock S3 client to artificially throw socket timeout exception */
+    private static SocketTimeoutMockS3Client mockS3;
+
+    /** The transfer utility used to upload to S3 */
+    private static TransferUtility util;
+
+    /** Countdown latch for testing */
+    private static CountDownLatch latch;
+
+    /** The file containing the test data uploaded to S3 */
+    private static File file = null;
+
+    /**
+     * Creates and initializes all the test resources needed for these tests.
+     */
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUp();
+        mockS3 = new SocketTimeoutMockS3Client(credentials,
+                Region.getRegion(Regions.US_WEST_1));
+        util = TransferUtility.builder()
+                .context(context)
+                .s3Client(mockS3)
+                .build();
+
+        try {
+            s3.createBucket(bucketName);
+            waitForBucketCreation(bucketName);
+        } catch (final Exception e) {
+            System.out.println("Error in creating the bucket. "
+                    + "Please manually create the bucket " + bucketName);
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        try {
+            deleteBucketAndAllContents(bucketName);
+        } catch (final Exception e) {
+            System.out.println("Error in deleting the bucket. "
+                    + "Please manually delete the bucket " + bucketName);
+            e.printStackTrace();
+        }
+
+        if (file != null) {
+            file.delete();
+        }
+    }
+
+    @Test
+    public void testSinglePartUploadTimeout() throws Exception {
+        TransferObserver observer;
+
+        // Small (1KB) file upload
+        file = getRandomTempFile("small", 1000L);
+
+        // First attempt at uploading should throw socket timeout exception error
+        latch = new CountDownLatch(1);
+        mockS3.setTransferEnabled(false);
+        observer = util.upload(bucketName, file.getName(), file);
+        observer.setTransferListener(new TransferListener() {
+            @Override
+            public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {
+            }
+
+            @Override
+            public void onStateChanged(int id, TransferState state) {
+                if (state.equals(TransferState.FAILED)) { latch.countDown(); }
+            }
+
+            @Override
+            public void onError(int id, Exception ex) {
+            }
+        });
+        latch.await(300, TimeUnit.SECONDS);
+        assertEquals(TransferState.FAILED, observer.getState());
+
+        // Attempt to resume should complete upload as intended
+        latch = new CountDownLatch(1);
+        mockS3.setTransferEnabled(true);
+        observer = util.resume(observer.getId());
+        observer.setTransferListener(new TransferListener() {
+            @Override
+            public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {
+            }
+
+            @Override
+            public void onStateChanged(int id, TransferState state) {
+                if (state.equals(TransferState.COMPLETED)) { latch.countDown(); }
+            }
+
+            @Override
+            public void onError(int id, Exception ex) {
+                fail(ex.getMessage());
+            }
+        });
+        latch.await(300, TimeUnit.SECONDS);
+        assertEquals(TransferState.COMPLETED, observer.getState());
+    }
+
+    @Test
+    public void testMultiPartUploadTimeout() throws Exception {
+        TransferObserver observer;
+
+        // Large (5MB) file upload
+        long size = 20 * 1024 * 1024 + 1;
+        file = getRandomSparseFile("large", size);
+
+        // First attempt at uploading should throw socket timeout exception error
+        latch = new CountDownLatch(1);
+        mockS3.setTransferEnabled(false);
+        observer = util.upload(bucketName, file.getName(), file);
+        observer.setTransferListener(new TransferListener() {
+            @Override
+            public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {
+            }
+
+            @Override
+            public void onStateChanged(int id, TransferState state) {
+                if (state.equals(TransferState.FAILED)) { latch.countDown(); }
+            }
+
+            @Override
+            public void onError(int id, Exception ex) {
+            }
+        });
+        latch.await(300, TimeUnit.SECONDS);
+        assertEquals(TransferState.FAILED, observer.getState());
+
+        // Attempt to resume should complete upload as intended
+        latch = new CountDownLatch(1);
+        mockS3.setTransferEnabled(true);
+        observer = util.resume(observer.getId());
+        observer.setTransferListener(new TransferListener() {
+            @Override
+            public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {
+            }
+
+            @Override
+            public void onStateChanged(int id, TransferState state) {
+                if (state.equals(TransferState.COMPLETED)) { latch.countDown(); }
+            }
+
+            @Override
+            public void onError(int id, Exception ex) {
+                fail(ex.getMessage());
+            }
+        });
+        latch.await(300, TimeUnit.SECONDS);
+        assertEquals(TransferState.COMPLETED, observer.getState());
+    }
+}
+

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/TaggingIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/TaggingIntegrationTest.java
@@ -13,15 +13,12 @@
  * limitations under the License.
  */
 
-package com.amazonaws.services.s3;
+package com.amazonaws.mobileconnectors.s3.transferutility;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 
-import com.amazonaws.mobileconnectors.s3.transferutility.TransferListener;
-import com.amazonaws.mobileconnectors.s3.transferutility.TransferNetworkLossHandler;
-import com.amazonaws.mobileconnectors.s3.transferutility.TransferState;
-import com.amazonaws.mobileconnectors.s3.transferutility.TransferUtility;
+import com.amazonaws.services.s3.S3IntegrationTestBase;
 import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.Tag;
@@ -31,7 +28,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.RandomAccessFile;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -42,7 +38,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public class TransferUtilityIntegrationTest extends S3IntegrationTestBase {
+public class TaggingIntegrationTest extends S3IntegrationTestBase {
 
     /** The bucket created and used by these tests */
     private static final String bucketName = "amazon-transfer-util-integ-test-" + new Date().getTime();
@@ -83,7 +79,6 @@ public class TransferUtilityIntegrationTest extends S3IntegrationTestBase {
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         setUp();
-        TransferNetworkLossHandler.getInstance(context);
         util = TransferUtility.builder()
                 .context(context)
                 .s3Client(s3)
@@ -114,7 +109,7 @@ public class TransferUtilityIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void testSingleUploadTagging() throws Exception {
+    public void testSinglePartUploadTagging() throws Exception {
         // Object metadata to add
         metadata = new ObjectMetadata();
         metadata.addUserMetadata("x-amz-tagging", "key1=value1&key2=value2");
@@ -139,7 +134,7 @@ public class TransferUtilityIntegrationTest extends S3IntegrationTestBase {
     }
 
     @Test
-    public void testMultiUploadTagging() throws Exception {
+    public void testMultiPartUploadTagging() throws Exception {
         // Object metadata to add
         metadata = new ObjectMetadata();
         metadata.addUserMetadata("x-amz-tagging", "key1=value1&key2=value2");
@@ -162,18 +157,5 @@ public class TransferUtilityIntegrationTest extends S3IntegrationTestBase {
                 new Tag("key1", "value1"),
                 new Tag("key2", "value2")
         ));
-    }
-
-    /*
-     * Helper method to create a sparse file (Faster than writing a file with random bytes with getRandomTempFile)
-     * Use for testing large uploads
-     */
-    private File getRandomSparseFile(String filename, long contentLength) throws Exception {
-        // Use the same storage path as getRandomTempFile()
-        String pathPrefix = System.getProperty("java.io.tmpdir") + File.separator + System.currentTimeMillis() + "-";
-        File tempFile = new File(pathPrefix + filename);
-        RandomAccessFile raf = new RandomAccessFile(tempFile, "rw"); // Create a new random access file with read/write access
-        raf.setLength(contentLength);
-        return tempFile;
     }
 }

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3IntegrationTestBase.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3IntegrationTestBase.java
@@ -47,6 +47,7 @@ import com.amazonaws.testutils.util.RandomTempFile;
 import org.junit.BeforeClass;
 
 import java.io.File;
+import java.io.RandomAccessFile;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
@@ -98,6 +99,17 @@ public abstract class S3IntegrationTestBase extends AWSTestBase {
         else {
             return new RandomTempFile(androidRootDir, filename, contentLength);
         }
+    }
+
+    /*
+     * Helper method to create a sparse file (Faster than writing a file with random bytes with getRandomTempFile)
+     * Use for testing large uploads
+     */
+    protected static File getRandomSparseFile(String filename, long contentLength) throws Exception {
+        File tempFile = getRandomTempFile(filename, 0);
+        RandomAccessFile raf = new RandomAccessFile(tempFile, "rw"); // Create a new random access file with read/write access
+        raf.setLength(contentLength);
+        return tempFile;
     }
 
     /**
@@ -321,7 +333,7 @@ public abstract class S3IntegrationTestBase extends AWSTestBase {
      * waiting a specific bucket created When exceed the poll time, will throw
      * Max poll time exceeded exception
      */
-    static void waitForBucketCreation(String bucketName) throws Exception {
+    protected static void waitForBucketCreation(String bucketName) throws Exception {
         final long startTime = System.currentTimeMillis();
         final long endTime = startTime + (30 * 60 * 1000);
         int hits = 0;


### PR DESCRIPTION
*Issue #, if available:*
[1006](https://github.com/aws-amplify/aws-sdk-android/issues/1006)

*Description of changes:*
Not a fix to issue, but an integration test to reproduce this issue for documentation.

This issue stems from how TransferUtility only sets transfer state to WAITING_FOR_NETWORK if and only if android lost network connection. For any other network-related interruption (such as weak signal or slow connection), state is set to FAILED and will not resume on its own. This integration test reproduces such situation both to verify the expected behavior and to confirm that failed transfers can still be resumed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
