### PR TITLE
Update java compatibility to 1.7

### DIFF
--- a/aws-android-sdk-connect/build.gradle
+++ b/aws-android-sdk-connect/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":aws-android-sdk-core")
 }
 
-sourceCompatibility = "1.6"
-targetCompatibility = "1.6"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"

--- a/aws-android-sdk-connectparticipant/build.gradle
+++ b/aws-android-sdk-connectparticipant/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":aws-android-sdk-core")
 }
 
-sourceCompatibility = "1.6"
-targetCompatibility = "1.6"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"

--- a/aws-android-sdk-textract/build.gradle
+++ b/aws-android-sdk-textract/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":aws-android-sdk-core")
 }
 
-sourceCompatibility = "1.6"
-targetCompatibility = "1.6"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some contributors without java 1.6 are experiencing trouble building the project due to three of the modules specifying the following in `build.gradle`:

```gradle
sourceCompatibility = "1.6"
targetCompatibility = "1.6"
```

These modules are the newest additions to the repo, and they were likely each copied from one to the next after the initial mistake. I have confirmed that all of the other modules use "1.7" and have confirmed with a user that updating these values allowed the project to build successfully.
