### PR TITLE
Fixes sign in method caching issues #1469 and #1262

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1129,6 +1129,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
 
         this.signInCallback = callback;
         signInState = null;
+        mStore.set(SIGN_IN_MODE, SignInMode.SIGN_IN.toString());
 
         return new Runnable() {
             @Override
@@ -1594,6 +1595,8 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                       final boolean assignState) {
 
         final Map<String, String> loginsMap = new HashMap<String, String>();
+        mStore.set(SIGN_IN_MODE, SignInMode.FEDERATED_SIGN_IN.toString());
+
         try {
             loginsMap.put(providerKey, token);
 


### PR DESCRIPTION
Currently SIGN_IN_MODE is only set when the user signs in with HostedUI or OAuth leading to a failure in retrieving tokens if the user afterwards ever tries to sign in with UserPools or Federated Identities. 

This ensures that the sign in mode is switched when those methods are used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
