### PR TITLE
Update javadoc to warn against using BasicAWSCredentials

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/BasicAWSCredentials.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/BasicAWSCredentials.java
@@ -18,6 +18,10 @@ package com.amazonaws.auth;
 /**
  * Basic implementation of the AWSCredentials interface that allows callers to
  * pass in the AWS access key and secret access in the constructor.
+ *
+ * It is not recommended to use this class. Instead, use short term credentials
+ * from Cognito with the AWSMobileClient.
+ * @see <a href="https://aws-amplify.github.io/aws-sdk-android/docs/reference/com/amazonaws/mobile/client/AWSMobileClient.html">AWSMobileClient</a>
  */
 public class BasicAWSCredentials implements AWSCredentials {
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Update javadoc with a link to [AWSMobileClient](https://aws-amplify.github.io/aws-sdk-android/docs/reference/com/amazonaws/mobile/client/AWSMobileClient.html) as recommended alternative to using `BasicAWSCredentials`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
