### PR TITLE
Remove unused vestigial integration test config

### DIFF
--- a/aws-android-sdk-auth-core/build.gradle
+++ b/aws-android-sdk-auth-core/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -27,8 +26,5 @@ dependencies {
     api project(':aws-android-sdk-core')
 
     testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 

--- a/aws-android-sdk-auth-facebook/build.gradle
+++ b/aws-android-sdk-auth-facebook/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -29,8 +28,5 @@ dependencies {
     implementation 'com.android.support:support-v4:23.0.1'
 
     testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 

--- a/aws-android-sdk-auth-google/build.gradle
+++ b/aws-android-sdk-auth-google/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -29,8 +28,5 @@ dependencies {
     implementation 'com.android.support:support-v4:23.0.1'
 
     testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 

--- a/aws-android-sdk-auth-ui/build.gradle
+++ b/aws-android-sdk-auth-ui/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
 
     }
 
@@ -29,8 +28,5 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:23.0.1'
 
     testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 

--- a/aws-android-sdk-auth-userpools/build.gradle
+++ b/aws-android-sdk-auth-userpools/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -29,8 +28,5 @@ dependencies {
     implementation 'com.android.support:support-v4:27.+'
 
     testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 

--- a/aws-android-sdk-lex/build.gradle
+++ b/aws-android-sdk-lex/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -28,8 +27,5 @@ dependencies {
     implementation 'com.google.guava:guava:20.0'
 
     testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 

--- a/aws-android-sdk-testutils/build.gradle
+++ b/aws-android-sdk-testutils/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {


### PR DESCRIPTION
There are a number of projects that do not have any instrumentation
tests, but that do include dependency specifications for instrumentation
tests.
    
As these are not used, and are cluttering the build spec: remove them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
