### PR TITLE
Add support to Custom Challenge without password check.

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1182,7 +1182,11 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                             try {
                                 if (awsConfiguration.optJsonObject("Auth") != null && awsConfiguration.optJsonObject("Auth").has("authenticationFlowType") && awsConfiguration.optJsonObject("Auth").getString("authenticationFlowType").equals("CUSTOM_AUTH")) {
                                     final HashMap<String, String> authParameters = new HashMap<String,String>();
-                                    authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, authParameters, validationData));
+                                    if (password == null) {
+                                        authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, authParameters, validationData));
+                                    } else {
+                                        authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, authParameters, validationData));
+                                    }
                                 } else {
                                     authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, validationData));
                                 }

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1122,6 +1122,21 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         return internalCallback.await(_signIn(username, password, validationData, internalCallback));
     }
 
+    @AnyThread
+    public void signIn(final String username,
+                       final Map<String, String> validationData,
+                       final Callback<SignInResult> callback) {
+
+        signIn(username, null, validationData, callback);
+    }
+
+    @WorkerThread
+    public SignInResult signIn(final String username,
+                               final Map<String, String> validationData) throws Exception {
+
+        return signIn(username, null, validationData);
+    }
+
     private Runnable _signIn(final String username,
                              final String password,
                              final Map<String, String> validationData,


### PR DESCRIPTION
The suggestion change here solve the problem with the issue https://github.com/aws-amplify/aws-sdk-android/issues/1306 

If we create an instance from `AuthenticationDetails` using the constructor with password it going to send a request where the challengeName is `SRP_A` the server is waiting for a request where this name is `CUSTOM_CHALLENGE` that is exactly what happens when we create an instance using the constructor bellow: 

```
    /**
     * Constructs a new object for custom authentication.
     *
     * @param userId REQUIRED: User ID, NOTE: This will over ride the current
     *            Used ID.
     * @param authenticationParameters REQUIRED: Authentication details to
     *            launch custom authentication process.
     * @param validationData REQUIRED: Contains authentication parameters 
     *            which are passed to triggered pre-auth lambda. trigger 
     */
    public AuthenticationDetails(String userId, Map<String, String> authenticationParameters,
            Map<String, String> validationData)
```
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
