### PR TITLE
Add user attributes to endpoint profile user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.16.11](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.11)
+
+### New Features
+
+- **Amazon Pinpoint**
+  - `EndpointProfileUser` can now store user attributes, which will persist even after updating the endpoint.
+
 ## [Release 2.16.10](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.10)
 
 ### Bug Fixes

--- a/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/EndpointProfileIntegrationTest.java
+++ b/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/EndpointProfileIntegrationTest.java
@@ -111,7 +111,7 @@ public class EndpointProfileIntegrationTest extends AWSTestBase {
 
         EndpointProfileUser user = new EndpointProfileUser();
         user.setUserId(credentialsProvider.getIdentityId());
-        user.setUserAttributes(Collections.singletonMap("user-key", Arrays.asList("user-value")));
+        user.addUserAttribute("user-key", Collections.singletonList("user-value"));
         endpointProfile.setUser(user);
 
         targetingClient.updateEndpointProfile();
@@ -120,7 +120,7 @@ public class EndpointProfileIntegrationTest extends AWSTestBase {
         assertEquals(credentialsProvider.getIdentityId(),
                 endpointProfile.getUser().getUserId());
         assertNotNull(endpointProfile.getUser().getUserAttributes());
-        assertEquals(Collections.singletonMap("user-key", Arrays.asList("user-value")),
+        assertEquals(Collections.singletonMap("user-key", Collections.singletonList("user-value")),
                 endpointProfile.getUser().getUserAttributes());
 
         endpointProfile.addAttribute("key", Arrays.asList("value"));

--- a/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/EndpointProfileIntegrationTest.java
+++ b/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/EndpointProfileIntegrationTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -106,9 +107,11 @@ public class EndpointProfileIntegrationTest extends AWSTestBase {
         EndpointProfile endpointProfile = targetingClient.currentEndpoint();
         assertNotNull(endpointProfile);
         assertNull(endpointProfile.getUser().getUserId());
+        assertNull(endpointProfile.getUser().getUserAttributes());
 
         EndpointProfileUser user = new EndpointProfileUser();
         user.setUserId(credentialsProvider.getIdentityId());
+        user.setUserAttributes(Collections.singletonMap("user-key", Arrays.asList("user-value")));
         endpointProfile.setUser(user);
 
         targetingClient.updateEndpointProfile();
@@ -116,6 +119,9 @@ public class EndpointProfileIntegrationTest extends AWSTestBase {
         assertNotNull(endpointProfile);
         assertEquals(credentialsProvider.getIdentityId(),
                 endpointProfile.getUser().getUserId());
+        assertNotNull(endpointProfile.getUser().getUserAttributes());
+        assertEquals(Collections.singletonMap("user-key", Arrays.asList("user-value")),
+                endpointProfile.getUser().getUserAttributes());
 
         endpointProfile.addAttribute("key", Arrays.asList("value"));
         targetingClient.updateEndpointProfile();

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
@@ -584,8 +584,9 @@ public class EventRecorder {
         if (endpointProfile.getUser().getUserId() == null) {
             user = null;
         } else {
-            user = new EndpointUser();
-            user.setUserId(endpointProfile.getUser().getUserId());
+            user = new EndpointUser()
+                    .withUserId(endpointProfile.getUser().getUserId())
+                    .withUserAttributes(endpointProfile.getUser().getUserAttributes());
         }
 
         endpoint.withChannelType(endpointProfile.getChannelType())

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/TargetingClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/TargetingClient.java
@@ -171,8 +171,9 @@ public class TargetingClient {
         if (endpointProfile.getUser().getUserId() == null) {
             user = null;
         } else {
-            user = new EndpointUser();
-            user.setUserId(endpointProfile.getUser().getUserId());
+            user = new EndpointUser()
+                    .withUserId(endpointProfile.getUser().getUserId())
+                    .withUserAttributes(endpointProfile.getUser().getUserAttributes());
         }
 
         final EndpointRequest endpointRequest = new EndpointRequest().withChannelType(endpointProfile.getChannelType())

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/endpointProfile/EndpointProfileUser.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/endpointProfile/EndpointProfileUser.java
@@ -15,16 +15,26 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.targeting.endpointProfile;
 
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
+
+import com.amazonaws.logging.Log;
+import com.amazonaws.logging.LogFactory;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.util.JSONBuilder;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.util.JSONSerializable;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * An endpoint profile user
  */
 public class EndpointProfileUser implements JSONSerializable {
+    private static final Log log = LogFactory.getLog(EndpointProfileUser.class);
 
     private String userId;
+    private Map<String, List<String>> userAttributes;
 
     public String getUserId() {
         return this.userId;
@@ -34,10 +44,35 @@ public class EndpointProfileUser implements JSONSerializable {
         this.userId = userId;
     }
 
+    public Map<String, List<String>> getUserAttributes() {
+        return this.userAttributes;
+    }
+
+    public void setUserAttributes(Map<String, List<String>> userAttributes) {
+        this.userAttributes = userAttributes;
+    }
+
     @Override
     public JSONObject toJSONObject() {
         final JSONBuilder builder = new JSONBuilder(null);
         builder.withAttribute("UserId", getUserId());
+
+        final JSONObject attributesJson = new JSONObject();
+        for (final Map.Entry<String, List<String>> entry : getUserAttributes().entrySet()) {
+            try {
+                final JSONArray array = new JSONArray(entry.getValue());
+                attributesJson.put(entry.getKey(), array);
+            } catch (final JSONException e) {
+                // Do not log e due to potentially sensitive information
+                log.warn("Error serializing user attributes.");
+            }
+        }
+
+        // If there are any attributes put then add the attributes to the structure
+        if (attributesJson.length() > 0) {
+            builder.withAttribute("UserAttributes", attributesJson);
+        }
+
         return builder.toJSONObject();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
[Internal ticket](https://t.corp.amazon.com/mobilesdk-4751)

*Description of changes:*
Add `userAttributes` field to `EndpointProfileUser` to better represent `EndpointUser` model. This field will now update alongside endpoint profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
