### PR TITLE
Ignore topic modeling integration test

### DIFF
--- a/aws-android-sdk-comprehend-test/src/androidTest/java/com/amazonaws/services/comprehend/ComprehendIntegrationTest.java
+++ b/aws-android-sdk-comprehend-test/src/androidTest/java/com/amazonaws/services/comprehend/ComprehendIntegrationTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -148,6 +149,9 @@ public class ComprehendIntegrationTest extends AWSTestBase {
                 .getNeutral());
     }
 
+    @Ignore("In order to test topic modeling, we require an S3 bucket populated with an input file and an IAM role that can" +
+            "read from and write to that bucket. We could choose to do this using our CDK setup package, but this test" +
+            "is covering an unlikely mobile use-case, and spending up to 20 minutes of runtime to do so. Ignoring for now.")
     @Test
     public void testTopicModeling() throws Exception {
         final String inputS3Uri = "s3://comprehend-android-sdk-test/comprehend-input.txt";


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* The Comprehend suite has an elaborate test that runs topics detection which allows Comprehend to example a collection of documents to determine common themes. There isn't a clear mobile use case for this as topic modeling jobs are recommended to be ran with at least 1,000 documents and are run asynchronously. This is more of a batch operation, and the test has a 20 minute maximum runtime to reflect that. Given the dubious nature of the mobile use case, the resources required to orchestrate the test (IAM Role, S3 Bucket), and the amount of time it takes to run, I'm putting @Ignore on it versus snaking through the AWS resources to rehabilitate it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.