### PR TITLE
Fix multipart upload pause

### DIFF
--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/PauseTransferIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/PauseTransferIntegrationTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.mobileconnectors.s3.transferutility;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+
+import com.amazonaws.services.s3.S3IntegrationTestBase;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public final class PauseTransferIntegrationTest extends S3IntegrationTestBase {
+
+    private static final String bucketName = "amazon-transfer-util-integ-test-" + new Date().getTime();
+    private static TransferUtility util;
+    private static Context context = InstrumentationRegistry.getContext();
+
+    private File file;
+    private CountDownLatch started;
+    private CountDownLatch paused;
+    private CountDownLatch resumed;
+    private CountDownLatch completed;
+
+    /**
+     * Creates and initializes all the test resources needed for these tests.
+     */
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        setUp();
+        TransferNetworkLossHandler.getInstance(context);
+        util = TransferUtility.builder()
+                .context(context)
+                .s3Client(s3)
+                .build();
+
+        try {
+            s3.createBucket(bucketName);
+            waitForBucketCreation(bucketName);
+        } catch (final Exception e) {
+            System.out.println("Error in creating the bucket. "
+                    + "Please manually create the bucket " + bucketName);
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        try {
+            deleteBucketAndAllContents(bucketName);
+        } catch (final Exception e) {
+            System.out.println("Error in deleting the bucket. "
+                    + "Please manually delete the bucket " + bucketName);
+            e.printStackTrace();
+        }
+    }
+
+    @Before
+    public void setUpLatches() {
+        started = new CountDownLatch(1);
+        paused = new CountDownLatch(1);
+        resumed = new CountDownLatch(1);
+        completed = new CountDownLatch(1);
+    }
+
+    @Test
+    public void testSinglePartUploadPause() throws Exception {
+        // Small (1KB) file upload
+        file = getRandomTempFile("small", 1000L);
+        testUploadPause();
+    }
+
+    @Test
+    public void testMultiPartUploadPause() throws Exception {
+        // Large (10MB) file upload
+        file = getRandomSparseFile("large", 10L * 1024 * 1024);
+        testUploadPause();
+    }
+
+    private void testUploadPause() throws Exception {
+        // start transfer and wait for progress
+        TransferObserver observer = util.upload(bucketName, file.getName(), file);
+        observer.setTransferListener(new TestListener());
+        started.await(100, TimeUnit.MILLISECONDS);
+
+        // pause and wait
+        util.pause(observer.getId());
+        paused.await(100, TimeUnit.MILLISECONDS);
+        Thread.sleep(1000); // throws if progress is made
+
+        // resume if pause was properly executed
+        util.resume(observer.getId());
+        resumed.await(100, TimeUnit.MILLISECONDS);
+
+        // cancel early to avoid having to wait for completion
+        util.cancel(observer.getId());
+        completed.await(100, TimeUnit.MILLISECONDS);
+    }
+
+    private final class TestListener implements TransferListener {
+        @Override
+        public void onStateChanged(int id, TransferState state) {
+            switch (state) {
+                case CANCELED:
+                case COMPLETED:
+                    completed.countDown();
+                    break;
+                case PAUSED:
+                    paused.countDown();
+                    break;
+                case IN_PROGRESS:
+                    if (paused.getCount() == 0) {
+                        // Post-pause
+                        resumed.countDown();
+                    } else {
+                        // Pre-pause
+                        started.countDown();
+                    }
+                    break;
+                case FAILED:
+                    throw new RuntimeException("Failed transfer.");
+            }
+        }
+
+        @Override
+        public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {
+            if (paused.getCount() == 0 && resumed.getCount() > 0) {
+                throw new RuntimeException("Progress made even while paused.");
+            }
+        }
+
+        @Override
+        public void onError(int id, Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/PauseTransferIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/PauseTransferIntegrationTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 public final class PauseTransferIntegrationTest extends S3IntegrationTestBase {
 
-    private static final String bucketName = "amazon-transfer-util-integ-test-" + new Date().getTime();
+    private static final String BUCKET_NAME = "amazon-transfer-util-integ-test-" + new Date().getTime();
     private static TransferUtility util;
     private static Context context = InstrumentationRegistry.getContext();
 
@@ -55,21 +55,21 @@ public final class PauseTransferIntegrationTest extends S3IntegrationTestBase {
                 .build();
 
         try {
-            s3.createBucket(bucketName);
-            waitForBucketCreation(bucketName);
+            s3.createBucket(BUCKET_NAME);
+            waitForBucketCreation(BUCKET_NAME);
         } catch (final Exception e) {
             System.out.println("Error in creating the bucket. "
-                    + "Please manually create the bucket " + bucketName);
+                    + "Please manually create the bucket " + BUCKET_NAME);
         }
     }
 
     @AfterClass
     public static void tearDown() {
         try {
-            deleteBucketAndAllContents(bucketName);
+            deleteBucketAndAllContents(BUCKET_NAME);
         } catch (final Exception e) {
             System.out.println("Error in deleting the bucket. "
-                    + "Please manually delete the bucket " + bucketName);
+                    + "Please manually delete the bucket " + BUCKET_NAME);
             e.printStackTrace();
         }
     }
@@ -98,7 +98,7 @@ public final class PauseTransferIntegrationTest extends S3IntegrationTestBase {
 
     private void testUploadPause() throws Exception {
         // start transfer and wait for progress
-        TransferObserver observer = util.upload(bucketName, file.getName(), file);
+        TransferObserver observer = util.upload(BUCKET_NAME, file.getName(), file);
         observer.setTransferListener(new TestListener());
         started.await(100, TimeUnit.MILLISECONDS);
 

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/SocketTimeoutIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/SocketTimeoutIntegrationTest.java
@@ -82,7 +82,7 @@ class SocketTimeoutMockS3Client extends AmazonS3Client {
 
 public class SocketTimeoutIntegrationTest extends S3IntegrationTestBase {
     /** The bucket created and used by these tests */
-    private static final String bucketName = "amazon-transfer-util-integ-test-" + new Date().getTime();
+    private static final String BUCKET_NAME = "amazon-transfer-util-integ-test-" + new Date().getTime();
 
     /** Instrumentation test context */
     private static Context context = InstrumentationRegistry.getContext();
@@ -113,21 +113,21 @@ public class SocketTimeoutIntegrationTest extends S3IntegrationTestBase {
                 .build();
 
         try {
-            s3.createBucket(bucketName);
-            waitForBucketCreation(bucketName);
+            s3.createBucket(BUCKET_NAME);
+            waitForBucketCreation(BUCKET_NAME);
         } catch (final Exception e) {
             System.out.println("Error in creating the bucket. "
-                    + "Please manually create the bucket " + bucketName);
+                    + "Please manually create the bucket " + BUCKET_NAME);
         }
     }
 
     @AfterClass
     public static void tearDown() {
         try {
-            deleteBucketAndAllContents(bucketName);
+            deleteBucketAndAllContents(BUCKET_NAME);
         } catch (final Exception e) {
             System.out.println("Error in deleting the bucket. "
-                    + "Please manually delete the bucket " + bucketName);
+                    + "Please manually delete the bucket " + BUCKET_NAME);
             e.printStackTrace();
         }
 
@@ -146,7 +146,7 @@ public class SocketTimeoutIntegrationTest extends S3IntegrationTestBase {
         // First attempt at uploading should throw socket timeout exception error
         latch = new CountDownLatch(1);
         mockS3.setTransferEnabled(false);
-        observer = util.upload(bucketName, file.getName(), file);
+        observer = util.upload(BUCKET_NAME, file.getName(), file);
         observer.setTransferListener(new TransferListener() {
             @Override
             public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {
@@ -198,7 +198,7 @@ public class SocketTimeoutIntegrationTest extends S3IntegrationTestBase {
         // First attempt at uploading should throw socket timeout exception error
         latch = new CountDownLatch(1);
         mockS3.setTransferEnabled(false);
-        observer = util.upload(bucketName, file.getName(), file);
+        observer = util.upload(BUCKET_NAME, file.getName(), file);
         observer.setTransferListener(new TransferListener() {
             @Override
             public void onProgressChanged(int id, long bytesCurrent, long bytesTotal) {

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/TaggingIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/TaggingIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.fail;
 public class TaggingIntegrationTest extends S3IntegrationTestBase {
 
     /** The bucket created and used by these tests */
-    private static final String bucketName = "amazon-transfer-util-integ-test-" + new Date().getTime();
+    private static final String BUCKET_NAME = "amazon-transfer-util-integ-test-" + new Date().getTime();
 
     /** Instrumentation test context */
     private static Context context = InstrumentationRegistry.getContext();
@@ -85,21 +85,21 @@ public class TaggingIntegrationTest extends S3IntegrationTestBase {
                 .build();
 
         try {
-            s3.createBucket(bucketName);
-            waitForBucketCreation(bucketName);
+            s3.createBucket(BUCKET_NAME);
+            waitForBucketCreation(BUCKET_NAME);
         } catch (final Exception e) {
             System.out.println("Error in creating the bucket. "
-                    + "Please manually create the bucket " + bucketName);
+                    + "Please manually create the bucket " + BUCKET_NAME);
         }
     }
 
     @AfterClass
     public static void tearDown() {
         try {
-            deleteBucketAndAllContents(bucketName);
+            deleteBucketAndAllContents(BUCKET_NAME);
         } catch (final Exception e) {
             System.out.println("Error in deleting the bucket. "
-                    + "Please manually delete the bucket " + bucketName);
+                    + "Please manually delete the bucket " + BUCKET_NAME);
             e.printStackTrace();
         }
 
@@ -118,12 +118,12 @@ public class TaggingIntegrationTest extends S3IntegrationTestBase {
         latch = new CountDownLatch(1);
         // Small (1KB) file upload
         file = getRandomTempFile("small", 1000L);
-        util.upload(bucketName, file.getName(), file, metadata)
+        util.upload(BUCKET_NAME, file.getName(), file, metadata)
                 .setTransferListener(listener);
         latch.await(300, TimeUnit.SECONDS);
 
         List<Tag> tags = s3.getObjectTagging(new GetObjectTaggingRequest(
-                bucketName,
+                BUCKET_NAME,
                 file.getName()
         )).getTagSet();
         assertThat(tags.size(), is(2));
@@ -144,12 +144,12 @@ public class TaggingIntegrationTest extends S3IntegrationTestBase {
         // Large (5MB) file upload
         long size = 5 * 1024 * 1024 + 1;
         file = getRandomSparseFile("large", size);
-        util.upload(bucketName, file.getName(), file, metadata)
+        util.upload(BUCKET_NAME, file.getName(), file, metadata)
                 .setTransferListener(listener);
         latch.await(300, TimeUnit.SECONDS);
 
         List<Tag> tags = s3.getObjectTagging(new GetObjectTaggingRequest(
-                bucketName,
+                BUCKET_NAME,
                 file.getName()
         )).getTagSet();
         assertThat(tags.size(), is(2));

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/DownloadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/DownloadTask.java
@@ -114,16 +114,16 @@ class DownloadTask implements Callable<Boolean> {
             return true;
         } catch (final Exception e) {
             // No need to update the progress listener.
-            if (TransferState.CANCELED.equals(download.state)) {
-                LOGGER.info("Transfer is " + download.state);
+            if (TransferState.PENDING_CANCEL.equals(download.state)) {
+                updater.updateState(download.id, TransferState.CANCELED);
+                LOGGER.info("Transfer is " + TransferState.CANCELED);
                 return false;
             }
 
             // Reset the progress when the transfer is paused.
-            if (TransferState.PAUSED.equals(download.state)) {
-                LOGGER.info("Transfer is " + download.state);
-                ProgressEvent resetEvent = new ProgressEvent(0);
-                resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
+            if (TransferState.PENDING_PAUSE.equals(download.state)) {
+                updater.updateState(download.id, TransferState.PAUSED);
+                LOGGER.info("Transfer is " + TransferState.PAUSED);
                 progressListener.progressChanged(new ProgressEvent(0));
                 return false;
             }
@@ -144,8 +144,6 @@ class DownloadTask implements Callable<Boolean> {
                      */
                     updater.updateState(download.id, TransferState.WAITING_FOR_NETWORK);
                     LOGGER.debug("Network Connection Interrupted: " + "Moving the TransferState to WAITING_FOR_NETWORK");
-                    ProgressEvent resetEvent = new ProgressEvent(0);
-                    resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
                     progressListener.progressChanged(new ProgressEvent(0));
                     return false;
                 }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/DownloadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/DownloadTask.java
@@ -124,6 +124,8 @@ class DownloadTask implements Callable<Boolean> {
             if (TransferState.PENDING_PAUSE.equals(download.state)) {
                 updater.updateState(download.id, TransferState.PAUSED);
                 LOGGER.info("Transfer is " + TransferState.PAUSED);
+                ProgressEvent resetEvent = new ProgressEvent(0);
+                resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
                 progressListener.progressChanged(new ProgressEvent(0));
                 return false;
             }
@@ -144,6 +146,8 @@ class DownloadTask implements Callable<Boolean> {
                      */
                     updater.updateState(download.id, TransferState.WAITING_FOR_NETWORK);
                     LOGGER.debug("Network Connection Interrupted: " + "Moving the TransferState to WAITING_FOR_NETWORK");
+                    ProgressEvent resetEvent = new ProgressEvent(0);
+                    resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
                     progressListener.progressChanged(new ProgressEvent(0));
                     return false;
                 }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
@@ -199,11 +199,12 @@ class TransferRecord {
      * @return true if the transfer is running and is paused successfully, false
      *         otherwise
      */
-    public boolean pause(final AmazonS3 s3, 
+    public boolean pause(final AmazonS3 s3,
                          final TransferStatusUpdater updater) {
-        if (!isFinalState(state) && 
-            !TransferState.PAUSED.equals(state)) {
-            updater.updateState(id, TransferState.PAUSED);
+        if (!isFinalState(state)
+                && !TransferState.PAUSED.equals(state)
+                && !TransferState.PENDING_PAUSE.equals(state)) {
+            updater.updateState(id, TransferState.PENDING_PAUSE);
             if (isRunning()) {
                 submittedTask.cancel(true);
             }
@@ -249,10 +250,11 @@ class TransferRecord {
     public boolean cancel(final AmazonS3 s3, 
                           final TransferStatusUpdater updater) {
         if (!isFinalState(state)) {
-            // Update the state to CANCELED in the TransferStatusUpdater and
-            // TransferDBUtil and involes the onStateChanged callback.
-            updater.updateState(id, TransferState.CANCELED);
+            // Update the state to PENDING_CANCEL in the TransferStatusUpdater
+            // and TransferDBUtil and involves the onStateChanged callback.
+            updater.updateState(id, TransferState.PENDING_CANCEL);
             if (isRunning()) {
+                // State will update to CANCELED upon encountering S3 exception
                 submittedTask.cancel(true);
             }
             // additional cleanup

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
@@ -367,7 +367,7 @@ class TransferStatusUpdater {
         public synchronized void progressChanged(ProgressEvent progressEvent) {
             if (ProgressEvent.RESET_EVENT_CODE == progressEvent.getEventCode()) {
                 // Reset will discard what's been transferred
-                LOGGER.info("Reset Event triggerred. Resetting the bytesCurrent to 0.");
+                LOGGER.info("Reset Event triggered. Resetting the bytesCurrent to 0.");
                 // Reset the local counter to 0.
                 bytesTransferredSoFar = 0;
             } else {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadPartTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadPartTask.java
@@ -15,7 +15,6 @@
 
 package com.amazonaws.mobileconnectors.s3.transferutility;
 
-
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressListener;
 import com.amazonaws.services.s3.AmazonS3;
@@ -112,7 +111,7 @@ class UploadPartTask implements Callable<Boolean> {
         public void progressChanged(ProgressEvent progressEvent) {
             if (ProgressEvent.RESET_EVENT_CODE == progressEvent.getEventCode()) {
                 // Reset will discard what's been transferred
-                LOGGER.info("Reset Event triggerred. Resetting the bytesCurrent to 0.");
+                LOGGER.info("Reset Event triggered. Resetting the bytesCurrent to 0.");
                 // Reset the local counter to 0.
                 bytesTransferredSoFar = 0;
             } else {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
@@ -295,6 +295,8 @@ class UploadTask implements Callable<Boolean> {
             if (TransferState.PENDING_PAUSE.equals(upload.state)) {
                 updater.updateState(upload.id, TransferState.PAUSED);
                 LOGGER.info("Transfer is " + TransferState.PAUSED);
+                ProgressEvent resetEvent = new ProgressEvent(0);
+                resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
                 progressListener.progressChanged(new ProgressEvent(0));
                 return false;
             }
@@ -315,6 +317,8 @@ class UploadTask implements Callable<Boolean> {
                      */
                     updater.updateState(upload.id, TransferState.WAITING_FOR_NETWORK);
                     LOGGER.debug("Network Connection Interrupted: " + "Moving the TransferState to WAITING_FOR_NETWORK");
+                    ProgressEvent resetEvent = new ProgressEvent(0);
+                    resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
                     progressListener.progressChanged(new ProgressEvent(0));
                     return false;
                 }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadTask.java
@@ -30,7 +30,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
@@ -193,15 +192,6 @@ class UploadTask implements Callable<Boolean> {
         } catch (final Exception e) {
             LOGGER.error("Upload resulted in an exception. " + e);
 
-            // If the thread that is executing the transfer is interrupted
-            // because of a user initiated pause or cancel operation,
-            // do not throw exception or set the state to FAILED.
-            if (TransferState.CANCELED.equals(upload.state) ||
-                TransferState.PAUSED.equals(upload.state)) {
-                LOGGER.info("Transfer is " + upload.state);
-                return false;
-            }
-
             /*
              * Future.get() will catch InterruptedException, but it's not a
              * failure, it may be caused by a pause operation from applications.
@@ -209,6 +199,21 @@ class UploadTask implements Callable<Boolean> {
              */
             for (final UploadPartTaskMetadata task : uploadPartTasks.values()) {
                 task.uploadPartTask.cancel(true);
+            }
+
+            // If the thread that is executing the transfer is interrupted
+            // because of a user initiated pause or cancel operation,
+            // do not throw exception or set the state to FAILED.
+            if (TransferState.PENDING_CANCEL.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.CANCELED);
+                LOGGER.info("Transfer is " + TransferState.CANCELED);
+                return false;
+            }
+
+            if (TransferState.PENDING_PAUSE.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.PAUSED);
+                LOGGER.info("Transfer is " + TransferState.PAUSED);
+                return false;
             }
 
             // interrupted due to network. Set the TransferState to 
@@ -274,22 +279,22 @@ class UploadTask implements Callable<Boolean> {
         putObjectRequest.setGeneralProgressListener(progressListener);
 
         try {
-            PutObjectResult putObjectResult = s3.putObject(putObjectRequest);
+            s3.putObject(putObjectRequest);
             updater.updateProgress(upload.id, length, length, true);
             updater.updateState(upload.id, TransferState.COMPLETED);
             return true;
         } catch (final Exception e) {
-           // we dont need to update progress listener
-            if (TransferState.CANCELED.equals(upload.state)) {
-                LOGGER.info("Transfer is " + upload.state);
+            // we dont need to update progress listener
+            if (TransferState.PENDING_CANCEL.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.CANCELED);
+                LOGGER.info("Transfer is " + TransferState.CANCELED);
                 return false;
             }
 
             // pause
-            if (TransferState.PAUSED.equals(upload.state)) {
-                LOGGER.info("Transfer is " + upload.state);
-                ProgressEvent resetEvent = new ProgressEvent(0);
-                resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
+            if (TransferState.PENDING_PAUSE.equals(upload.state)) {
+                updater.updateState(upload.id, TransferState.PAUSED);
+                LOGGER.info("Transfer is " + TransferState.PAUSED);
                 progressListener.progressChanged(new ProgressEvent(0));
                 return false;
             }
@@ -310,8 +315,6 @@ class UploadTask implements Callable<Boolean> {
                      */
                     updater.updateState(upload.id, TransferState.WAITING_FOR_NETWORK);
                     LOGGER.debug("Network Connection Interrupted: " + "Moving the TransferState to WAITING_FOR_NETWORK");
-                    ProgressEvent resetEvent = new ProgressEvent(0);
-                    resetEvent.setEventCode(ProgressEvent.RESET_EVENT_CODE);
                     progressListener.progressChanged(new ProgressEvent(0));
                     return false;
                 }


### PR DESCRIPTION
*Issue #, if available:*
#1500 

*Description of changes:*
`TransferUtility#pause(int)` was not behaving correctly when uploading a multipart (> 5MB) item. This was due to interruption detection (due to pause) code returning early before actually canceling the individual `UploadPartTask` tasks in the upload. The same result would have been seen for `TransferUtility#cancel(int)` for a large upload.

Additionally to fixing the above bug, this PR also contains fix to mitigate the effects of race condition observed when pausing multipart upload and resuming it instantly. Previously, the transfer state would be set to `PAUSED` or `CANCELED` as soon as the method was called even before all of the task was interrupted. Now `PENDING_PAUSE` and `PENDING_CANCEL` (already present in the codebase but unused) states are used to make sure that the task is successfully interrupted before the state is updated to its final state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
