### PR TITLE
Fixes for S3 tests

### DIFF
--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/PauseTransferIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/mobileconnectors/s3/transferutility/PauseTransferIntegrationTest.java
@@ -113,7 +113,7 @@ public final class PauseTransferIntegrationTest extends S3IntegrationTestBase {
 
         // cancel early to avoid having to wait for completion
         util.cancel(observer.getId());
-        completed.await(100, TimeUnit.MILLISECONDS);
+        completed.await(1000, TimeUnit.MILLISECONDS);
     }
 
     private final class TestListener implements TransferListener {

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/AclIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/AclIntegrationTest.java
@@ -48,9 +48,6 @@ public class AclIntegrationTest extends S3IntegrationTestBase {
     /** The key of the object these tests will create, test on and delete */
     private static final String KEY = "key";
 
-    /** The key of the object these tests will create, test on and delete */
-    private static final String DISPLAY_NAME = "aws-dr-mobile-test-android";
-
     /** Releases all test resources */
     @After
     public void tearDown() {
@@ -141,7 +138,6 @@ public class AclIntegrationTest extends S3IntegrationTestBase {
         assertEquals(bucketOwner, bucketAcl.getOwner());
         assertEquals(bucketOwner, objectAcl.getOwner());
         assertTrue(doesAclContainGroupGrant(objectAcl, GroupGrantee.AllUsers, Permission.Read));
-        assertTrue(doesAclContainsCanonicalGrant(objectAcl, DISPLAY_NAME, Permission.FullControl));
         assertEquals(2, objectAcl.getGrantsAsList().size());
         assertEquals(1, bucketAcl.getGrantsAsList().size());
 
@@ -193,8 +189,8 @@ public class AclIntegrationTest extends S3IntegrationTestBase {
      * @return True if the specified ACL contains a canonical grant with the
      *         specified display name and permission, otherwise false.
      */
-    private boolean doesAclContainsCanonicalGrant(AccessControlList acl, 
-        String expectedDisplayName, 
+    private boolean doesAclContainsCanonicalGrant(AccessControlList acl,
+        String expectedDisplayName,
         Permission expectedPermission) {
 
         for (final java.util.Iterator iterator = acl.getGrantsAsList().iterator(); iterator.hasNext();) {

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/BucketReplicationIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/BucketReplicationIntegrationTest.java
@@ -32,8 +32,10 @@ import com.amazonaws.services.s3.model.SetBucketVersioningConfigurationRequest;
 
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -41,11 +43,15 @@ import java.io.File;
 public class BucketReplicationIntegrationTest extends
         S3IntegrationTestBase {
 
-    /** source bucket name for the replication integration test */
+    /**
+     * source bucket name for the replication integration test
+     */
     private static final String SOURCE_BUCKET_NAME = "android-sdk-bucket-replication-integ-test-"
             + System.currentTimeMillis();
 
-    /** destination bucket name for the replication integration test */
+    /**
+     * destination bucket name for the replication integration test
+     */
     private static final String DESTINATION_BUCKET_NAME = "android-sdk-bucket-dest-replication-integ-test-"
             + System.currentTimeMillis();
 
@@ -107,7 +113,9 @@ public class BucketReplicationIntegrationTest extends
         }
     }
 
-    @Test
+    @Ignore("This test requires an IAM role with the ability to replicate data between S3 buckets. Previously it " +
+            "was hard-coded (ROLE), but the original account was deactivated. Since this test covers an uncommon" +
+            "use-case for users of the Android SDK and is testing generated code, we're disabling it.")
     public void testBucketReplication() {
         testSetAndRetrieveReplicationConfiguration();
         testDeleteConfiguration();
@@ -116,8 +124,7 @@ public class BucketReplicationIntegrationTest extends
     public void testSetAndRetrieveReplicationConfiguration() {
 
         // Setting new configuration and retrieving.
-        BucketReplicationConfiguration configuration = new BucketReplicationConfiguration()
-                .withRoleARN(ROLE);
+        BucketReplicationConfiguration configuration = new BucketReplicationConfiguration();
 
         configuration.addRule(
                 RULE1,

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3IntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/S3IntegrationTest.java
@@ -72,9 +72,6 @@ public class S3IntegrationTest extends S3IntegrationTestBase {
     private static final String EXPECTED_BUCKET_NAME = "android-sdk-integ-test-bucket-"
             + System.currentTimeMillis();
 
-    /** Name of the test S3 account running these tests */
-    private final String expectedS3AccountOwnerName = "aws-dr-mobile-test-android";
-
     /** Name of the test key these tests will create, test, delete, etc */
     private static String expectedKey = "integ-test-key-" + new Date().getTime();
 
@@ -393,16 +390,6 @@ public class S3IntegrationTest extends S3IntegrationTestBase {
         assertEquals(bucket.getOwner(), s3.getS3AccountOwner());
         assertNotNull(bucket.getOwner().getDisplayName());
         assertNotNull(bucket.getOwner().getId());
-    }
-
-    /**
-     * Tests that we can get an account owner for this account
-     */
-    @Test
-    public void testGetS3AccountOwner() {
-        Owner owner = s3.getS3AccountOwner();
-        assertNotNull(owner);
-        assertEquals(expectedS3AccountOwnerName, owner.getDisplayName());
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

- PauseTransferIntegrationTest.testMultiPartUploadPause
  - This pause test was intermittently failing both in Android Studio and
        when run through gradlew; it appears that 100 milliseconds wasn't
        enough time for the transfer to transition to CANCELED, which
        resulted in intermittent exceptions. This change raises the wait for
        the transition to CANCELED to a second through the completed latch.
    
 - AclIntegrationTest.testCannedAcls
    - This test had an assertion against a hardcoded value looking at the S3
        display name. It expected the value in the old account this thing ran
        in. There's actually no great way to get this kind of information from
        CloudFormation, and I don't really understand what this is testing (it's
        default S3 behavior to leave existing ACLs in place), so I'm just
        removing the assertion.
    
  - S3IntegrationTest.testGetS3AccountOwner
    - Similarly, this test was looking at the same data from a different
        method and had another hard-coded constant. This isn't a terribly
        well-trod path of AWS these days, there's no easy way to snake this
        through CloudFormation, and I'm not sure it changes our test coverage
        by not having a test for this explicitly.
    
  - BucketReplicationIntegrationTest
    - This test covered the setup of S3 bucket replication, an uncommon
        use-case for mobile developers, and used a hard-coded role to do it.
        Instead of creating and snaking the role through, this change @Ignores
        it for now.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
