### PR TITLE
Disable Amazon Machine Learning tests

### DIFF
--- a/aws-android-sdk-machinelearning-test/src/androidTest/java/com/amazonaws/services/machinelearning/AmazonMachineLearningIntegrationTest.java
+++ b/aws-android-sdk-machinelearning-test/src/androidTest/java/com/amazonaws/services/machinelearning/AmazonMachineLearningIntegrationTest.java
@@ -8,11 +8,13 @@ import com.amazonaws.services.machinelearning.model.PredictResult;
 import com.amazonaws.testutils.AWSTestBase;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
 
+@Ignore("The model referenced by ML_MODEL_ID no longer exists, this test will need to be rewritten using dynamic resources.")
 public class AmazonMachineLearningIntegrationTest extends AWSTestBase {
 
     private static final String ML_MODEL_ID = "pr-hoMlig0hsoI";


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* These tests require a resource that no longer exists and was previously hardcoded. To restore these tests, work must be done to create the model via CloudFormation and pass it through.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
