### PR TITLE
Ignore Amazon Connect tests

### DIFF
--- a/aws-android-sdk-connect-test/src/androidTest/java/com/amazonaws/services/connect/ConnectInstrumentedTest.java
+++ b/aws-android-sdk-connect-test/src/androidTest/java/com/amazonaws/services/connect/ConnectInstrumentedTest.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.connect.model.UserSummary;
 import com.amazonaws.testutils.AWSTestBase;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
+@Ignore("These tests require Amazon Connect resources which we cannot create via CloudFormation currently.")
 @RunWith(AndroidJUnit4.class)
 public class ConnectInstrumentedTest extends AWSTestBase {
 

--- a/aws-android-sdk-connectparticipant-test/src/androidTest/java/com/amazonaws/services/connectparticipant/ConnectParticipantInstrumentedTest.java
+++ b/aws-android-sdk-connectparticipant-test/src/androidTest/java/com/amazonaws/services/connectparticipant/ConnectParticipantInstrumentedTest.java
@@ -30,6 +30,7 @@ import com.amazonaws.testutils.AWSTestBase;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +41,7 @@ import static org.junit.Assert.fail;
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
+@Ignore("These tests require Amazon Connect resources which we cannot create via CloudFormation currently.")
 @RunWith(AndroidJUnit4.class)
 public class ConnectParticipantInstrumentedTest extends AWSTestBase {
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* These tests require resources to run against that we cannot create programmatically. Given this is generated code, I'm disabling these tests for now and we can revisit in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.