### PR TITLE
[mobile-client] Fixing NullPointerException when clientMetadata is null

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1372,7 +1372,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         }
                         detectedContinuation = signInChallengeContinuation;
                         signInCallback = new InternalCallback<SignInResult>(callback);
-                        if (CUSTOM_CHALLENGE.equals(signInState)) {
+                        if (CUSTOM_CHALLENGE.equals(signInState) && clientMetaData != null) {
                             signInChallengeContinuation.setClientMetaData(clientMetaData);
                         }
                         break;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using CUSTOM_AUTH and responding to a challenge with a null clientMetadata, we were throwing a NPE.

According to [the documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html#CognitoUserPools-RespondToAuthChallenge-request-ClientMetadata) that field is not required and is only relevant if the developer is using those fields inside their lambda function. At that point, it's up to the developer to ensure they're calling the [overloaded `confirmSignin`](https://aws-amplify.github.io/aws-sdk-android/docs/reference/com/amazonaws/mobile/client/AWSMobileClient.html#confirmSignIn-java.util.Map-java.util.Map-) method that takes in the clientMetadata parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
