### PR TITLE
Modifies confirmSignUp to be consistent with iOS fixing tt P29658303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   - Now supports calling LogFactory.setLevel(Level) to set a global level of which logs will be output. Any logs below the set level will not be output
     You can also call Log.setLevel(Level) on a specific Logger to limit the logs which are output by a specific class. Addresses issue #1174
 
+### Bug Fixes
+
+- **AWSMobileClient**
+  - Sets default confirmSignup behavior to prevent a user from signing up with the same email/phone as another user. This is the same as iOS.
+    NOTE: When you upgrade to this version, your app behavior will change from allowing users to sign up with the same email/phone as another user
+    (and just overriding the existing user) to giving the user an error if they attempt to do that.
+
 ## [Release 2.16.2](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.2)
 
 ### New Features

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1904,7 +1904,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         return new Runnable() {
             @Override
             public void run() {
-                userpool.getUser(username).confirmSignUp(signUpChallengeResponse, true, new GenericHandler() {
+                userpool.getUser(username).confirmSignUp(signUpChallengeResponse, false, new GenericHandler() {
                     @Override
                     public void onSuccess() {
                         callback.onResult(new SignUpResult(


### PR DESCRIPTION
*Issue #, if available:*
Internal request

*Description of changes:*
Currently the android SDK has inconsistent behavior with iOS in allowing new users to have the same email/phone as an existing user (and just overriding that existing user with the new login credentials).

This changes that to be consistent with iOS and disallow registering with the same email/phone as an existing user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
