### PR TITLE
Use latest version of Gradle and Android Gradle Plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,20 +18,24 @@ commands:
             fi
 
   generate_gradle_wrapper:
-    description: >-
-      Downloads and install gradle 4.10.2
+    description: Downloads and installs Gradle wrapper
+    parameters:
+      gradle_version:
+        description: "The version of Gradle to install"
+        default: "6.3"
+        type: string
     steps:
       - run:
           name: Download gradle zip
           command: |
             cd ~
-            wget https://services.gradle.org/distributions/gradle-4.10.2-bin.zip
-            unzip gradle-4.10.2-bin.zip
+            wget https://services.gradle.org/distributions/gradle-<< parameters.gradle_version >>-bin.zip
+            unzip gradle-<< parameters.gradle_version >>-bin.zip
       - run:
           name: Generate wrapper
           command: |
             cd ~/code # This is a pre-defined location
-            ~/gradle-4.10.2/bin/gradle wrapper
+            ~/gradle-<< parameters.gradle_version >>/bin/gradle wrapper
 
   configure_aws:
     description: >-

--- a/aws-android-sdk-auth-core/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-auth-core/src/main/AndroidManifest.xml
@@ -2,4 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 		  package="com.amazonaws.mobile.auth.core">
 
-<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="25" /></manifest>
+</manifest>

--- a/aws-android-sdk-auth-facebook/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-auth-facebook/src/main/AndroidManifest.xml
@@ -6,4 +6,4 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="25" /></manifest>
+</manifest>

--- a/aws-android-sdk-auth-google/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-auth-google/src/main/AndroidManifest.xml
@@ -10,4 +10,4 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
  
-<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="25" /></manifest>
+</manifest>

--- a/aws-android-sdk-auth-ui/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-auth-ui/src/main/AndroidManifest.xml
@@ -13,5 +13,5 @@
              android:screenOrientation="portrait"
              android:configChanges="keyboard|keyboardHidden|orientation|screenSize"/>
     </application>
-<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="25" /></manifest>
+</manifest>
 

--- a/aws-android-sdk-auth-userpools/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-auth-userpools/src/main/AndroidManifest.xml
@@ -36,4 +36,4 @@
              android:screenOrientation="portrait"
              android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
      </application>
-<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="25" /></manifest>
+</manifest>

--- a/aws-android-sdk-cognitoauth/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-cognitoauth/src/main/AndroidManifest.xml
@@ -5,6 +5,4 @@
  
      <application android:allowBackup="true"/>
 
-     <uses-sdk android:minSdkVersion="15"
-               android:targetSdkVersion="25" />
  </manifest>

--- a/aws-android-sdk-iot/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-iot/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amazonaws.iot" >
 
-    <uses-sdk android:minSdkVersion="11"
-        android:targetSdkVersion="27"/>
-
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/aws-android-sdk-kinesisvideo-archivedmedia/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-kinesisvideo-archivedmedia/src/main/AndroidManifest.xml
@@ -5,4 +5,4 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="27" /></manifest>
+</manifest>

--- a/aws-android-sdk-kinesisvideo/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-kinesisvideo/src/main/AndroidManifest.xml
@@ -7,5 +7,5 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <application>
     </application>
-<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="25" /></manifest>
+</manifest>
 

--- a/aws-android-sdk-lambda/src/test/resources/com/amazonaws/mobileconnectors/util/AndroidManifest.xml
+++ b/aws-android-sdk-lambda/src/test/resources/com/amazonaws/mobileconnectors/util/AndroidManifest.xml
@@ -3,10 +3,6 @@
     android:versionCode="2"
     android:versionName="2.1.2" >
 
-    <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="17" />
-
     <!-- The android resource is used here as stub, so that the res folder is unnecessary -->
     <application
         android:allowBackup="true"

--- a/aws-android-sdk-lex/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-lex/src/main/AndroidManifest.xml
@@ -8,8 +8,5 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 	
-    <uses-sdk
-        android:minSdkVersion="11"
-        android:targetSdkVersion="21" />
-
 </manifest>
+

--- a/aws-android-sdk-mobile-client/src/androidTest/AndroidManifest.xml
+++ b/aws-android-sdk-mobile-client/src/androidTest/AndroidManifest.xml
@@ -3,11 +3,6 @@
     xmlns:amazon="http://schemas.amazon.com/apk/res/android"
     package="com.amazonaws.mobile.client">
 
-    <uses-sdk xmlns:tools="http://schemas.android.com/tools"
-        android:minSdkVersion="21"
-        android:targetSdkVersion="25"
-        tools:overrideLibrary="android.support.test.uiautomator.v18,com.amazonaws.mobile.auth.ui" />
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />

--- a/aws-android-sdk-mobile-client/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-mobile-client/src/main/AndroidManifest.xml
@@ -3,9 +3,6 @@
            xmlns:amazon="http://schemas.amazon.com/apk/res/android"
            package="com.amazonaws.mobile.client">
 
-    <uses-sdk android:minSdkVersion="15"
-              android:targetSdkVersion="27"/>
-
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
  

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.2.30'
-
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.3'
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.6.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
New Versions:
 - Gradle 6.3
 - Android Gradle Plugin 3.6.2.

These changes also required the following changes, in order for the
project to continue building:

 - Remove conflicting Kotlin version, which is not used.
 - Remove `uses-sdk` from AndroidManifest.xml; these values are overridden
   in `build.gradle`.

Refer: https://stackoverflow.com/a/20002844/695787

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
