### PR TITLE
Remove Robolectric dependency from S3 integration tests

### DIFF
--- a/aws-android-sdk-s3-test/build.gradle
+++ b/aws-android-sdk-s3-test/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation project(":aws-android-sdk-testutils")
     androidTestImplementation 'org.apache.commons:commons-io:1.3.2'
-    androidTestImplementation 'org.robolectric:robolectric:3.8'
 }
 
 devicefarm {

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/AmazonS3ClientIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/AmazonS3ClientIntegrationTest.java
@@ -36,10 +36,8 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.Tag;
-import com.amazonaws.util.Base64;
 import com.amazonaws.util.IOUtils;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;


### PR DESCRIPTION
Robolectric version was bumped for S3 integration tests from v2.4 to v3.8, but it turns out the tests don't need it at all after all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
