### PR TITLE
Rjuliano/pwdfix

### DIFF
--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTest.java
@@ -32,6 +32,7 @@ import com.amazonaws.mobile.client.results.Token;
 import com.amazonaws.mobile.client.results.Tokens;
 import com.amazonaws.mobile.client.results.UserCodeDeliveryDetails;
 import com.amazonaws.mobile.config.AWSConfiguration;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoServiceConstants;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cognitoidentity.AmazonCognitoIdentity;
@@ -41,6 +42,7 @@ import com.amazonaws.services.cognitoidentity.model.GetOpenIdTokenForDeveloperId
 import com.amazonaws.services.cognitoidentityprovider.AmazonCognitoIdentityProvider;
 import com.amazonaws.services.cognitoidentityprovider.AmazonCognitoIdentityProviderClient;
 import com.amazonaws.services.cognitoidentityprovider.model.AdminConfirmSignUpRequest;
+import com.amazonaws.services.cognitoidentityprovider.model.AdminCreateUserRequest;
 import com.amazonaws.services.cognitoidentityprovider.model.AdminDeleteUserRequest;
 import com.amazonaws.services.cognitoidentityprovider.model.AdminGetDeviceRequest;
 import com.amazonaws.services.cognitoidentityprovider.model.AdminGetDeviceResult;
@@ -49,6 +51,7 @@ import com.amazonaws.services.cognitoidentityprovider.model.DeviceRememberedStat
 import com.amazonaws.services.cognitoidentityprovider.model.InvalidParameterException;
 import com.amazonaws.services.cognitoidentityprovider.model.ListUsersRequest;
 import com.amazonaws.services.cognitoidentityprovider.model.ListUsersResult;
+import com.amazonaws.services.cognitoidentityprovider.model.MessageActionType;
 import com.amazonaws.services.cognitoidentityprovider.model.ResourceNotFoundException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserNotConfirmedException;
 import com.amazonaws.services.cognitoidentityprovider.model.UserType;
@@ -73,6 +76,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.amazonaws.mobile.client.UserState.SIGNED_IN;
+import static com.amazonaws.mobile.client.results.SignInState.DONE;
+import static com.amazonaws.mobile.client.results.SignInState.NEW_PASSWORD_REQUIRED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -90,9 +96,12 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
     private static final String TAG = AWSMobileClientTest.class.getSimpleName();
 
     private static final String EMAIL = "somebody@email.com";
+    private static final String EMAIL_ADMIN_API_USER = "sombody-temp@amazon.com";
     private static final String BLURRED_EMAIL = "s***@e***.com";
     private static final String USERNAME = "somebody";
+    private static final String USERNAME_ADMIN_API_USER = "somebody-temp";
     private static final String PASSWORD = "1234Password!";
+    private static final String TEMP_PASSWORD = "Password1234!";
     private static String IDENTITY_ID;
     private static final String NEW_PASSWORD = "new1234Password!";
     private static final int THROTTLED_DELAY = 5000;
@@ -137,6 +146,22 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
         AdminConfirmSignUpRequest adminConfirmSignUpRequest = new AdminConfirmSignUpRequest();
         adminConfirmSignUpRequest.withUsername(username).withUserPoolId(userpoolId);
         getUserpoolLL().adminConfirmSignUp(adminConfirmSignUpRequest);
+    }
+
+    public static void createUserViaAdminAPI(final String userpoolId,
+                                                     final String username,
+                                                     final String email){
+        AdminCreateUserRequest request = new AdminCreateUserRequest()
+                .withUsername(username)
+                .withTemporaryPassword(TEMP_PASSWORD)
+                .withUserPoolId(userpoolId)
+                .withMessageAction(MessageActionType.SUPPRESS)
+                .withForceAliasCreation(true)
+                .withUserAttributes(
+                        new AttributeType().withName("email").withValue(email),
+                        new AttributeType().withName("email_verified").withValue("true")
+                );
+        getUserpoolLL().adminCreateUser(request);
     }
 
     public static void deleteAllUsers(final String userpoolId) {
@@ -212,6 +237,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
         identityPoolId = identityPoolConfig.getString("PoolId");
 
         deleteAllUsers(userPoolId);
+        createUserViaAdminAPI(userPoolId, USERNAME_ADMIN_API_USER, EMAIL_ADMIN_API_USER);
     }
 
     @Before
@@ -297,6 +323,42 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
     }
 
     @Test
+    public void testSignInForceChangePassword() throws Exception{
+        final CountDownLatch stateNotificationLatch = new CountDownLatch(1);
+        final AtomicReference<UserStateDetails> userState = new AtomicReference<UserStateDetails>();
+        listener = new UserStateListener() {
+            @Override
+            public void onUserStateChanged(UserStateDetails details) {
+                userState.set(details);
+                auth.removeUserStateListener(listener);
+                stateNotificationLatch.countDown();
+
+            }
+        };
+        auth.addUserStateListener(listener);
+        //Sign-in using the temporary password
+        final SignInResult signInResult = auth.signIn(USERNAME_ADMIN_API_USER, TEMP_PASSWORD, null);
+        //Assert we're receiving challenge to change password
+        assertEquals(NEW_PASSWORD_REQUIRED, signInResult.getSignInState());
+
+        HashMap<String, String> inputAttributes = new HashMap<String, String>();
+        //Add attribute to set new password
+        inputAttributes.put(CognitoServiceConstants.CHLG_RESP_NEW_PASSWORD, PASSWORD);
+        //Set some extra attributes
+        inputAttributes.put(CognitoServiceConstants.CHLG_PARAM_USER_ATTRIBUTE_PREFIX + "name", "dummy-name");
+        inputAttributes.put(CognitoServiceConstants.CHLG_PARAM_USER_ATTRIBUTE_PREFIX + "nickname", "dummy-nickname");
+
+        //Confirm sign-in using the challenge response + attributes
+        SignInResult signInResultAfterConfirm = auth.confirmSignIn(inputAttributes);
+        assertEquals(DONE, signInResultAfterConfirm.getSignInState());
+
+        //Get the user attributes and assert the extra attributes were set
+        Map<String, String> userAttributes = auth.getUserAttributes();
+        assertEquals("dummy-name", userAttributes.get("name"));
+        assertEquals("dummy-nickname", userAttributes.get("nickname"));
+    }
+
+    @Test
     public void testSignIn() throws Exception {
         final CountDownLatch stateNotificationLatch = new CountDownLatch(1);
         final AtomicReference<UserStateDetails> userState = new AtomicReference<UserStateDetails>();
@@ -341,7 +403,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
         stateNotificationLatch.await(5, TimeUnit.SECONDS);
 
         UserStateDetails userStateDetails = userState.get();
-        assertEquals(userStateDetails.getUserState(), UserState.SIGNED_IN);
+        assertEquals(userStateDetails.getUserState(), SIGNED_IN);
         Map<String, String> details = userStateDetails.getDetails();
         assertNotEquals(getPackageConfigure().getString("identity_id"), details.toString());
     }
@@ -538,7 +600,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
         UserStateDetails userStateDetails =
                 auth.federatedSignIn(IdentityProvider.DEVELOPER.toString(), token, options);
 
-        assertEquals(UserState.SIGNED_IN, userStateDetails.getUserState());
+        assertEquals(SIGNED_IN, userStateDetails.getUserState());
 
         assertNotNull("Credentials from federated sign-in should not be null", auth.getCredentials());
     }
@@ -775,7 +837,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
         AWSMobileClient.getInstance().initialize(appContext, new Callback<UserStateDetails>() {
             @Override
             public void onResult(UserStateDetails result) {
-                assertEquals(UserState.SIGNED_IN,
+                assertEquals(SIGNED_IN,
                         result.getUserState());
                 waitForAWSMobileClientToBeInitialized.countDown();
             }

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -98,6 +98,7 @@ import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.SignUpHan
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.UpdateAttributesHandler;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.VerificationHandler;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoPinpointSharedContext;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.util.CognitoServiceConstants;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cognitoidentity.AmazonCognitoIdentity;
@@ -177,6 +178,10 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     /// This value is a boolean stored as a String 'true' 'false'
     static final String FEDERATION_ENABLED_KEY = "isFederationEnabled";
     private static final String CUSTOM_ROLE_ARN_KEY = "customRoleArn";
+
+    public static final String CHALLENGE_RESPONSE_NEW_PASSWORD_KEY = CognitoServiceConstants.CHLG_RESP_NEW_PASSWORD;
+    public static final String CHALLENGE_RESPONSE_USER_ATTRIBUTES_PREFIX_KEY = CognitoServiceConstants.CHLG_PARAM_USER_ATTRIBUTE_PREFIX;
+
     /**
      * Configuration keys for SignInProviders in awsconfiguration.json.
      */
@@ -1366,7 +1371,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         }
                         detectedContinuation = signInChallengeContinuation;
                         signInCallback = new InternalCallback<SignInResult>(callback);
-                        if(CUSTOM_CHALLENGE.equals(signInState)){
+                        if (CUSTOM_CHALLENGE.equals(signInState)) {
                             signInChallengeContinuation.setClientMetaData(clientMetaData);
                         }
                         break;

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -128,6 +128,8 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static com.amazonaws.mobile.client.results.SignInState.CUSTOM_CHALLENGE;
+
 /**
  * The AWSMobileClient provides client APIs and building blocks for developers who want to create
  * user authentication experiences. This includes declarative methods for performing
@@ -1354,17 +1356,19 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                 final CognitoIdentityProviderContinuation detectedContinuation;
                 switch (signInState) {
                     case SMS_MFA:
-                    case NEW_PASSWORD_REQUIRED:
                         callback.onError(new IllegalStateException(
                                 "Please use confirmSignIn(String, Callback) " +
-                                        "for SMS_MFA and NEW_PASSWORD_REQUIRED challenges"));
+                                        "for SMS_MFA challenges"));
                     case CUSTOM_CHALLENGE:
+                    case NEW_PASSWORD_REQUIRED:
                         for (final String key : signInChallengeResponse.keySet()) {
                             signInChallengeContinuation.setChallengeResponse(key, signInChallengeResponse.get(key));
                         }
                         detectedContinuation = signInChallengeContinuation;
-                        signInChallengeContinuation.setClientMetaData(clientMetaData);
                         signInCallback = new InternalCallback<SignInResult>(callback);
+                        if(CUSTOM_CHALLENGE.equals(signInState)){
+                            signInChallengeContinuation.setClientMetaData(clientMetaData);
+                        }
                         break;
                     case DONE:
                         detectedContinuation = null;


### PR DESCRIPTION
*Issue #1403 and #1452 

*Description of changes:
Modified the overloaded method for _confirmSignin that takes a map of attributes to allow the caller to pass in the user attributes as part of the challenge response for NEW_PASSWORD_REQUIRED.

Added an integration test that creates a user in a FORCE_CHANGE_PASSWORD status, logs in with that users, sets the new password and a couple other attributes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
