### PR TITLE
Adds logging levels - addresses issue #1174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.16.3](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.3)
+
+### New Features
+
+- **AWS Core**
+  - Now supports calling LogFactory.setLevel(Level) to set a global level of which logs will be output. Any logs below the set level will not be output
+    You can also call Log.setLevel(Level) on a specific Logger to limit the logs which are output by a specific class. Addresses issue #1174
+
 ## [Release 2.16.2](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.2)
 
 ### New Features

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/logging/AndroidLog.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/logging/AndroidLog.java
@@ -26,6 +26,9 @@ public class AndroidLog implements com.amazonaws.logging.Log {
     /** Tag for the log message */
     private final String tag;
 
+    /** If set, only this level and above logs will be output by this logger **/
+    private LogFactory.Level level = null;
+
     /**
      *
      * @param tag The tag that is present in
@@ -37,76 +40,118 @@ public class AndroidLog implements com.amazonaws.logging.Log {
 
     @Override
     public boolean isDebugEnabled() {
-        return Log.isLoggable(tag, Log.DEBUG);
+        return Log.isLoggable(tag, Log.DEBUG) &&
+                (getLevel() == null || getLevel().getValue() <= LogFactory.Level.DEBUG.getValue());
     }
 
     @Override
     public boolean isErrorEnabled() {
-        return Log.isLoggable(tag, Log.ERROR);
+        return Log.isLoggable(tag, Log.ERROR) &&
+                (getLevel() == null || getLevel().getValue() <= LogFactory.Level.ERROR.getValue());
     }
 
     @Override
     public boolean isInfoEnabled() {
-        return Log.isLoggable(tag, Log.INFO);
+        return Log.isLoggable(tag, Log.INFO) &&
+                (getLevel() == null || getLevel().getValue() <= LogFactory.Level.INFO.getValue());
     }
 
     @Override
     public boolean isTraceEnabled() {
-        return Log.isLoggable(tag, Log.VERBOSE);
+        return Log.isLoggable(tag, Log.VERBOSE) &&
+                (getLevel() == null || getLevel().getValue() <= LogFactory.Level.TRACE.getValue());
     }
 
     @Override
     public boolean isWarnEnabled() {
-        return Log.isLoggable(tag, Log.WARN);
+        return Log.isLoggable(tag, Log.WARN) &&
+                (getLevel() == null || getLevel().getValue() <= LogFactory.Level.WARN.getValue());
     }
 
     @Override
     public void trace(Object message) {
-        Log.v(tag, message.toString());
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.TRACE.getValue()) {
+            Log.v(tag, message.toString());
+        }
     }
 
     @Override
     public void trace(Object message, Throwable t) {
-        Log.v(tag, message.toString(), t);
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.TRACE.getValue()) {
+            Log.v(tag, message.toString(), t);
+        }
     }
 
     @Override
     public void debug(Object message) {
-        Log.d(tag, message.toString());
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.DEBUG.getValue()) {
+            Log.d(tag, message.toString());
+        }
     }
 
     @Override
     public void debug(Object message, Throwable t) {
-        Log.d(tag, message.toString(), t);
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.DEBUG.getValue()) {
+            Log.d(tag, message.toString(), t);
+        }
     }
 
     @Override
     public void info(Object message) {
-        Log.i(tag, message.toString());
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.INFO.getValue()) {
+            Log.i(tag, message.toString());
+        }
     }
 
     @Override
     public void info(Object message, Throwable t) {
-        Log.i(tag, message.toString(), t);
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.INFO.getValue()) {
+            Log.i(tag, message.toString(), t);
+        }
     }
 
     @Override
     public void warn(Object message) {
-        Log.w(tag, message.toString());
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.WARN.getValue()) {
+            Log.w(tag, message.toString());
+        }
     }
 
     @Override
     public void warn(Object message, Throwable t) {
-        Log.w(tag, message.toString(), t);
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.WARN.getValue()) {
+            Log.w(tag, message.toString(), t);
+        }
     }
 
     @Override
     public void error(Object message) {
-        Log.e(tag, message.toString());
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.ERROR.getValue()) {
+            Log.e(tag, message.toString());
+        }
     }
 
     @Override
     public void error(Object message, Throwable t) {
-        Log.e(tag, message.toString(), t);
+        if (getLevel() == null || getLevel().getValue() <= LogFactory.Level.ERROR.getValue()) {
+            Log.e(tag, message.toString(), t);
+        }
+    }
+
+    @Override
+    public void setLevel(LogFactory.Level level) {
+        this.level = level;
+    }
+
+    /**
+     * Checks whether a log level has been set either at the local level or, if not, the global one
+     * @return Appropriate log level if one has been set by the user
+     */
+    private LogFactory.Level getLevel() {
+        if (level != null) {
+            return level;
+        } else {
+            return LogFactory.getLevel();
+        }
     }
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/logging/ApacheCommonsLogging.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/logging/ApacheCommonsLogging.java
@@ -17,6 +17,7 @@ package com.amazonaws.logging;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import com.amazonaws.logging.LogFactory.Level;
 
 /**
  * This is a wrapper over the Apache Commons
@@ -27,6 +28,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
     private Class logClass;
     private String logString;
     private Log log;
+
+    /** If set, only this level and above logs will be output by this logger **/
+    private Level level = null;
 
     /**
      * @param logClass the class object
@@ -55,7 +59,8 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public boolean isDebugEnabled() {
-        return this.log.isDebugEnabled();
+        return this.log.isDebugEnabled() &&
+                (getLevel() == null || getLevel().getValue() <= Level.DEBUG.getValue());
     }
 
     /**
@@ -69,7 +74,8 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public boolean isErrorEnabled() {
-        return this.log.isErrorEnabled();
+        return this.log.isErrorEnabled() &&
+                (getLevel() == null || getLevel().getValue() <= Level.ERROR.getValue());
     }
 
 
@@ -84,7 +90,8 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public boolean isInfoEnabled() {
-        return this.log.isInfoEnabled();
+        return this.log.isInfoEnabled()  &&
+                (getLevel() == null || getLevel().getValue() <= Level.INFO.getValue());
     }
 
     /**
@@ -98,7 +105,8 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public boolean isTraceEnabled() {
-        return this.log.isTraceEnabled();
+        return this.log.isTraceEnabled() &&
+                (getLevel() == null || getLevel().getValue() <= Level.TRACE.getValue());
     }
 
     /**
@@ -112,7 +120,8 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public boolean isWarnEnabled() {
-        return this.log.isWarnEnabled();
+        return this.log.isWarnEnabled()  &&
+                (getLevel() == null || getLevel().getValue() <= Level.WARN.getValue());
     }
 
     /**
@@ -122,7 +131,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void trace(Object message) {
-        this.log.trace(message);
+        if (getLevel() == null || getLevel().getValue() <= Level.TRACE.getValue()) {
+            this.log.trace(message);
+        }
     }
 
     /**
@@ -133,7 +144,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void trace(Object message, Throwable t) {
-        this.log.trace(message, t);
+        if (getLevel() == null || getLevel().getValue() <= Level.TRACE.getValue()) {
+            this.log.trace(message, t);
+        }
     }
 
     /**
@@ -143,7 +156,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void debug(Object message) {
-        this.log.debug(message);
+        if (getLevel() == null || getLevel().getValue() <= Level.DEBUG.getValue()) {
+            this.log.debug(message);
+        }
     }
 
     /**
@@ -154,7 +169,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void debug(Object message, Throwable t) {
-        this.log.debug(message, t);
+        if (getLevel() == null || getLevel().getValue() <= Level.DEBUG.getValue()) {
+            this.log.debug(message, t);
+        }
     }
 
     /**
@@ -164,7 +181,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void info(Object message) {
-        this.log.info(message);
+        if (getLevel() == null || getLevel().getValue() <= Level.INFO.getValue()) {
+            this.log.info(message);
+        }
     }
 
     /**
@@ -175,7 +194,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void info(Object message, Throwable t) {
-        this.log.info(message, t);
+        if (getLevel() == null || getLevel().getValue() <= Level.INFO.getValue()) {
+            this.log.info(message, t);
+        }
     }
 
     /**
@@ -185,7 +206,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void warn(Object message) {
-        this.log.warn(message);
+        if (getLevel() == null || getLevel().getValue() <= Level.WARN.getValue()) {
+            this.log.warn(message);
+        }
     }
 
     /**
@@ -196,7 +219,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void warn(Object message, Throwable t) {
-        this.log.warn(message, t);
+        if (getLevel() == null || getLevel().getValue() <= Level.WARN.getValue()) {
+            this.log.warn(message, t);
+        }
     }
 
     /**
@@ -206,7 +231,9 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void error(Object message) {
-        this.log.error(message);
+        if (getLevel() == null || getLevel().getValue() <= Level.ERROR.getValue()) {
+            this.log.error(message);
+        }
     }
 
     /**
@@ -217,6 +244,30 @@ public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
      */
     @Override
     public void error(Object message, Throwable t) {
-        this.log.error(message, t);
+        if (getLevel() == null || getLevel().getValue() <= Level.ERROR.getValue()) {
+            this.log.error(message, t);
+        }
+    }
+
+    /**
+     * <p> Set the level of logs which will be output for this particular logger. </p>
+     *
+     * @param level Only logs of this level and above will now be output
+     */
+    @Override
+    public void setLevel(Level level) {
+        this.level = level;
+    }
+
+    /**
+     * Checks whether a log level has been set either at the local level or, if not, the global one
+     * @return Appropriate log level if one has been set by the user
+     */
+    private Level getLevel() {
+        if (level != null) {
+            return level;
+        } else {
+            return com.amazonaws.logging.LogFactory.getLevel();
+        }
     }
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/logging/Log.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/logging/Log.java
@@ -211,4 +211,11 @@ public interface Log {
      * @param t log this cause
      */
     public void error(Object message, Throwable t);
+
+    /**
+     * <p> Set the level of logs which will be output for this particular logger. </p>
+     *
+     * @param level Only logs of this level and above will now be output
+     */
+    public void setLevel(LogFactory.Level level);
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/logging/LogFactory.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/logging/LogFactory.java
@@ -30,7 +30,7 @@ public class LogFactory {
      */
     private static final String TAG = LogFactory.class.getSimpleName();
     private static final String APACHE_COMMONS_LOGGING_LOGFACTORY = "org.apache.commons.logging.LogFactory";
-
+    private static Level globalLogLevel = null;
     private static Map<String, Log> logMap = new HashMap<String, Log>();
 
     /**
@@ -70,6 +70,14 @@ public class LogFactory {
         return log;
     }
 
+    public static void setLevel(Level level) {
+        globalLogLevel = level;
+    }
+
+    public static Level getLevel() {
+        return globalLogLevel;
+    }
+
     private static boolean checkApacheCommonsLoggingExists() {
         try {
             Class<?> classObject = Class.forName(APACHE_COMMONS_LOGGING_LOGFACTORY);
@@ -100,5 +108,28 @@ public class LogFactory {
         }
 
         return logTag;
+    }
+
+    public enum Level
+    {
+        ALL(Integer.MIN_VALUE),
+        TRACE(0),
+        DEBUG(1),
+        INFO(2),
+        WARN(3),
+        ERROR(4),
+        OFF(Integer.MAX_VALUE);
+
+        private int value;
+
+        public int getValue()
+        {
+            return this.value;
+        }
+
+        Level(int value)
+        {
+            this.value = value;
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#1174 

*Description of changes:*
Adds the ability to set the level of logs which will be output or turn them off altogether. This can be set on the global level or a per logger (per class) level.

Thoroughly tested in a sample app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
