### PR TITLE
Update confirmSignIn api to accept client meta data 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.16.6](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.6)
+
+### New Features
+
+- **AWSMobileClient**
+  - `confirmSignIn()` now supports passing clientMetaData, map of custom key-value pairs that developers can provide as an input for any custom workflow lambda triggers.
+
 ## [Release 2.16.5](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.5)
 
 ### New Features

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/ChallengeContinuation.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/ChallengeContinuation.java
@@ -26,6 +26,7 @@ import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoServic
 import com.amazonaws.services.cognitoidentityprovider.model.RespondToAuthChallengeRequest;
 import com.amazonaws.services.cognitoidentityprovider.model.RespondToAuthChallengeResult;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -104,7 +105,7 @@ public class ChallengeContinuation implements CognitoIdentityProviderContinuatio
      * @param clientMetaData MetaData to be passed as input to the lambda triggers.
      */
     public void setClientMetaData(Map<String, String> clientMetaData) {
-        this.clientMetaData = clientMetaData;
+        this.clientMetaData = Collections.unmodifiableMap(clientMetaData);
     }
 
     /**

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/ChallengeContinuation.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/ChallengeContinuation.java
@@ -88,10 +88,21 @@ public class ChallengeContinuation implements CognitoIdentityProviderContinuatio
         challengeResponses = new HashMap<String, String>();
     }
 
+    /**
+     * <p>
+     * <code>clientMetadata</code> is a map of custom key-value pairs that you can provide as input for any
+     * custom work flows. Accessor method for <code>clientMetadata</code>.
+     * </p>
+     * @return ClientMetadata
+     */
     public Map<String, String> getClientMetaData() {
         return clientMetaData;
     }
 
+    /**
+     * Mutator for <code>clientMetadata</code>.
+     * @param clientMetaData MetaData to be passed as input to the lambda triggers.
+     */
     public void setClientMetaData(Map<String, String> clientMetaData) {
         this.clientMetaData = clientMetaData;
     }

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/ChallengeContinuation.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/ChallengeContinuation.java
@@ -52,8 +52,9 @@ public class ChallengeContinuation implements CognitoIdentityProviderContinuatio
     private final CognitoUser user;
     private final String username;
     private final AuthenticationHandler callback;
-    protected Map<String, String> challengeResponses;
     private final boolean runInBackground;
+    protected Map<String, String> challengeResponses;
+    protected Map<String, String> clientMetaData;
 
     /**
      * Constructs a continuation for a challenge to be presented to the user.
@@ -85,6 +86,14 @@ public class ChallengeContinuation implements CognitoIdentityProviderContinuatio
         this.callback = callback;
         this.runInBackground = runInBackground;
         challengeResponses = new HashMap<String, String>();
+    }
+
+    public Map<String, String> getClientMetaData() {
+        return clientMetaData;
+    }
+
+    public void setClientMetaData(Map<String, String> clientMetaData) {
+        this.clientMetaData = clientMetaData;
     }
 
     /**
@@ -140,6 +149,9 @@ public class ChallengeContinuation implements CognitoIdentityProviderContinuatio
         respondToAuthChallengeRequest.setSession(challengeResult.getSession());
         respondToAuthChallengeRequest.setClientId(clientId);
         respondToAuthChallengeRequest.setChallengeResponses(challengeResponses);
+        if (clientMetaData != null) {
+            respondToAuthChallengeRequest.setClientMetadata(clientMetaData);
+        }
         if (runInBackground) {
             new Thread(new Runnable() {
                 @Override

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientCustomAuthTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientCustomAuthTest.java
@@ -217,7 +217,7 @@ public class AWSMobileClientCustomAuthTest extends AWSMobileClientTestBase {
         final Map<String, String> clientMetaData = new HashMap<String, String>();
         clientMetaData.put("challengeResponseAnswer", "1134");
         res.put(CognitoServiceConstants.CHLG_RESP_ANSWER, "1134");
-        auth.confirmSignIn(res, new Callback<SignInResult>() {
+        auth.confirmSignIn(res, clientMetaData, new Callback<SignInResult>() {
             @Override
             public void onResult(final SignInResult signInResult) {
                 runOnUiThread(new Runnable() {
@@ -239,7 +239,7 @@ public class AWSMobileClientCustomAuthTest extends AWSMobileClientTestBase {
                 Log.e(TAG, "Confirm sign-in error", e);
                 signUpLatch.countDown();
             }
-        }, clientMetaData);
+        });
 
         try {
             signUpLatch.await(20, TimeUnit.SECONDS);

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientCustomAuthTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientCustomAuthTest.java
@@ -214,7 +214,9 @@ public class AWSMobileClientCustomAuthTest extends AWSMobileClientTestBase {
 
     private void confirmSignIn() {
         final Map<String, String> res = new HashMap<String, String>();
-        res.put(CognitoServiceConstants.CHLG_RESP_ANSWER, "1133");
+        final Map<String, String> clientMetaData = new HashMap<String, String>();
+        clientMetaData.put("challengeResponseAnswer", "1134");
+        res.put(CognitoServiceConstants.CHLG_RESP_ANSWER, "1134");
         auth.confirmSignIn(res, new Callback<SignInResult>() {
             @Override
             public void onResult(final SignInResult signInResult) {
@@ -237,7 +239,7 @@ public class AWSMobileClientCustomAuthTest extends AWSMobileClientTestBase {
                 Log.e(TAG, "Confirm sign-in error", e);
                 signUpLatch.countDown();
             }
-        });
+        }, clientMetaData);
 
         try {
             signUpLatch.await(20, TimeUnit.SECONDS);

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1282,15 +1282,46 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
      * Call with the user's response to the sign-in challenge.
      *
      * @param signInChallengeResponse obtained from user
+     * @param clientMetaData Meta data for lambda triggers
      * @param callback callback
      */
     @AnyThread
     public void confirmSignIn(final Map<String, String> signInChallengeResponse,
-                              final Callback<SignInResult> callback,
-                              final Map<String, String> clientMetaData) {
+                              final Map<String, String> clientMetaData,
+                              final Callback<SignInResult> callback) {
 
         final InternalCallback internalCallback = new InternalCallback<SignInResult>(callback);
         internalCallback.async(_confirmSignIn(signInChallengeResponse, internalCallback, clientMetaData));
+    }
+
+    /**
+     * The counter part to {@link #signIn}.
+     * Call with the user's response to the sign-in challenge.
+     *
+     * @param signInChallengeResponse obtained from user
+     * @param clientMetaData Meta data for lambda triggers
+     * @return the result containing next steps or done.
+     * @throws Exception
+     */
+    @WorkerThread
+    public SignInResult confirmSignIn(final Map<String, String> signInChallengeResponse,
+                                      final Map<String, String> clientMetaData) throws Exception {
+
+        final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>();
+        return internalCallback.await(_confirmSignIn(signInChallengeResponse, internalCallback, clientMetaData));
+    }
+
+    /**
+     * The counter part to {@link #signIn}.
+     * Call with the user's response to the sign-in challenge.
+     *
+     * @param signInChallengeResponse obtained from user
+     * @param callback callback
+     */
+    @AnyThread
+    public void confirmSignIn(final Map<String, String> signInChallengeResponse,
+                              final Callback<SignInResult> callback) {
+        confirmSignIn(signInChallengeResponse, null, callback);
     }
 
     /**
@@ -1302,11 +1333,9 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
      * @throws Exception
      */
     @WorkerThread
-    public SignInResult confirmSignIn(final Map<String, String> signInChallengeResponse,
-                                      final Map<String, String> clientMetaData) throws Exception {
-
+    public SignInResult confirmSignIn(final Map<String, String> signInChallengeResponse) throws Exception {
         final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>();
-        return internalCallback.await(_confirmSignIn(signInChallengeResponse, internalCallback, clientMetaData));
+        return internalCallback.await(_confirmSignIn(signInChallengeResponse, internalCallback, null));
     }
 
     private Runnable _confirmSignIn(final Map<String, String> signInChallengeResponse,

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1286,10 +1286,11 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
      */
     @AnyThread
     public void confirmSignIn(final Map<String, String> signInChallengeResponse,
-                              final Callback<SignInResult> callback) {
+                              final Callback<SignInResult> callback,
+                              final Map<String, String> clientMetaData) {
 
         final InternalCallback internalCallback = new InternalCallback<SignInResult>(callback);
-        internalCallback.async(_confirmSignIn(signInChallengeResponse, internalCallback));
+        internalCallback.async(_confirmSignIn(signInChallengeResponse, internalCallback, clientMetaData));
     }
 
     /**
@@ -1301,14 +1302,16 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
      * @throws Exception
      */
     @WorkerThread
-    public SignInResult confirmSignIn(final Map<String, String> signInChallengeResponse) throws Exception {
+    public SignInResult confirmSignIn(final Map<String, String> signInChallengeResponse,
+                                      final Map<String, String> clientMetaData) throws Exception {
 
         final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>();
-        return internalCallback.await(_confirmSignIn(signInChallengeResponse, internalCallback));
+        return internalCallback.await(_confirmSignIn(signInChallengeResponse, internalCallback, clientMetaData));
     }
 
     private Runnable _confirmSignIn(final Map<String, String> signInChallengeResponse,
-                                    final Callback<SignInResult> callback) {
+                                    final Callback<SignInResult> callback,
+                                    final Map<String, String> clientMetaData) {
 
         return new Runnable() {
             @Override
@@ -1331,6 +1334,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                             signInChallengeContinuation.setChallengeResponse(key, signInChallengeResponse.get(key));
                         }
                         detectedContinuation = signInChallengeContinuation;
+                        signInChallengeContinuation.setClientMetaData(clientMetaData);
                         signInCallback = new InternalCallback<SignInResult>(callback);
                         break;
                     case DONE:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enables users to pass client meta data information that is passed to the custom auth lambda triggers via the RespondToAuthChallenge API

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
