### PR TITLE
Fix core tests

### DIFF
--- a/aws-android-sdk-core-test/src/androidTest/java/com/amazonaws/internal/keyvaluestore/CognitoCachingCredentialsProviderIntegrationTest.java
+++ b/aws-android-sdk-core-test/src/androidTest/java/com/amazonaws/internal/keyvaluestore/CognitoCachingCredentialsProviderIntegrationTest.java
@@ -184,7 +184,7 @@ public class CognitoCachingCredentialsProviderIntegrationTest extends CoreIntegr
     public void testMultipleCognitoCachingCredentialsProviders() throws Exception {
         CognitoCachingCredentialsProvider credentialsProvider1 = new CognitoCachingCredentialsProvider(
                 InstrumentationRegistry.getTargetContext(),
-                getPackageConfigure("kinesis").getString("identity_pool_id"),
+                getPackageConfigure().getString("other_identity_pool_id"),
                 Regions.US_EAST_1);
 
         credentialsProviders.add(credentialsProvider1);
@@ -219,7 +219,7 @@ public class CognitoCachingCredentialsProviderIntegrationTest extends CoreIntegr
     public void testMultipleCognitoCachingCredentialsProvidersWithRefresh() throws Exception {
         CognitoCachingCredentialsProvider credentialsProvider1 = new CognitoCachingCredentialsProvider(
                 InstrumentationRegistry.getTargetContext(),
-                getPackageConfigure("kinesis").getString("identity_pool_id"),
+                getPackageConfigure().getString("other_identity_pool_id"),
                 Regions.US_EAST_1);
         credentialsProvider1.setPersistenceEnabled(false);
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* We were using another identity pool from the Kinesis tests in core but there was no specific dependencies on that identity pool setup -- rather the test just wants two identity pools. Thus, I'm moving that identity pool into the core namespace and prefixing it with "other" rather than maintaining a kinesis namespace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.