### PR TITLE
[delivers #167300863] Update paho version for iot sdk to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### New Features
 
+- **AWS IoT**
+  - AWS IoT now depends on the paho version 1.2.2
+
+## [Release 2.16.0](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.0)
+
+### New Features
+
 - **AWS Mobile Client**
   - **Breaking API Change**
     - `SignUpResult` available in the user callback provided during sign up now contains UserSub(UID)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - AWS SDK for Android
 
-## [Release 2.16.0](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.0)
+## [Release 2.16.1](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.1)
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [Release 2.16.1](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.1)
 
-### New Features
+### Misc. Updates
 
 - **AWS IoT**
-  - AWS IoT now depends on the paho version 1.2.2
+  - AWS Android SDK for IoT now depends on the 1.2.2 version of the Paho Library org.eclipse.paho.client.mqttv3
 
 ## [Release 2.16.0](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.0)
 

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     api (project(":aws-android-sdk-core")){
         exclude group: "com.google.android", module: "android"
     }
-    implementation "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.1.0"
+    implementation "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.2"
     implementation "org.conscrypt:conscrypt-android:2.0.0"
 
     testImplementation "junit:junit:4.12"

--- a/aws-android-sdk-iot/pom.xml
+++ b/aws-android-sdk-iot/pom.xml
@@ -24,7 +24,7 @@
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
       <optional>false</optional>
-      <version>1.1.0</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/MockMqttClient.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/MockMqttClient.java
@@ -35,7 +35,7 @@ public class MockMqttClient extends MqttAsyncClient {
     IMqttDeliveryToken testDeliveryToken = new MqttDeliveryToken();
 
     MockMqttClient() throws MqttException {
-        super("local://mockendpoint.example.com", "mock-id");
+        super("wss://mockendpoint.example.com", "mock-id");
         mockSubscriptions = new HashMap<String, Integer>();
         isConnected = false;
         throwsExceptionOnConnect = false;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update underlying paho version for IoT SDK to 1.2.2 to be able to use of the latest features and bug fixes.

Also fixes following security alert in the repo
<img width="1082" alt="Screen Shot 2019-09-24 at 10 49 35 AM" src="https://user-images.githubusercontent.com/4340938/65536891-18ecd100-deb9-11e9-8c7d-7249b140f26a.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
