### PR TITLE
Account for campaign attributes

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
@@ -467,6 +467,20 @@ public class AnalyticsClient implements JSONSerializable {
             }
         }
 
+        final JSONArray campaignAttrs = new JSONArray();
+        if (null != campaignAttributes) {
+            for (final Entry<String, String> entry : campaignAttributes.entrySet()) {
+                try {
+                    final JSONObject attr = new JSONObject();
+                    attr.put(entry.getKey(), entry.getValue());
+                    campaignAttrs.put(attr);
+                } catch (final JSONException e) {
+                    // Do not log e due to potentially sensitive information
+                    log.error("Error parsing Campaign Attributes.");
+                }
+            }
+        }
+
         return new JSONBuilder(this)
             .withAttribute("uniqueId", context.getUniqueId())
             .withAttribute("observers", observersJSON)
@@ -474,6 +488,7 @@ public class AnalyticsClient implements JSONSerializable {
             .withAttribute("globalMetrics", globalMets)
             .withAttribute("eventTypeAttributes", eventTypesAttributesJson)
             .withAttribute("eventTypeMetrics", eventTypesMetricsJson)
+            .withAttribute("campaignAttributes", campaignAttrs)
             .toJSONObject();
     }
 


### PR DESCRIPTION
*Issue #, if available:*
[Internal ticket](https://t.corp.amazon.com/V180718865)

*Description of changes:*
`AnalyticsClient` accepts campaign attributes and does not use it anywhere, so I added the code to include it json serialization

TODO: add unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
