### PR TITLE
Rjuliano/journeys

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
@@ -75,7 +75,7 @@ public class AnalyticsClient implements JSONSerializable {
     private final Map<String, Double> globalMetrics = new ConcurrentHashMap<String, Double>();
     private final Map<String, Map<String, String>> eventTypeAttributes = new ConcurrentHashMap<String, Map<String, String>>();
     private final Map<String, Map<String, Double>> eventTypeMetrics = new ConcurrentHashMap<String, Map<String, Double>>();
-    private Map<String, String> eventSourceAttributes = new ConcurrentHashMap<String, String>();
+    private final Map<String, String> eventSourceAttributes = new ConcurrentHashMap<String, String>();
     private String sessionId;
     private long sessionStartTime;
     private EventRecorder eventRecorder;
@@ -359,6 +359,16 @@ public class AnalyticsClient implements JSONSerializable {
     }
 
     /**
+     *
+     * @param campaign
+     * @deprecated see {@link #updateEventSourceGlobally(Map)}
+     */
+    @Deprecated
+    public void setCampaignAttributes(Map<String, String> campaign) {
+        updateEventSourceGlobally(campaign);
+    }
+
+    /**
      * Replaces the current event source attributes (if any)
      * with a new set of event source attributes
      * @param attributes map of attribute values
@@ -374,7 +384,7 @@ public class AnalyticsClient implements JSONSerializable {
         }
         //We set this so the analytics client knows what to remove from
         //from the globalAttributes collection when it's time to clear it
-        this.eventSourceAttributes = attributes;
+        eventSourceAttributes.putAll(attributes);
     }
 
     /**

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
@@ -75,7 +75,7 @@ public class AnalyticsClient implements JSONSerializable {
     private final Map<String, Double> globalMetrics = new ConcurrentHashMap<String, Double>();
     private final Map<String, Map<String, String>> eventTypeAttributes = new ConcurrentHashMap<String, Map<String, String>>();
     private final Map<String, Map<String, Double>> eventTypeMetrics = new ConcurrentHashMap<String, Map<String, Double>>();
-    private Map<String, String> campaignAttributes = new ConcurrentHashMap<String, String>();
+    private Map<String, String> pinpointAttributes = new ConcurrentHashMap<String, String>();
     private String sessionId;
     private long sessionStartTime;
     private EventRecorder eventRecorder;
@@ -359,33 +359,33 @@ public class AnalyticsClient implements JSONSerializable {
     }
 
     /**
-     * Adds the specified campaign attributes to events to track Campaign Analytic
+     * Adds the specified pinpoint attributes to events to track Campaign/Journey Analytic
      * <p>
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.
      *
-     * @param campaign the map with campaign attributes of the campaign received
+     * @param pinpointAttributes the map with pinpointAttributes attributes of the pinpointAttributes received
      */
-    public void setCampaignAttributes(Map<String, String> campaign) {
-        if (campaign == null) {
-            log.warn("Null campaign attributes provided to setCampaignAttributes.");
+    public void setPinpointAttributes(Map<String, String> pinpointAttributes) {
+        if (pinpointAttributes == null) {
+            log.warn("Null pinpointAttributes attributes provided to setPinpointAttributes.");
             return;
         }
 
-        campaignAttributes = campaign;
+        this.pinpointAttributes = pinpointAttributes;
     }
 
     /**
-     * Clears campaign attributes
+     * Clears pinpoint attributes
      * <p>
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.
      */
-    public void clearCampaignAttributes() {
-        for (final String key : campaignAttributes.keySet()) {
+    public void clearPinpointAttributes() {
+        for (final String key : pinpointAttributes.keySet()) {
             this.removeGlobalAttribute(key);
         }
-        campaignAttributes.clear();
+        pinpointAttributes.clear();
     }
 
     @Override

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
@@ -359,7 +359,7 @@ public class AnalyticsClient implements JSONSerializable {
     }
 
     /**
-     * Adds the specified pinpoint attributes to events to track Campaign/Journey Analytic
+     * Adds the specified Pinpoint attributes to events to track Campaign/Journey analytics
      * <p>
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.
@@ -376,7 +376,7 @@ public class AnalyticsClient implements JSONSerializable {
     }
 
     /**
-     * Clears pinpoint attributes
+     * Clears Pinpoint attributes
      * <p>
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
@@ -75,7 +75,7 @@ public class AnalyticsClient implements JSONSerializable {
     private final Map<String, Double> globalMetrics = new ConcurrentHashMap<String, Double>();
     private final Map<String, Map<String, String>> eventTypeAttributes = new ConcurrentHashMap<String, Map<String, String>>();
     private final Map<String, Map<String, Double>> eventTypeMetrics = new ConcurrentHashMap<String, Map<String, Double>>();
-    private Map<String, String> pinpointAttributes = new ConcurrentHashMap<String, String>();
+    private Map<String, String> eventSourceAttributes = new ConcurrentHashMap<String, String>();
     private String sessionId;
     private long sessionStartTime;
     private EventRecorder eventRecorder;
@@ -364,15 +364,15 @@ public class AnalyticsClient implements JSONSerializable {
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.
      *
-     * @param pinpointAttributes the map with pinpointAttributes attributes of the pinpointAttributes received
+     * @param eventSourceAttributes the map with pinpointAttributes attributes of the pinpointAttributes received
      */
-    public void setPinpointAttributes(Map<String, String> pinpointAttributes) {
-        if (pinpointAttributes == null) {
+    public void setEventSourceAttributes(Map<String, String> eventSourceAttributes) {
+        if (eventSourceAttributes == null) {
             log.warn("Null pinpointAttributes attributes provided to setPinpointAttributes.");
             return;
         }
 
-        this.pinpointAttributes = pinpointAttributes;
+        this.eventSourceAttributes = eventSourceAttributes;
     }
 
     /**
@@ -381,11 +381,11 @@ public class AnalyticsClient implements JSONSerializable {
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.
      */
-    public void clearPinpointAttributes() {
-        for (final String key : pinpointAttributes.keySet()) {
+    public void clearEventSourceAttributes() {
+        for (final String key : eventSourceAttributes.keySet()) {
             this.removeGlobalAttribute(key);
         }
-        pinpointAttributes.clear();
+        eventSourceAttributes.clear();
     }
 
     @Override

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/AnalyticsClient.java
@@ -359,29 +359,34 @@ public class AnalyticsClient implements JSONSerializable {
     }
 
     /**
-     * Adds the specified Pinpoint attributes to events to track Campaign/Journey analytics
-     * <p>
-     * You should not use this method as it will be called by the NotificationManager when the app is opened
-     * from a push notification.
-     *
-     * @param eventSourceAttributes the map with pinpointAttributes attributes of the pinpointAttributes received
+     * Replaces the current event source attributes (if any)
+     * with a new set of event source attributes
+     * @param attributes map of attribute values
      */
-    public void setEventSourceAttributes(Map<String, String> eventSourceAttributes) {
-        if (eventSourceAttributes == null) {
-            log.warn("Null pinpointAttributes attributes provided to setPinpointAttributes.");
-            return;
+    public void updateEventSourceGlobally(final Map<String, String> attributes) {
+        //This call removes previous events identifiers from the
+        //globalAttributes collection in AnalyticsEvent.
+        clearEventSourceAttributes();
+        for (final Map.Entry<String, String> entry : attributes.entrySet()) {
+            if (entry.getValue() != null) {
+                addGlobalAttribute(entry.getKey(), entry.getValue());
+            }
         }
-
-        this.eventSourceAttributes = eventSourceAttributes;
+        //We set this so the analytics client knows what to remove from
+        //from the globalAttributes collection when it's time to clear it
+        this.eventSourceAttributes = attributes;
     }
 
     /**
-     * Clears Pinpoint attributes
+     * Removes the attributes currently stored in eventSourceAttributes
+     * from the globalAttributes collection. This is typically called
+     * when we want to switch which event source (campaign, journey, or other future
+     * pinpoint construct) pinpoint events are attributed to.
      * <p>
      * You should not use this method as it will be called by the NotificationManager when the app is opened
      * from a push notification.
      */
-    public void clearEventSourceAttributes() {
+    void clearEventSourceAttributes() {
         for (final String key : eventSourceAttributes.keySet()) {
             this.removeGlobalAttribute(key);
         }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SessionClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SessionClient.java
@@ -211,7 +211,7 @@ public class SessionClient {
         this.pinpointContext.getAnalyticsClient().recordEvent(e);
 
         // clear the global campaign attributes.
-        this.pinpointContext.getAnalyticsClient().clearCampaignAttributes();
+        this.pinpointContext.getAnalyticsClient().clearPinpointAttributes();
 
         // Kill Session Object
         session = null;

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SessionClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/analytics/SessionClient.java
@@ -211,7 +211,7 @@ public class SessionClient {
         this.pinpointContext.getAnalyticsClient().recordEvent(e);
 
         // clear the global campaign attributes.
-        this.pinpointContext.getAnalyticsClient().clearPinpointAttributes();
+        this.pinpointContext.getAnalyticsClient().clearEventSourceAttributes();
 
         // Kill Session Object
         session = null;

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClient.java
@@ -44,12 +44,12 @@ final class ADMNotificationClient extends NotificationClientBase {
 
 
     @Override
-    protected PendingIntent createOpenAppPendingIntent(final Bundle pushBundle, final Class<?> targetClass, final String campaignId,
+    protected PendingIntent createOpenAppPendingIntent(final Bundle pushBundle, final Class<?> targetClass, final String eventSourceId,
                                                        final int requestId, final String intentAction) {
         PendingIntent contentIntent = null;
         if (intentAction.equals(NotificationClient.ADM_INTENT_ACTION)) {
             contentIntent = PendingIntent.getService(pinpointContext.getApplicationContext(), requestId,
-                    this.notificationIntent(pushBundle, campaignId, requestId, NotificationClient.ADM_INTENT_ACTION,
+                    this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.ADM_INTENT_ACTION,
                             targetClass), PendingIntent.FLAG_ONE_SHOT);
         }
         return contentIntent;

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClient.java
@@ -37,11 +37,11 @@ final class BaiduNotificationClient extends NotificationClientBase {
     }
 
     @Override
-    protected PendingIntent createOpenAppPendingIntent(Bundle pushBundle, Class<?> targetClass, String campaignId, int requestId, String intentAction) {
+    protected PendingIntent createOpenAppPendingIntent(Bundle pushBundle, Class<?> targetClass, String eventSourceId, int requestId, String intentAction) {
         PendingIntent contentIntent = null;
         if (NotificationClient.BAIDU_INTENT_ACTION.equals(intentAction)) {
             contentIntent = PendingIntent.getBroadcast(pinpointContext.getApplicationContext(), requestId,
-                    this.notificationIntent(pushBundle, campaignId, requestId, NotificationClient.BAIDU_INTENT_ACTION,
+                    this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.BAIDU_INTENT_ACTION,
                             targetClass), PendingIntent.FLAG_ONE_SHOT);
             PinpointNotificationReceiver.setNotificationClient(this);
         }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
@@ -33,7 +33,7 @@ import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.Not
 import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.JOURNEY_ACTIVITY_ID_ATTRIBUTE_KEY;
 import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.JOURNEY_ID_ATTRIBUTE_KEY;
 
-public class EventSourceType {
+class EventSourceType {
     private static final String TAG = EventSourceType.class.getSimpleName();
     private static final String AWS_EVENT_TYPE_OPENED = "opened_notification";
     private static final String AWS_EVENT_TYPE_RECEIVED_FOREGROUND = "received_foreground";

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
@@ -40,6 +40,12 @@ class EventSourceType {
     private static final String AWS_EVENT_TYPE_RECEIVED_BACKGROUND = "received_background";
     private static final String PINPOINT_ATTRIBUTE_KEY = "pinpoint";
     private static final String JOURNEY_ATTRIBUTE_KEY = "journey";
+    private static final String CAMPAIGN_EVENT_SOURCE_NAME = "campaign";
+    private static final String JOURNEY_EVENT_SOURCE_NAME = "journey";
+    private static final String CAMPAIGN_EVENT_SOURCE_PREFIX = "_campaign";
+    private static final String JOURNEY_EVENT_SOURCE_PREFIX = "_journey";
+    static final String UNKNOWN_EVENT_SOURCE_NAME = "unknown";
+
     private final EventSourceAttributeParser attributeParser;
     private String eventSourceName;
     private String eventTypeOpenend;
@@ -49,12 +55,7 @@ class EventSourceType {
     private String eventSourceActivityIdAttributeKey;
     private String eventSourceKeyPrefix;
 
-    private static final String CAMPAIGN_EVENT_SOURCE_NAME = "campaign";
-    private static final String JOURNEY_EVENT_SOURCE_NAME = "journey";
-    static final String UNKNOWN_EVENT_SOURCE_NAME = "unknown";
 
-    private static final String CAMPAIGN_EVENT_SOURCE_PREFIX = "_campaign";
-    private static final String JOURNEY_EVENT_SOURCE_PREFIX = "_journey";
 
     private static EventSourceType CAMPAIGN = new EventSourceType(CAMPAIGN_EVENT_SOURCE_NAME,
             CAMPAIGN_EVENT_SOURCE_PREFIX,

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
@@ -47,13 +47,13 @@ final class EventSourceType {
     private static final String UNKNOWN_EVENT_SOURCE_NAME = "unknown";
 
     private final EventSourceAttributeParser attributeParser;
-    private String eventSourceName;
-    private String eventTypeOpenend;
-    private String eventTypeReceivedForeground;
-    private String eventTypeReceivedBackground;
-    private String eventSourceIdAttributeKey;
-    private String eventSourceActivityIdAttributeKey;
-    private String eventSourceKeyPrefix;
+    private final String eventSourceName;
+    private final String eventTypeOpenend;
+    private final String eventTypeReceivedForeground;
+    private final String eventTypeReceivedBackground;
+    private final String eventSourceIdAttributeKey;
+    private final String eventSourceActivityIdAttributeKey;
+    private final String eventSourceKeyPrefix;
 
     private static EventSourceType CAMPAIGN = new EventSourceType(CAMPAIGN_EVENT_SOURCE_NAME,
             CAMPAIGN_EVENT_SOURCE_PREFIX,

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2016-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.mobileconnectors.pinpoint.targeting.notification;
+
+import android.os.Bundle;
+import android.util.Log;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.CAMPAIGN_ACTIVITY_ID_ATTRIBUTE_KEY;
+import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.CAMPAIGN_ID_ATTRIBUTE_KEY;
+import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.CAMPAIGN_PUSH_KEY_PREFIX;
+import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.JOURNEY_ACTIVITY_ID_ATTRIBUTE_KEY;
+import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.JOURNEY_ID_ATTRIBUTE_KEY;
+
+public class EventSourceType {
+    private static final String TAG = EventSourceType.class.getSimpleName();
+    private static final String AWS_EVENT_TYPE_OPENED = "opened_notification";
+    private static final String AWS_EVENT_TYPE_RECEIVED_FOREGROUND = "received_foreground";
+    private static final String AWS_EVENT_TYPE_RECEIVED_BACKGROUND = "received_background";
+    private static final String PINPOINT_ATTRIBUTE_KEY = "pinpoint";
+    private static final String JOURNEY_ATTRIBUTE_KEY = "journey";
+    private final EventSourceAttributeParser attributeParser;
+    private String eventSourceName;
+    private String eventTypeOpenend;
+    private String eventTypeReceivedForeground;
+    private String eventTypeReceivedBackground;
+    private String eventSourceIdAttributeKey;
+    private String eventSourceActivityIdAttributeKey;
+    private String eventSourceKeyPrefix;
+
+    /**
+     * Campaign attributes are send from pinpoint flattened
+     * For example:
+     *  "pinpoint.campaign.campaign_id"
+     * Journey attributes come in JSON format
+     * This interface just seeks to abstract some of that away
+     * from the logic that handles the notfication
+     * @return
+     */
+    public interface EventSourceAttributeParser {
+        Map<String, String> getEventSourceAttributes(Bundle bundle);
+    }
+
+    private static final EventSourceAttributeParser CAMPAIGN_PARSER = new EventSourceAttributeParser() {
+        @Override
+        public Map<String, String> getEventSourceAttributes(Bundle bundle) {
+            if(bundle == null) {
+                return null;
+            }
+            final Map<String, String> campaignAttributes = new HashMap<>();
+            String campaignKeyPrefix = CAMPAIGN.getEventSourceKeyPrefix();
+
+            for(String key : bundle.keySet()) {
+                if (key.startsWith(campaignKeyPrefix)) {
+                    //If it matches the prefix, include it in the attributes
+                    //after stripping out the prefix
+                    campaignAttributes.put(key.replace(campaignKeyPrefix,""), bundle.getString(key));
+                }
+            }
+            return campaignAttributes.size() > 0 ? campaignAttributes : null;
+        }
+    };
+
+    private static final EventSourceAttributeParser JOURNEY_PARSER = new EventSourceAttributeParser() {
+        @Override
+        public Map<String, String> getEventSourceAttributes(Bundle bundle) {
+            String pinpointPayload = bundle.getString(PINPOINT_ATTRIBUTE_KEY);
+            if(pinpointPayload == null) {
+                return null;
+            }
+            Map<String, String> result = null;
+            try {
+                JsonElement pinpointJson = new JsonParser().parse(pinpointPayload);
+                JsonElement journeyJson = pinpointJson.getAsJsonObject().get(JOURNEY_ATTRIBUTE_KEY);
+                if(journeyJson == null) {
+                    return null;
+                }
+                result = new HashMap<>();
+                for(Map.Entry entry : journeyJson.getAsJsonObject().entrySet()) {
+                    result.put((String) entry.getKey(), ((JsonPrimitive)entry.getValue()).getAsString());
+                }
+            } catch(JsonSyntaxException ex) {
+                Log.w(TAG, "Exception attempting to parse pinpoint JSON payload.", ex);
+                Log.v(TAG, "Payload: "+pinpointPayload);
+                return null;
+            }
+
+            return result;
+        }
+    };
+
+    public static EventSourceType CAMPAIGN = new EventSourceType("campaign",
+            "_campaign",
+            CAMPAIGN_ID_ATTRIBUTE_KEY,
+            CAMPAIGN_ACTIVITY_ID_ATTRIBUTE_KEY,
+            CAMPAIGN_PUSH_KEY_PREFIX,
+            CAMPAIGN_PARSER);
+    public static EventSourceType JOURNEY = new EventSourceType("journey",
+            "_journey",
+            JOURNEY_ID_ATTRIBUTE_KEY,
+            JOURNEY_ACTIVITY_ID_ATTRIBUTE_KEY,
+            null,
+            JOURNEY_PARSER);
+
+    public static EventSourceType getEventSourceType(Bundle bundle) {
+        if(bundle == null) {
+            return null;
+        }
+        if(bundle.containsKey(CAMPAIGN.getEventSourceKeyPrefix()+CAMPAIGN.getEventSourceIdAttributeKey())) {
+            return CAMPAIGN;
+        } else {
+            return JOURNEY;
+        }
+    }
+
+    public static Map<String, String> getEventSourceAttributes(Bundle bundle) {
+        if(bundle == null) {
+            return null;
+        }
+        if(bundle.containsKey(CAMPAIGN.getEventSourceKeyPrefix()+CAMPAIGN.getEventSourceIdAttributeKey())) {
+            return CAMPAIGN_PARSER.getEventSourceAttributes(bundle);
+        } else {
+            return JOURNEY_PARSER.getEventSourceAttributes(bundle);
+        }
+    }
+
+    private EventSourceType(String eventSourceName,
+                            String eventSourcePrefix,
+                            String eventSourceIdAttributeKey,
+                            String eventSourceActivityIdAttributeKey,
+                            String eventSourceKeyPrefix,
+                            EventSourceAttributeParser attributeParser) {
+        this.eventSourceName = eventSourceName;
+        this.eventTypeOpenend = eventSourcePrefix+"." + AWS_EVENT_TYPE_OPENED;
+        this.eventTypeReceivedBackground = eventSourcePrefix+"." + AWS_EVENT_TYPE_RECEIVED_BACKGROUND;
+        this.eventTypeReceivedForeground = eventSourcePrefix+"." + AWS_EVENT_TYPE_RECEIVED_FOREGROUND;
+        this.eventSourceIdAttributeKey = eventSourceIdAttributeKey;
+        this.eventSourceActivityIdAttributeKey = eventSourceActivityIdAttributeKey;
+        this.eventSourceKeyPrefix = eventSourceKeyPrefix;
+        this.attributeParser = attributeParser;
+    }
+
+    public EventSourceAttributeParser getAttributeParser() {
+        return attributeParser;
+    }
+
+    public String getEventSourceName() {
+        return eventSourceName;
+    }
+
+    public String getEventTypeOpenend() {
+        return eventTypeOpenend;
+    }
+
+    public String getEventTypeReceivedForeground() {
+        return eventTypeReceivedForeground;
+    }
+
+    public String getEventTypeReceivedBackground() {
+        return eventTypeReceivedBackground;
+    }
+
+    public String getEventSourceIdAttributeKey() {
+        return eventSourceIdAttributeKey;
+    }
+
+    public String getEventSourceActivityIdAttributeKey() {
+        return eventSourceActivityIdAttributeKey;
+    }
+
+    public String getEventSourceKeyPrefix() {
+        return eventSourceKeyPrefix;
+    }
+}

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/EventSourceType.java
@@ -33,7 +33,7 @@ import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.Not
 import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.JOURNEY_ACTIVITY_ID_ATTRIBUTE_KEY;
 import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClientBase.JOURNEY_ID_ATTRIBUTE_KEY;
 
-class EventSourceType {
+final class EventSourceType {
     private static final String TAG = EventSourceType.class.getSimpleName();
     private static final String AWS_EVENT_TYPE_OPENED = "opened_notification";
     private static final String AWS_EVENT_TYPE_RECEIVED_FOREGROUND = "received_foreground";
@@ -44,7 +44,7 @@ class EventSourceType {
     private static final String JOURNEY_EVENT_SOURCE_NAME = "journey";
     private static final String CAMPAIGN_EVENT_SOURCE_PREFIX = "_campaign";
     private static final String JOURNEY_EVENT_SOURCE_PREFIX = "_journey";
-    static final String UNKNOWN_EVENT_SOURCE_NAME = "unknown";
+    private static final String UNKNOWN_EVENT_SOURCE_NAME = "unknown";
 
     private final EventSourceAttributeParser attributeParser;
     private String eventSourceName;
@@ -54,8 +54,6 @@ class EventSourceType {
     private String eventSourceIdAttributeKey;
     private String eventSourceActivityIdAttributeKey;
     private String eventSourceKeyPrefix;
-
-
 
     private static EventSourceType CAMPAIGN = new EventSourceType(CAMPAIGN_EVENT_SOURCE_NAME,
             CAMPAIGN_EVENT_SOURCE_PREFIX,
@@ -105,6 +103,10 @@ class EventSourceType {
         this.eventSourceActivityIdAttributeKey = eventSourceActivityIdAttributeKey;
         this.eventSourceKeyPrefix = eventSourceKeyPrefix;
         this.attributeParser = attributeParser;
+    }
+
+    boolean isUnkown() {
+        return UNKNOWN_EVENT_SOURCE_NAME.equals(this.eventSourceName);
     }
 
     EventSourceAttributeParser getAttributeParser() {

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClient.java
@@ -30,7 +30,7 @@ final class GCMNotificationClient extends NotificationClientBase {
     /**
      * Constructor.
      *
-     * @param pinpointContext the pinpoint context. {@link PinpointContext}
+     * @param pinpointContext the Pinpoint context. {@link PinpointContext}
      */
     protected GCMNotificationClient(PinpointContext pinpointContext) {
         super(pinpointContext);

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClient.java
@@ -42,16 +42,16 @@ final class GCMNotificationClient extends NotificationClientBase {
     }
 
     @Override
-    protected PendingIntent createOpenAppPendingIntent(final Bundle pushBundle, final Class<?> targetClass, final String campaignId,
+    protected PendingIntent createOpenAppPendingIntent(final Bundle pushBundle, final Class<?> targetClass, final String eventSourceId,
                                                      final int requestId, final String intentAction) {
         PendingIntent contentIntent = null;
         if (intentAction.equals(NotificationClient.GCM_INTENT_ACTION)) {
             contentIntent = PendingIntent.getService(pinpointContext.getApplicationContext(), requestId,
-                    this.notificationIntent(pushBundle, campaignId, requestId, NotificationClient.GCM_INTENT_ACTION,
+                    this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.GCM_INTENT_ACTION,
                             targetClass), PendingIntent.FLAG_ONE_SHOT);
         } else {
             contentIntent = PendingIntent.getBroadcast(pinpointContext.getApplicationContext(), requestId,
-                    this.notificationIntent(pushBundle, campaignId, requestId, NotificationClient.FCM_INTENT_ACTION,
+                    this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.FCM_INTENT_ACTION,
                             targetClass), PendingIntent.FLAG_ONE_SHOT);
             PinpointNotificationReceiver.setNotificationClient(this);
         }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -324,15 +324,15 @@ public class NotificationClient {
         SILENT
     }
 
-    PinpointPushResult handleNotificationOpen(Map<String, String> campaignAttributes,
+    PinpointPushResult handleNotificationOpen(Map<String, String> eventSourceAttributes,
                                               final Bundle data) {
         return notificationClientBase
-                .handleNotificationOpen(campaignAttributes, data);
+                .handleNotificationOpen(eventSourceAttributes, data);
     }
 
-    int getNotificationRequestId(final String campaignId,
+    int getNotificationRequestId(final String eventSourceId,
                                  final String activityId) {
         return notificationClientBase
-                .getNotificationRequestId(campaignId, activityId);
+                .getNotificationRequestId(eventSourceId, activityId);
     }
 }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -89,7 +89,7 @@ public class NotificationClient {
     /**
      * Constructor.
      *
-     * @param pinpointContext the pinpoint context. {@link PinpointContext}
+     * @param pinpointContext the Pinpoint context. {@link PinpointContext}
      * @deprecated Use {@link #createClient(PinpointContext, ChannelType)} instead.
      */
     @Deprecated
@@ -151,7 +151,7 @@ public class NotificationClient {
     }
 
     /**
-     * Handles pinpoint FCM push messages by posting a local notification when
+     * Handles Pinpoint FCM push messages by posting a local notification when
      * the app is in the background, or sending a local broadcast if the app is
      * in the foreground. Also on Api level 19 devices and above, if local
      * notifications have been disabled and the app is in the background, a
@@ -164,18 +164,18 @@ public class NotificationClient {
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
      */
     @Deprecated
-    public PinpointPushResult handleFCMCampaignPush(final String from,
+    public CampaignPushResult handleFCMCampaignPush(final String from,
                                                     final Map<String, String> data) {
         NotificationDetails.NotificationDetailsBuilder notificationDetailsBuilder =
                 NotificationDetails.builder()
                 .from(from)
                 .mapData(data)
                 .intentAction(FCM_INTENT_ACTION);
-        return notificationClientBase.handleCampaignPush(notificationDetailsBuilder.build());
+        return handleCampaignPush(notificationDetailsBuilder.build());
     }
 
     /**
-     * Handles pinpoint GCM push messages by posting a local notification when
+     * Handles Pinpoint GCM push messages by posting a local notification when
      * the app is in the background, or sending a local broadcast if the app is
      * in the foreground. Also on Api level 19 devices and above, if local
      * notifications have been disabled and the app is in the background, a
@@ -190,14 +190,14 @@ public class NotificationClient {
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
      */
     @Deprecated
-    public PinpointPushResult handleGCMCampaignPush(final String from, final Bundle data, final Class<? extends Service> serviceClass) {
+    public CampaignPushResult handleGCMCampaignPush(final String from, final Bundle data, final Class<? extends Service> serviceClass) {
         NotificationDetails.NotificationDetailsBuilder notificationDetailsBuilder =
                 NotificationDetails.builder()
                 .from(from)
                 .bundle(data)
                 .serviceClass(serviceClass)
                 .intentAction(GCM_INTENT_ACTION);
-        return notificationClientBase.handleCampaignPush(notificationDetailsBuilder.build());
+        return handleCampaignPush(notificationDetailsBuilder.build());
     }
 
     /**
@@ -277,7 +277,7 @@ public class NotificationClient {
     }
 
     /**
-     * Handles pinpoint push messages by posting a local notification when
+     * Handles Pinpoint push messages by posting a local notification when
      * the app is in the background, or sending a local broadcast if the app is
      * in the foreground. Also on Api level 19 devices and above, if local
      * notifications have been disabled and the app is in the background, a
@@ -295,14 +295,24 @@ public class NotificationClient {
      * @deprecated see {@link #handlePushNotification(NotificationDetails)}
      */
     @Deprecated
-    public PinpointPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
-        return notificationClientBase.handlePushNotification(notificationDetails);
+    public CampaignPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
+        return CampaignPushResult.valueOf(notificationClientBase.handlePushNotification(notificationDetails).toString());
     }
 
-
+    /**
+     * @deprecated see {@link PinpointPushResult}
+     */
+    public enum CampaignPushResult {
+        NOT_HANDLED,
+        POSTED_NOTIFICATION,
+        APP_IN_FOREGROUND,
+        OPTED_OUT,
+        NOTIFICATION_OPENED,
+        SILENT
+    }
 
     /**
-     * Result values of handling a pinpoint push message.
+     * Result values of handling a Pinpoint push message.
      */
     public enum PinpointPushResult {
         /**

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -159,12 +159,12 @@ public class NotificationClient {
      *
      * @param from the from string received by the FCM service,
      * @param data the bundle received from the FCM service
-     * @return {@link CampaignPushResult}.
+     * @return {@link PinpointPushResult}.
      *
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
      */
     @Deprecated
-    public CampaignPushResult handleFCMCampaignPush(final String from,
+    public PinpointPushResult handleFCMCampaignPush(final String from,
                                                     final Map<String, String> data) {
         NotificationDetails.NotificationDetailsBuilder notificationDetailsBuilder =
                 NotificationDetails.builder()
@@ -185,12 +185,12 @@ public class NotificationClient {
      * @param data         the bundle received from the GCM service
      * @param serviceClass the class extending GCMListenerService that handles
      *                     receiving GCM messages.
-     * @return {@link CampaignPushResult}.
+     * @return {@link PinpointPushResult}.
      *
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
      */
     @Deprecated
-    public CampaignPushResult handleGCMCampaignPush(final String from, final Bundle data, final Class<? extends Service> serviceClass) {
+    public PinpointPushResult handleGCMCampaignPush(final String from, final Bundle data, final Class<? extends Service> serviceClass) {
         NotificationDetails.NotificationDetailsBuilder notificationDetailsBuilder =
                 NotificationDetails.builder()
                 .from(from)
@@ -284,16 +284,16 @@ public class NotificationClient {
      * local broadcast is sent.
      *
      * @param notificationDetails the notification message received by the device's messaging service
-     * @return {@link NotificationClient.CampaignPushResult}.
+     * @return {@link PinpointPushResult}.
      */
-    public CampaignPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
+    public PinpointPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
         return notificationClientBase.handleCampaignPush(notificationDetails);
     }
 
     /**
      * Result values of handling a pinpoint push message.
      */
-    public enum CampaignPushResult {
+    public enum PinpointPushResult {
         /**
          * The message wasn't for pinpoint.
          */
@@ -324,7 +324,7 @@ public class NotificationClient {
         SILENT
     }
 
-    CampaignPushResult handleNotificationOpen(Map<String, String> campaignAttributes,
+    PinpointPushResult handleNotificationOpen(Map<String, String> campaignAttributes,
                                               final Bundle data) {
         return notificationClientBase
                 .handleNotificationOpen(campaignAttributes, data);

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -285,10 +285,21 @@ public class NotificationClient {
      *
      * @param notificationDetails the notification message received by the device's messaging service
      * @return {@link PinpointPushResult}.
+     *
      */
-    public PinpointPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
-        return notificationClientBase.handleCampaignPush(notificationDetails);
+    public PinpointPushResult handlePushNotification(final NotificationDetails notificationDetails) {
+        return notificationClientBase.handlePushNotification(notificationDetails);
     }
+
+    /**
+     * @deprecated see {@link #handlePushNotification(NotificationDetails)}
+     */
+    @Deprecated
+    public PinpointPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
+        return notificationClientBase.handlePushNotification(notificationDetails);
+    }
+
+
 
     /**
      * Result values of handling a pinpoint push message.

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -302,6 +302,7 @@ public class NotificationClient {
     /**
      * @deprecated see {@link PushResult}
      */
+    @Deprecated
     public enum CampaignPushResult {
         NOT_HANDLED,
         POSTED_NOTIFICATION,

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -159,7 +159,7 @@ public class NotificationClient {
      *
      * @param from the from string received by the FCM service,
      * @param data the bundle received from the FCM service
-     * @return {@link PinpointPushResult}.
+     * @return {@link PushResult}.
      *
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
      */
@@ -185,7 +185,7 @@ public class NotificationClient {
      * @param data         the bundle received from the GCM service
      * @param serviceClass the class extending GCMListenerService that handles
      *                     receiving GCM messages.
-     * @return {@link PinpointPushResult}.
+     * @return {@link PushResult}.
      *
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
      */
@@ -284,10 +284,10 @@ public class NotificationClient {
      * local broadcast is sent.
      *
      * @param notificationDetails the notification message received by the device's messaging service
-     * @return {@link PinpointPushResult}.
+     * @return {@link PushResult}.
      *
      */
-    public PinpointPushResult handlePushNotification(final NotificationDetails notificationDetails) {
+    public PushResult handlePushNotification(final NotificationDetails notificationDetails) {
         return notificationClientBase.handlePushNotification(notificationDetails);
     }
 
@@ -300,7 +300,7 @@ public class NotificationClient {
     }
 
     /**
-     * @deprecated see {@link PinpointPushResult}
+     * @deprecated see {@link PushResult}
      */
     public enum CampaignPushResult {
         NOT_HANDLED,
@@ -314,7 +314,7 @@ public class NotificationClient {
     /**
      * Result values of handling a Pinpoint push message.
      */
-    public enum PinpointPushResult {
+    public enum PushResult {
         /**
          * The message wasn't for pinpoint.
          */
@@ -345,8 +345,8 @@ public class NotificationClient {
         SILENT
     }
 
-    PinpointPushResult handleNotificationOpen(Map<String, String> eventSourceAttributes,
-                                              final Bundle data) {
+    PushResult handleNotificationOpen(Map<String, String> eventSourceAttributes,
+                                      final Bundle data) {
         return notificationClientBase
                 .handleNotificationOpen(eventSourceAttributes, data);
     }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -287,16 +287,16 @@ public class NotificationClient {
      * @return {@link PushResult}.
      *
      */
-    public PushResult handlePushNotification(final NotificationDetails notificationDetails) {
-        return notificationClientBase.handlePushNotification(notificationDetails);
+    public PushResult handleNotificationReceived(final NotificationDetails notificationDetails) {
+        return notificationClientBase.handleNotificationReceived(notificationDetails);
     }
 
     /**
-     * @deprecated see {@link #handlePushNotification(NotificationDetails)}
+     * @deprecated see {@link #handleNotificationReceived(NotificationDetails)}
      */
     @Deprecated
     public CampaignPushResult handleCampaignPush(final NotificationDetails notificationDetails) {
-        return CampaignPushResult.valueOf(notificationClientBase.handlePushNotification(notificationDetails).toString());
+        return CampaignPushResult.valueOf(notificationClientBase.handleNotificationReceived(notificationDetails).toString());
     }
 
     /**

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -859,7 +859,7 @@ abstract class NotificationClientBase {
      */
     public NotificationClient.PushResult handleNotificationReceived(NotificationDetails notificationDetails) {
         final EventSourceType eventSourceType = EventSourceType.getEventSourceType(notificationDetails.getBundle());
-        if (EventSourceType.UNKNOWN_EVENT_SOURCE_NAME.equals(eventSourceType.getEventSourceName())) {
+        if (eventSourceType.isUnkown()) {
             return NotificationClient.PushResult.NOT_HANDLED;
         }
 

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -108,10 +108,6 @@ abstract class NotificationClientBase {
     private static final int ANDROID_OREO = 26;
     private static final int NOTIFICATION_CHANNEL_IMPORTANCE = 4; //IMPORTANCE_HIGH = 4. This corresponds to PRIORITY_HIGH (value 1) in NotificationBuilder. setPriority is deprecated in API 26
 
-    private static final String CAMPAIGN_AWS_EVENT_TYPE_OPENED = "_campaign.opened_notification";
-    private static final String CAMPAIGN_AWS_EVENT_TYPE_RECEIVED_FOREGROUND = "_campaign.received_foreground";
-    private static final String CAMPAIGN_AWS_EVENT_TYPE_RECEIVED_BACKGROUND = "_campaign.received_background";
-    private static final String JOURNEY_AWS_EVENT_TYPE_OPENED = "_journey.opened_notification";
     private static final String CHECK_OP_NO_THROW = "checkOpNoThrow";
     private static final String OP_POST_NOTIFICATION = "OP_POST_NOTIFICATION";
     private static final String APP_OPS_MODE_ALLOWED = "MODE_ALLOWED";
@@ -155,7 +151,7 @@ abstract class NotificationClientBase {
     /**
      * Constructor.
      *
-     * @param pinpointContext the pinpoint context. {@link PinpointContext}
+     * @param pinpointContext the Pinpoint context. {@link PinpointContext}
      */
     protected NotificationClientBase(final PinpointContext pinpointContext) {
         this.pinpointContext = pinpointContext;
@@ -657,7 +653,7 @@ abstract class NotificationClientBase {
      *
      * @param data             the data to push
      * @param intentReceiver   the class that handles receiving messages.
-     * @param eventSourceId       pinpoint campaign/journey id
+     * @param eventSourceId       Pinpoint campaign/journey id
      * @param requestId        request id
      * @param intentAction     intent action
      * @return {@link PendingIntent}
@@ -675,7 +671,7 @@ abstract class NotificationClientBase {
      * intent.
      *
      * @param data the data to push
-     * @param eventSourceId identifies the pinpoint campaign
+     * @param eventSourceId identifies the Pinpoint campaign
      * @param requestId identifies the notification request
      * @param intentAction specifies the action of the intent
      * @param intentReceiver the target class that handles receiving messages.
@@ -870,7 +866,7 @@ abstract class NotificationClientBase {
     }
 
     /**
-     * Handles pinpoint push messages by posting a local notification when
+     * Handles Pinpoint push messages by posting a local notification when
      * the app is in the background, or sending a local broadcast if the app is
      * in the foreground. Also on Api level 19 devices and above, if local
      * notifications have been disabled and the app is in the background, a
@@ -881,13 +877,13 @@ abstract class NotificationClientBase {
      */
     public NotificationClient.PinpointPushResult handlePushNotification(NotificationDetails notificationDetails) {
         final EventSourceType eventSourceType = EventSourceType.getEventSourceType(notificationDetails.getBundle());
-        if(eventSourceType == null) {
+        if (EventSourceType.UNKNOWN_EVENT_SOURCE_NAME.equals(eventSourceType.getEventSourceName())) {
             return NotificationClient.PinpointPushResult.NOT_HANDLED;
         }
 
         final Bundle bundle = notificationDetails.getBundle();
-        Map<String, String> eventSourceAttributes = eventSourceType.getAttributeParser().getEventSourceAttributes(bundle);
-        if(eventSourceAttributes == null) {
+        Map<String, String> eventSourceAttributes = eventSourceType.getAttributeParser().parseAttributes(bundle);
+        if (eventSourceAttributes.isEmpty()) {
             return NotificationClient.PinpointPushResult.NOT_HANDLED;
         }
 

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -241,8 +241,8 @@ abstract class NotificationClientBase {
     public abstract String getChannelType();
 
     private void addGlobalEventSourceAttributes(
-        final Map<String, String> campaignAttribs) {
-        for (final Map.Entry<String, String> entry : campaignAttribs.entrySet()) {
+        final Map<String, String> eventSourceAttributes) {
+        for (final Map.Entry<String, String> entry : eventSourceAttributes.entrySet()) {
             if (entry.getValue() != null) {
                 this.pinpointContext.getAnalyticsClient().addGlobalAttribute(entry.getKey(), entry.getValue());
             }
@@ -703,7 +703,7 @@ abstract class NotificationClientBase {
     int getNotificationRequestId(final String eventSourceId,
                                  final String activityId) {
         // Adding a random unique identifier for direct sends. For a campaign,
-        // use the campaignId and the activityId in order to prevent displaying
+        // use the eventSourceId and the activityId in order to prevent displaying
         // duplicate notifications from a campaign activity.
         if (DIRECT_CAMPAIGN_SEND.equals(eventSourceId) && activityId == null) {
             return random.nextInt();
@@ -880,7 +880,7 @@ abstract class NotificationClientBase {
             }
             final String openApp = data.getString(EVENT_SOURCE_OPEN_APP_PUSH_KEY);
             if (openApp == null) {
-                log.warn("No key/value present to determine action for campaign notification, default to open app.");
+                log.warn("No key/value present to determine action for pinpoint notification, default to open app.");
             }
             openApp();
         }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -239,36 +239,6 @@ abstract class NotificationClientBase {
      */
     public abstract String getChannelType();
 
-    /**
-     * Replaces the current event source attributes (if any)
-     * with a new set of event source attributes
-     * @param attributes map of attribute values
-     */
-    private void updateEventSourceGlobally(final Map<String, String> attributes) {
-        //This call removes previous events identifiers from the
-        //globalAttributes collection in AnalyticsEvent.
-        pinpointContext.getAnalyticsClient().clearEventSourceAttributes();
-        addGlobalAttributes(attributes);
-        //This adds to the eventSourceAttributes collection
-        //so the analytics client knows what to remove from
-        //from the globalAttributes collection
-        pinpointContext.getAnalyticsClient().setEventSourceAttributes(attributes);
-    }
-
-    /**
-     * Adds the items in the input attributes collection
-     * to the AnalyticsClient's globalAttributes collection
-     * @param attributes map of attribute values
-     */
-    private void addGlobalAttributes(
-        final Map<String, String> attributes) {
-        for (final Map.Entry<String, String> entry : attributes.entrySet()) {
-            if (entry.getValue() != null) {
-                this.pinpointContext.getAnalyticsClient().addGlobalAttribute(entry.getKey(), entry.getValue());
-            }
-        }
-    }
-
     private Resources getPackageResources() {
         final PackageManager packageManager = pinpointContext.getApplicationContext().getPackageManager();
         try {
@@ -851,7 +821,7 @@ abstract class NotificationClientBase {
             if (this.pinpointContext.getSessionClient() != null) {
                 this.pinpointContext.getSessionClient().stopSession();
             }
-            updateEventSourceGlobally(eventSourceAttributes);
+            this.pinpointContext.getAnalyticsClient().updateEventSourceGlobally(eventSourceAttributes);
 
             String eventType = eventSourceType.getEventTypeOpenend();
             final AnalyticsEvent pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventType);
@@ -919,7 +889,7 @@ abstract class NotificationClientBase {
         if (isAppInForeground) {
             pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventSourceType.getEventTypeReceivedForeground());
         } else {
-            updateEventSourceGlobally(eventSourceAttributes);
+            this.pinpointContext.getAnalyticsClient().updateEventSourceGlobally(eventSourceAttributes);
             pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventSourceType.getEventTypeReceivedBackground());
         }
         pushEvent.addAttribute("isAppInForeground", Boolean.toString(isAppInForeground));

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -93,9 +93,9 @@ abstract class NotificationClientBase {
     private static final String PINPOINT_IMAGE_SMALL_ICON_PUSH_KEY =
         GCM_NOTIFICATION_PUSH_KEY_PREFIX + "imageSmallIconUrl";
     // Engage Attributes
-    private static final String CAMPAIGN_URL_PUSH_KEY = PINPOINT_PUSH_KEY_PREFIX + "url";
-    private static final String CAMPAIGN_DEEP_LINK_PUSH_KEY = PINPOINT_PUSH_KEY_PREFIX + "deeplink";
-    private static final String CAMPAIGN_OPEN_APP_PUSH_KEY = PINPOINT_PUSH_KEY_PREFIX + "openApp";
+    private static final String EVENT_SOURCE_URL_PUSH_KEY = PINPOINT_PUSH_KEY_PREFIX + "url";
+    private static final String EVENT_SOURCE_DEEP_LINK_PUSH_KEY = PINPOINT_PUSH_KEY_PREFIX + "deeplink";
+    private static final String EVENT_SOURCE_OPEN_APP_PUSH_KEY = PINPOINT_PUSH_KEY_PREFIX + "openApp";
     private static final String REQUEST_ID = "requestId";
     private static final int INVALID_RESOURCE = 0;
     private static final int ANDROID_JELLYBEAN = 16;
@@ -240,7 +240,7 @@ abstract class NotificationClientBase {
      */
     public abstract String getChannelType();
 
-    private void addGlobalCampaignAttributes(
+    private void addGlobalEventSourceAttributes(
         final Map<String, String> campaignAttribs) {
         for (final Map.Entry<String, String> entry : campaignAttribs.entrySet()) {
             if (entry.getValue() != null) {
@@ -854,31 +854,31 @@ abstract class NotificationClientBase {
 
     /* pkg */
     NotificationClient.PinpointPushResult handleNotificationOpen(
-        Map<String, String> campaignAttributes,
+        Map<String, String> eventSourceAttributes,
         final Bundle data) {
         // Add any campaign global attributes
-        if (campaignAttributes != null) {
+        if (eventSourceAttributes != null) {
             // Stop Session
             if (this.pinpointContext.getSessionClient() != null) {
                 this.pinpointContext.getSessionClient().stopSession();
             }
-            addGlobalCampaignAttributes(campaignAttributes);
+            addGlobalEventSourceAttributes(eventSourceAttributes);
 
             final AnalyticsEvent pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(CAMPAIGN_AWS_EVENT_TYPE_OPENED);
             this.pinpointContext.getAnalyticsClient().recordEvent(pushEvent);
             this.pinpointContext.getAnalyticsClient().submitEvents();
 
-            final String url = data.getString(CAMPAIGN_URL_PUSH_KEY);
+            final String url = data.getString(EVENT_SOURCE_URL_PUSH_KEY);
             if (url != null) {
                 openURL(url, false);
                 return NotificationClient.PinpointPushResult.NOTIFICATION_OPENED;
             }
-            final String deepLink = data.getString(CAMPAIGN_DEEP_LINK_PUSH_KEY);
+            final String deepLink = data.getString(EVENT_SOURCE_DEEP_LINK_PUSH_KEY);
             if (deepLink != null) {
                 openURL(deepLink, true);
                 return NotificationClient.PinpointPushResult.NOTIFICATION_OPENED;
             }
-            final String openApp = data.getString(CAMPAIGN_OPEN_APP_PUSH_KEY);
+            final String openApp = data.getString(EVENT_SOURCE_OPEN_APP_PUSH_KEY);
             if (openApp == null) {
                 log.warn("No key/value present to determine action for campaign notification, default to open app.");
             }
@@ -920,7 +920,7 @@ abstract class NotificationClientBase {
         campaignAttributes.put(CAMPAIGN_TREATMENT_ID_ATTRIBUTE_KEY, data.getString(CAMPAIGN_TREATMENT_ID_PUSH_KEY));
         campaignAttributes.put(CAMPAIGN_ACTIVITY_ID_ATTRIBUTE_KEY, data.getString(CAMPAIGN_ACTIVITY_ID_PUSH_KEY));
 
-        this.pinpointContext.getAnalyticsClient().setPinpointAttributes(campaignAttributes);
+        this.pinpointContext.getAnalyticsClient().setEventSourceAttributes(campaignAttributes);
         log.info("Campaign Attributes are:" + campaignAttributes);
 
         if (CAMPAIGN_AWS_EVENT_TYPE_OPENED.equals(from)) {

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -922,7 +922,14 @@ abstract class NotificationClientBase {
                 if ("1".equalsIgnoreCase(bundle.getString(NOTIFICATION_SILENT_PUSH_KEY))) {
                     return NotificationClient.PushResult.SILENT;
                 }
-                addPinpointAttributesToEvent(pushEvent, eventSourceAttributes);
+                //This call removes previous events identifiers from the
+                //globalAttributes collection in AnalyticsEvent.
+                pinpointContext.getAnalyticsClient().clearEventSourceAttributes();
+                addGlobalEventSourceAttributes(eventSourceAttributes);
+                //This adds to the eventSourceAttributes collection
+                //so the analytics client knows what to remove from
+                //from the globalAttributes collection
+                pinpointContext.getAnalyticsClient().setEventSourceAttributes(eventSourceAttributes);
                 // App is in the background; attempt to display a
                 // notification in the notification center.,
                 if (!areAppNotificationsEnabled() ||

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -829,7 +829,7 @@ abstract class NotificationClientBase {
     }
 
     /* pkg */
-    NotificationClient.PinpointPushResult handleNotificationOpen(
+    NotificationClient.PushResult handleNotificationOpen(
         Map<String, String> eventSourceAttributes,
         final Bundle data) {
         // Add any campaign global attributes
@@ -849,12 +849,12 @@ abstract class NotificationClientBase {
             final String url = data.getString(EVENT_SOURCE_URL_PUSH_KEY);
             if (url != null) {
                 openURL(url, false);
-                return NotificationClient.PinpointPushResult.NOTIFICATION_OPENED;
+                return NotificationClient.PushResult.NOTIFICATION_OPENED;
             }
             final String deepLink = data.getString(EVENT_SOURCE_DEEP_LINK_PUSH_KEY);
             if (deepLink != null) {
                 openURL(deepLink, true);
-                return NotificationClient.PinpointPushResult.NOTIFICATION_OPENED;
+                return NotificationClient.PushResult.NOTIFICATION_OPENED;
             }
             final String openApp = data.getString(EVENT_SOURCE_OPEN_APP_PUSH_KEY);
             if (openApp == null) {
@@ -862,7 +862,7 @@ abstract class NotificationClientBase {
             }
             openApp();
         }
-        return NotificationClient.PinpointPushResult.NOTIFICATION_OPENED;
+        return NotificationClient.PushResult.NOTIFICATION_OPENED;
     }
 
     /**
@@ -873,18 +873,18 @@ abstract class NotificationClientBase {
      * local broadcast is sent.
      *
      * @param notificationDetails the notification message received by the device's messaging service
-     * @return {@link NotificationClient.PinpointPushResult}.
+     * @return {@link NotificationClient.PushResult}.
      */
-    public NotificationClient.PinpointPushResult handlePushNotification(NotificationDetails notificationDetails) {
+    public NotificationClient.PushResult handlePushNotification(NotificationDetails notificationDetails) {
         final EventSourceType eventSourceType = EventSourceType.getEventSourceType(notificationDetails.getBundle());
         if (EventSourceType.UNKNOWN_EVENT_SOURCE_NAME.equals(eventSourceType.getEventSourceName())) {
-            return NotificationClient.PinpointPushResult.NOT_HANDLED;
+            return NotificationClient.PushResult.NOT_HANDLED;
         }
 
         final Bundle bundle = notificationDetails.getBundle();
         Map<String, String> eventSourceAttributes = eventSourceType.getAttributeParser().parseAttributes(bundle);
         if (eventSourceAttributes.isEmpty()) {
-            return NotificationClient.PinpointPushResult.NOT_HANDLED;
+            return NotificationClient.PushResult.NOT_HANDLED;
         }
 
         final boolean isAppInForeground = appUtil.isAppInForeground();
@@ -915,12 +915,12 @@ abstract class NotificationClientBase {
             // notifications in the foreground.
             if (!pinpointContext.getPinpointConfiguration().getShouldPostNotificationsInForeground() && isAppInForeground) {
                 // Notify the caller that the app was in the foreground.
-                return NotificationClient.PinpointPushResult.APP_IN_FOREGROUND;
+                return NotificationClient.PushResult.APP_IN_FOREGROUND;
             } else {
                 // Display a notification with an icon, title, message,
                 // image, and default sound.
                 if ("1".equalsIgnoreCase(bundle.getString(NOTIFICATION_SILENT_PUSH_KEY))) {
-                    return NotificationClient.PinpointPushResult.SILENT;
+                    return NotificationClient.PushResult.SILENT;
                 }
                 addPinpointAttributesToEvent(pushEvent, eventSourceAttributes);
                 // App is in the background; attempt to display a
@@ -942,7 +942,7 @@ abstract class NotificationClientBase {
                     pushEvent.addAttribute("isOptedOut", "true");
                     // We can't post a notification, so delegate to the
                     // passed in handler.
-                    return NotificationClient.PinpointPushResult.OPTED_OUT;
+                    return NotificationClient.PushResult.OPTED_OUT;
                 }
             }
         } finally {
@@ -950,14 +950,14 @@ abstract class NotificationClientBase {
             this.pinpointContext.getAnalyticsClient().submitEvents();
         }
 
-        return NotificationClient.PinpointPushResult.POSTED_NOTIFICATION;
+        return NotificationClient.PushResult.POSTED_NOTIFICATION;
     }
 
     /**
      * @deprecated Use {@link #handlePushNotification(NotificationDetails)}instead.
      */
     @Deprecated
-    public final NotificationClient.PinpointPushResult handleCampaignPush(NotificationDetails notificationDetails) {
+    public final NotificationClient.PushResult handleCampaignPush(NotificationDetails notificationDetails) {
         return handlePushNotification(notificationDetails);
     }
 

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/PinpointNotificationReceiver.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/PinpointNotificationReceiver.java
@@ -21,11 +21,13 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.util.Log;
 
 /**
  * The Amazon Pinpoint push notification receiver.
  */
 public class PinpointNotificationReceiver extends BroadcastReceiver {
+    private static String TAG = PinpointNotificationReceiver.class.getSimpleName();
 
     private static volatile NotificationClient notificationClient = null;
 
@@ -40,17 +42,7 @@ public class PinpointNotificationReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (notificationClient != null) {
-            final String prefix = NotificationClientBase.CAMPAIGN_PUSH_KEY_PREFIX;
-            final Map<String, String> campaignAttributes = new HashMap<String, String>();
-            campaignAttributes.put(NotificationClientBase.CAMPAIGN_ID_ATTRIBUTE_KEY,
-                                   intent.getStringExtra(prefix.concat(NotificationClientBase.CAMPAIGN_ID_ATTRIBUTE_KEY)));
-            campaignAttributes
-                .put(NotificationClientBase.CAMPAIGN_TREATMENT_ID_ATTRIBUTE_KEY,
-                     intent.getStringExtra(prefix.concat(NotificationClientBase.CAMPAIGN_TREATMENT_ID_ATTRIBUTE_KEY)));
-            campaignAttributes
-                .put(NotificationClientBase.CAMPAIGN_ACTIVITY_ID_ATTRIBUTE_KEY,
-                     intent.getStringExtra(prefix.concat(NotificationClientBase.CAMPAIGN_ACTIVITY_ID_ATTRIBUTE_KEY)));
-            notificationClient.handleNotificationOpen(campaignAttributes,
+            notificationClient.handleNotificationOpen(EventSourceType.getEventSourceAttributes(intent.getExtras()),
                                                       intent.getExtras());
         } else {
             final PackageManager pm = context.getPackageManager();

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/PinpointNotificationReceiver.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/PinpointNotificationReceiver.java
@@ -42,7 +42,8 @@ public class PinpointNotificationReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (notificationClient != null) {
-            notificationClient.handleNotificationOpen(EventSourceType.getEventSourceAttributes(intent.getExtras()),
+            EventSourceType eventSourceType = EventSourceType.getEventSourceType(intent.getExtras());
+            notificationClient.handleNotificationOpen(eventSourceType.getAttributeParser().parseAttributes(intent.getExtras()),
                                                       intent.getExtras());
         } else {
             final PackageManager pm = context.getPackageManager();

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
@@ -159,7 +159,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -179,7 +179,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
 
@@ -190,7 +190,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -210,7 +210,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -230,7 +230,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -252,7 +252,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
     @Test
@@ -264,7 +264,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -286,14 +286,14 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleADMPinpointMessageOpened() throws JSONException {
-        NotificationClient.PinpointPushResult result
+        NotificationClient.CampaignPushResult result
             = target.handleCampaignPush(buildNotificationDetails("_campaign.opened_notification"));
-        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -317,9 +317,9 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
                 .serviceClass(Service.class)
                 .intentAction(NotificationClient.ADM_INTENT_ACTION);;
 
-        NotificationClient.PinpointPushResult result =
+        NotificationClient.CampaignPushResult result =
                 target.handleCampaignPush(notificationDetailsBuilder.build());
-        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
+        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
@@ -158,7 +158,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -178,7 +178,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
 
@@ -189,7 +189,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -209,7 +209,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -229,7 +229,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -251,7 +251,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -285,14 +285,14 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleADMPinpointMessageOpened() throws JSONException {
-        NotificationClient.CampaignPushResult result
+        NotificationClient.PinpointPushResult result
             = target.handleCampaignPush(buildNotificationDetails("_campaign.opened_notification"));
-        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -316,9 +316,9 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
                 .serviceClass(Service.class)
                 .intentAction(NotificationClient.ADM_INTENT_ACTION);;
 
-        NotificationClient.CampaignPushResult result =
+        NotificationClient.PinpointPushResult result =
                 target.handleCampaignPush(notificationDetailsBuilder.build());
-        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
@@ -52,6 +52,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.times;
@@ -200,11 +201,11 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(4));
+        assertThat(receivedEvent.getAllAttributes().size(), is(1));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
+        assertNull(receivedEvent.getAttribute("campaign_id"));
+        assertNull(receivedEvent.getAttribute("treatment_id"));
+        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
@@ -241,12 +241,9 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(5));
+        assertThat(receivedEvent.getAllAttributes().size(), is(2));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
@@ -49,6 +49,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.times;
@@ -200,11 +201,11 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(4));
+        assertThat(receivedEvent.getAllAttributes().size(), is(1));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
+        assertNull(receivedEvent.getAttribute("campaign_id"));
+        assertNull(receivedEvent.getAttribute("treatment_id"));
+        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
@@ -39,7 +39,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -159,7 +158,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -179,7 +178,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
 
@@ -190,7 +189,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -210,7 +209,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -230,7 +229,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -252,7 +251,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
@@ -264,7 +263,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -286,14 +285,14 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleBaiduPinpointMessageOpened() throws JSONException {
-        NotificationClient.CampaignPushResult result
+        NotificationClient.PinpointPushResult result
             = target.handleCampaignPush(buildNotificationDetails("_campaign.opened_notification"));
-        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -315,8 +314,8 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
                 .message("")
                 .intentAction(NotificationClient.BAIDU_INTENT_ACTION);
 
-        NotificationClient.CampaignPushResult result = target.handleCampaignPush(notificationDetailsBuilder.build());
-        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
+        NotificationClient.PinpointPushResult result = target.handleCampaignPush(notificationDetailsBuilder.build());
+        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
@@ -241,12 +241,9 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(5));
+        assertThat(receivedEvent.getAllAttributes().size(), is(2));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
@@ -159,7 +159,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -179,7 +179,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
 
@@ -190,7 +190,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -210,7 +210,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -230,7 +230,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -252,7 +252,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
     @Test
@@ -264,7 +264,7 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails());
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -286,14 +286,14 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleBaiduPinpointMessageOpened() throws JSONException {
-        NotificationClient.PinpointPushResult result
+        NotificationClient.CampaignPushResult result
             = target.handleCampaignPush(buildNotificationDetails("_campaign.opened_notification"));
-        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -315,8 +315,8 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
                 .message("")
                 .intentAction(NotificationClient.BAIDU_INTENT_ACTION);
 
-        NotificationClient.PinpointPushResult result = target.handleCampaignPush(notificationDetailsBuilder.build());
-        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
+        NotificationClient.CampaignPushResult result = target.handleCampaignPush(notificationDetailsBuilder.build());
+        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.times;
@@ -194,11 +195,11 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(4));
+        assertThat(receivedEvent.getAllAttributes().size(), is(1));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
+        assertNull(receivedEvent.getAttribute("campaign_id"));
+        assertNull(receivedEvent.getAttribute("treatment_id"));
+        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
@@ -153,7 +153,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -173,7 +173,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
 
@@ -184,7 +184,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -204,7 +204,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -224,7 +224,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -246,7 +246,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
     @Test
@@ -258,7 +258,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.CampaignPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -280,14 +280,14 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleFCMPinpointMessageOpened() throws JSONException {
-        NotificationClient.PinpointPushResult result
+        NotificationClient.CampaignPushResult result
             = target.handleCampaignPush(buildNotificationDetails("_campaign.opened_notification"));
-        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -310,9 +310,9 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
                 .from("_campaign.opened")
                 .mapData(map)
                 .intentAction(NotificationClient.FCM_INTENT_ACTION);
-        NotificationClient.PinpointPushResult result =
+        NotificationClient.CampaignPushResult result =
                 target.handleCampaignPush(notificationDetailsBuilder.build());
-        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
+        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
@@ -152,7 +152,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -172,7 +172,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
 
@@ -183,7 +183,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -203,7 +203,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -223,7 +223,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -245,7 +245,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
@@ -257,7 +257,7 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleCampaignPush(buildNotificationDetails("12345"));
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -279,14 +279,14 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleFCMPinpointMessageOpened() throws JSONException {
-        NotificationClient.CampaignPushResult result
+        NotificationClient.PinpointPushResult result
             = target.handleCampaignPush(buildNotificationDetails("_campaign.opened_notification"));
-        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -309,9 +309,9 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
                 .from("_campaign.opened")
                 .mapData(map)
                 .intentAction(NotificationClient.FCM_INTENT_ACTION);
-        NotificationClient.CampaignPushResult result =
+        NotificationClient.PinpointPushResult result =
                 target.handleCampaignPush(notificationDetailsBuilder.build());
-        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
@@ -235,12 +235,9 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(5));
+        assertThat(receivedEvent.getAllAttributes().size(), is(2));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
@@ -159,7 +159,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleGCMCampaignPush("12345", buildPushBundle(), Service.class);
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -179,7 +179,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
 
@@ -190,7 +190,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleGCMCampaignPush("12345", buildPushBundle(), Service.class);
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -210,7 +210,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
         // Verify the notification is not posted and instead we get the result that the app was in the foreground.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.APP_IN_FOREGROUND));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.APP_IN_FOREGROUND));
     }
 
     @Test
@@ -230,7 +230,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(true);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleGCMCampaignPush("12345", buildPushBundle(), Service.class);
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -252,7 +252,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
@@ -264,7 +264,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         Whitebox.setInternalState(target.notificationClientBase, "appUtil", appUtil);
         Mockito.when(appUtil.isAppInForeground()).thenReturn(false);
 
-        NotificationClient.CampaignPushResult pushResult
+        NotificationClient.PinpointPushResult pushResult
             = target.handleGCMCampaignPush("12345", buildPushBundle(), Service.class);
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -286,14 +286,14 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
 
         // verify that the notification is posted even though the app is in the foreground, will actually
         // be OPTED_OUT, since the test can't get the app icon id.
-        assertTrue(pushResult.equals(NotificationClient.CampaignPushResult.OPTED_OUT));
+        assertTrue(pushResult.equals(NotificationClient.PinpointPushResult.OPTED_OUT));
     }
 
     @Test
     public void testHandleGCMPinpointMessageOpened() throws JSONException {
-        NotificationClient.CampaignPushResult result
+        NotificationClient.PinpointPushResult result
             = target.handleGCMCampaignPush("_campaign.opened_notification", buildPushBundle(), Service.class);
-        assertEquals(NotificationClient.CampaignPushResult.NOTIFICATION_OPENED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOTIFICATION_OPENED, result);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());
@@ -311,10 +311,10 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
     @Test
     public void testEmptyBundle() {
         Bundle pushBundle = new Bundle();
-        NotificationClient.CampaignPushResult result = target.handleGCMCampaignPush("_campaign.opened",
+        NotificationClient.PinpointPushResult result = target.handleGCMCampaignPush("_campaign.opened",
                                                                                            pushBundle,
                                                                                            Service.class);
-        assertEquals(NotificationClient.CampaignPushResult.NOT_HANDLED, result);
+        assertEquals(NotificationClient.PinpointPushResult.NOT_HANDLED, result);
     }
 
     @Test

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
@@ -23,7 +23,6 @@ import com.amazonaws.mobileconnectors.pinpoint.internal.event.EventRecorder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -31,10 +30,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -50,7 +45,6 @@ import com.amazonaws.services.pinpoint.model.ChannelType;
 
 import android.app.Service;
 import android.os.Bundle;
-import org.robolectric.shadows.ShadowBitmap;
 
 import java.util.Map;
 
@@ -62,7 +56,6 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
@@ -195,10 +188,10 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
                         .serviceClass(Service.class)
                         .intentAction(GCM_INTENT_ACTION);
 
-        NotificationClient.PinpointPushResult pushResult
+        NotificationClient.PushResult pushResult
                 = target.handlePushNotification(notificationDetailsBuilder.build());
 
-        assertEquals(NotificationClient.PinpointPushResult.OPTED_OUT, pushResult);
+        assertEquals(NotificationClient.PushResult.OPTED_OUT, pushResult);
 
         ArgumentCaptor<AnalyticsEvent> eventCaptor = ArgumentCaptor.forClass(AnalyticsEvent.class);
         verify(mockEventRecorder, times(1)).recordEvent(eventCaptor.capture());

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
@@ -189,7 +189,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
                         .intentAction(GCM_INTENT_ACTION);
 
         NotificationClient.PushResult pushResult
-                = target.handlePushNotification(notificationDetailsBuilder.build());
+                = target.handleNotificationReceived(notificationDetailsBuilder.build());
 
         assertEquals(NotificationClient.PushResult.OPTED_OUT, pushResult);
 
@@ -291,12 +291,9 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(5));
+        assertThat(receivedEvent.getAllAttributes().size(), is(2));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
-        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
-        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds support for push notifications from Pinpoint Journeys.

There are several commits. With the exception of the most recent, they mostly have to do with renaming and refactoring parts of the code that treated every push notification as being part of a campaign. I've changed that to be `eventSource` where appropriate. So any time you see eventSource throughout the code, think Pinpoint Campaign or Journey (or some other future thing)

The latest commit is the one that actually deals with adding an API (`handlePushNotification`) that will be able to handle both Campaigns and Journeys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
