### PR TITLE
[aws-android-sdk-testutils] Discontinue Use of Long-Lived Credentials

### DIFF
--- a/aws-android-sdk-testutils/src/main/java/com/amazonaws/testutils/AWSTestBase.java
+++ b/aws-android-sdk-testutils/src/main/java/com/amazonaws/testutils/AWSTestBase.java
@@ -25,7 +25,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.util.StringUtils;
 
 import org.json.JSONException;
@@ -53,77 +53,66 @@ import android.os.Build;
 import android.support.annotation.RawRes;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
-import android.util.Log;
 
 @RunWith(AndroidJUnit4.class)
 public abstract class AWSTestBase {
-
     protected static final String TEST_CONFIGURATION_FILENAME = "testconfiguration.json";
 
-    public static class JSONConfiguration  {
-        private JSONObject mJSONObject ;
-        public JSONConfiguration(JSONObject mJSONObject) {
+    public static final class JSONConfiguration {
+        private JSONObject mJSONObject;
+
+        private JSONConfiguration(JSONObject mJSONObject) {
             this.mJSONObject = mJSONObject ;
         }
-        JSONObject getCredentials() {
-            try {
-                return mJSONObject.getJSONObject("Credentials");
-            }
-            catch (JSONException je) {
-                throw new RuntimeException(
-                        "Failed to get credentials from " + TEST_CONFIGURATION_FILENAME + ", please check that it is correctly formed.",
-                        je);
-            }
-        }
-        JSONObject getPackages()  {
-            try {
-                return mJSONObject.getJSONObject("Packages");
-            }
-            catch (JSONException je) {
-                throw new RuntimeException(
-                        "Failed to get Packages from " + TEST_CONFIGURATION_FILENAME + ", please check that it is correctly formed.",
-                        je);
-            }
-         }
+
         public JSONObject getPackageConfigure(String packageName) {
             try {
-                return getPackages().getJSONObject(packageName);
+                return mJSONObject.getJSONObject("Packages")
+                    .getJSONObject(packageName);
             }
-            catch (JSONException je) {
+            catch (JSONException | NullPointerException configurationFileError) {
                 throw new RuntimeException(
-                        "Failed to get package configuration from " + TEST_CONFIGURATION_FILENAME + " + packageName",
-                        je);
+                    "Failed to get configuration for package = " + packageName + " from  " +
+                        TEST_CONFIGURATION_FILENAME + ".", configurationFileError
+                );
             }
         }
 
-        public String getAccessKey() {
-            try {
-                return getCredentials().getString("accessKey");
-            }
-            catch (JSONException je) {
-                throw new RuntimeException(
-                        "Failed to get accessKey from " + TEST_CONFIGURATION_FILENAME + ", please check that it is correctly formed.",
-                        je);
-            }
+        String getAccessKey() {
+            return extractStringByPath("Credentials.accessKey");
         }
-        public String getSecretKey() {
+
+        String getSecretKey() {
+            return extractStringByPath("Credentials.secretKey");
+        }
+
+        String getSessionToken() {
+            return extractStringByPath("Credentials.sessionToken");
+        }
+
+        String getAccountId() {
+            return extractStringByPath("Credentials.accountId");
+        }
+
+        private String extractStringByPath(String path) {
+            return extractStringByPath(mJSONObject, path);
+        }
+
+        // This is a poor man's implementation of JSONPath, that just handles literals,
+        // with the '.' meaning "down one more level." This will break if your key contains a period.
+        private String extractStringByPath(JSONObject container, String path) {
+            int indexOfFirstPeriod = path.indexOf(".");
+            if (indexOfFirstPeriod != -1) {
+                String firstPortion = path.substring(0, indexOfFirstPeriod);
+                return extractStringByPath(container, firstPortion);
+            }
             try {
-                return getCredentials().getString("secretKey");
-            }
-            catch (JSONException je) {
+                return container.getString(path);
+            } catch (JSONException jsonException) {
                 throw new RuntimeException(
-                        "Failed to get secretKey from " + TEST_CONFIGURATION_FILENAME + ", please check that it is correctly formed.",
-                        je);
-            }
-        }  
-        public String getAccountId() {
-            try {
-                return getCredentials().getString("accountId");
-            }
-            catch (JSONException je) {
-                throw new RuntimeException(
-                        "Failed to get accountId from " + TEST_CONFIGURATION_FILENAME + ", please check that it is correctly formed.",
-                        je);
+                    "Failed to get key " + path + " from " + TEST_CONFIGURATION_FILENAME +
+                        ", please check that it is correctly formed.", jsonException
+                );
             }
         }
     }
@@ -132,103 +121,81 @@ public abstract class AWSTestBase {
      * An implementation of AWSCredentialProvider that fetches the credentials
      * from test configuration json file.
      */
-    static class JSONCredentialProvider implements AWSCredentialsProvider {
-
+    final static class JSONCredentialProvider implements AWSCredentialsProvider {
         @Override
         public AWSCredentials getCredentials()  {
-            String accessKey = "";
-            String secretAccessKey = "";
-
-            try {
-                accessKey =  getAccessKey();
-                secretAccessKey = getSecretKey();
-            } catch (Exception e) {
-                Log.e(TAG, "Failed to get credentials");
-                e.printStackTrace();
-            }
-            return new BasicAWSCredentials(accessKey , secretAccessKey );
+            return new BasicSessionCredentials(getAccessKey() , getSecretKey(), getSessionToken());
         }
 
         @Override
         public void refresh() {
-            getCredentials();
         }
-
     }
 
     public static final String TAG = AWSTestBase.class.getSimpleName();
     /** Shared AWS credentials, loaded from a properties file */
     public static AWSCredentials credentials;
-    private static JSONConfiguration mJSONConfiguration; 
-    
+    private static JSONConfiguration mJSONConfiguration;
 
-
-    public static JSONConfiguration getJSONConfiguration()
-    {
-        Context context = getContext() ;
-        if (mJSONConfiguration == null) {
-            try {
-                Resources resources = context.getResources();
-                String packageName = context.getPackageName();
-                @RawRes int resourceId =
-                    resources.getIdentifier(TEST_CONFIGURATION_FILENAME, "raw", packageName);
-                InputStream inputStream = resources.openRawResource(resourceId);
-                Scanner in = new Scanner(inputStream);
-                StringBuilder sb = new StringBuilder();
-                while (in.hasNextLine()) {
-                    sb.append(in.nextLine());
-                }
-                in.close();
-
-                mJSONConfiguration  = new JSONConfiguration(new JSONObject(sb.toString()));
-            } catch (Exception je) {
-                throw new RuntimeException(
-                        "Failed to read " + TEST_CONFIGURATION_FILENAME + " please check that it is correctly formed.",
-                        je);
-            }
+    public static JSONConfiguration getJSONConfiguration() {
+        if (mJSONConfiguration != null) {
+            return mJSONConfiguration;
         }
-        return mJSONConfiguration;
+        try {
+            int periodIndex = TEST_CONFIGURATION_FILENAME.indexOf(".");
+            String resourceName = TEST_CONFIGURATION_FILENAME.substring(0, periodIndex);
+            String fileContents = readRawResourceContents(resourceName);
+            mJSONConfiguration  = new JSONConfiguration(new JSONObject(fileContents));
+            return mJSONConfiguration;
+        } catch (JSONException configurationFileError) {
+            throw new RuntimeException(
+                "Failed to read " + TEST_CONFIGURATION_FILENAME + " please check that it is correctly formed.",
+                configurationFileError
+            );
+        }
     }
+
+    @SuppressWarnings("SameParameterValue")
+    private static String readRawResourceContents(String rawResourceName) {
+        Context context = InstrumentationRegistry.getContext();
+        Resources resources = context.getResources();
+        String packageName = context.getPackageName();
+        @RawRes int resourceId =
+            resources.getIdentifier(rawResourceName, "raw", packageName);
+        InputStream inputStream = resources.openRawResource(resourceId);
+        Scanner in = new Scanner(inputStream);
+        StringBuilder sb = new StringBuilder();
+        while (in.hasNextLine()) {
+            sb.append(in.nextLine());
+        }
+        in.close();
+        return sb.toString();
+    }
+
     public static String getAccessKey() {
         return getJSONConfiguration().getAccessKey();
     }
-    public static String  getSecretKey() {
+
+    public static String getSecretKey() {
         return getJSONConfiguration().getSecretKey();
     }
+
+    public static String getSessionToken() {
+        return getJSONConfiguration().getSessionToken();
+    }
+
     public static String getAccountId() {
         return getJSONConfiguration().getAccountId();
     }
+
     public static JSONObject  getPackageConfigure(String packageName) {
         return getJSONConfiguration().getPackageConfigure(packageName);
     }
 
-    private  static Context getContext() {
-
-        return InstrumentationRegistry.getContext();
-    }
- 
-    private  static JSONCredentialProvider getJSONCredentialProvider() {
-        try
-        {
-            JSONCredentialProvider provider = new JSONCredentialProvider();
-            return provider ;
-        }
-        catch (Exception e) {
-
-            throw e;
-
-        }
-    }
-
-    /**
-     * Use provider chain for getting credentials.
-     */
-    private static final AWSCredentialsProviderChain chain = new AWSCredentialsProviderChain(
-            getJSONCredentialProvider()
-    );
-
     public static void setUpCredentials() {
         if (credentials == null) {
+            AWSCredentialsProvider provider = new JSONCredentialProvider();
+            AWSCredentialsProviderChain chain = new AWSCredentialsProviderChain(provider);
             credentials = chain.getCredentials();
         }
     }


### PR DESCRIPTION
The tests will no longer use long-lived credentials.

Instead, the `testconfiguration.json` will make reference to a
three-tuple of Access ID, Secret Key ID, Session Token. These are
provided via `BasicSessionCredentials`, from an
`AWSCredentialsProvider`.

The `"Credentials"` block of the `testconfiguration.json` will now require
this form:
```
{
    ...
    "Credentials": {
        "accessKey": "REDACTED_ACCESS_KEY",
        "secretKey": "REDACTED_SECRET_KEY",
        "sessionToken": "REDACTED_SESSION_TOKEN"
    },
    ...
}
```

The details of generating a suitably formatted `testconfiguration.json`
are handled externally to this code base.

Refer: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
