### PR TITLE
Stop using key pair in autoscaling tests

### DIFF
--- a/aws-android-sdk-autoscaling-test/src/androidTest/java/com/amazonaws/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/aws-android-sdk-autoscaling-test/src/androidTest/java/com/amazonaws/services/autoscaling/AutoScalingIntegrationTest.java
@@ -213,7 +213,6 @@ public class AutoScalingIntegrationTest extends AutoScalingIntegrationTestBase {
                         .withLaunchConfigurationName(launchConfigurationName)
                         .withImageId(AMI_ID)
                         .withInstanceType(INSTANCE_TYPE)
-                        .withKeyName(KEY_NAME)
                         .withSecurityGroups("default")
                         .withUserData(encodedUserData)
                         .withAssociatePublicIpAddress(false);
@@ -235,7 +234,6 @@ public class AutoScalingIntegrationTest extends AutoScalingIntegrationTestBase {
         assertEquals(AMI_ID, launchConfiguration.getImageId());
         assertEquals(INSTANCE_TYPE, launchConfiguration.getInstanceType());
         assertEquals(launchConfigurationName, launchConfiguration.getLaunchConfigurationName());
-        assertEquals(KEY_NAME, launchConfiguration.getKeyName());
         assertEquals("default", launchConfiguration.getSecurityGroups().get(0));
         assertEquals(encodedUserData, launchConfiguration.getUserData());
         assertEquals(false, launchConfiguration.getAssociatePublicIpAddress());

--- a/aws-android-sdk-autoscaling-test/src/androidTest/java/com/amazonaws/services/autoscaling/AutoScalingIntegrationTestBase.java
+++ b/aws-android-sdk-autoscaling-test/src/androidTest/java/com/amazonaws/services/autoscaling/AutoScalingIntegrationTestBase.java
@@ -50,7 +50,6 @@ public abstract class AutoScalingIntegrationTestBase extends AWSTestBase {
     protected static final String AVAILABILITY_ZONE = "us-east-1a";
     protected static final String AMI_ID = "ami-035be7bafff33b6b6";
     protected static final String INSTANCE_TYPE = "t2.micro";
-    protected static final String KEY_NAME = "fulghum";
 
     /**
      * Loads the AWS account info for the integration tests and creates an
@@ -78,8 +77,7 @@ public abstract class AutoScalingIntegrationTestBase extends AWSTestBase {
                 new CreateLaunchConfigurationRequest()
                         .withLaunchConfigurationName(name)
                         .withImageId(AMI_ID)
-                        .withInstanceType(INSTANCE_TYPE)
-                        .withKeyName(KEY_NAME);
+                        .withInstanceType(INSTANCE_TYPE);
         autoscaling.createLaunchConfiguration(createRequest);
     }
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Previously, these tests used a hard-coded key pair that was expected to be in the test account named by the alias of the developed that worked on this feature. EC2 key pairs cannot be created via CloudFormation, but aren't required in launch configurations. There's minimal impact to these tests by removing this element and assertion.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
