### PR TITLE
Added support for Europe (Milan) and Africa (Cape Town) region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.16.12](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.12)
+
+### New Features
+
+* **AWS Core Runtime**
+  * Added support for `af-south-1` - Africa (Cape Town) region.
+  * Added support for `eu-south-1` - Europe (Milan) region.
+
 ## [Release 2.16.11](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.11)
 
 ### New Features

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/regions/RegionDefaults.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/regions/RegionDefaults.java
@@ -25,6 +25,20 @@ class RegionDefaults {
         final List<Region> ret = new ArrayList<Region>();
         Region region;
 
+        region = new Region("af-south-1", "amazonaws.com");
+        ret.add(region);
+        updateRegion(region, "autoscaling", "autoscaling.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "dynamodb", "dynamodb.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "ec2", "ec2.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "elasticloadbalancing",
+                "elasticloadbalancing.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "kms", "kms.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "lambda", "lambda.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "logs", "logs.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "s3", "s3.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "sns", "sns.af-south-1.amazonaws.com", false, true);
+        updateRegion(region, "sqs", "sqs.af-south-1.amazonaws.com", false, true);
+
         region = new Region("ap-northeast-1", "amazonaws.com");
         ret.add(region);
         updateRegion(region, "autoscaling", "autoscaling.ap-northeast-1.amazonaws.com", false, true);
@@ -186,6 +200,19 @@ class RegionDefaults {
         updateRegion(region, "sns", "sns.eu-central-1.amazonaws.com", false, true);
         updateRegion(region, "sqs", "sqs.eu-central-1.amazonaws.com", false, true);
         updateRegion(region, "sts", "sts.amazonaws.com", false, true);
+
+        region = new Region("eu-south-1", "amazonaws.com");
+        ret.add(region);
+        updateRegion(region, "autoscaling", "autoscaling.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "dynamodb", "dynamodb.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "ec2", "ec2.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "elasticloadbalancing",
+                "elasticloadbalancing.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "lambda", "lambda.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "logs", "logs.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "s3", "s3.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "sns", "sns.eu-south-1.amazonaws.com", false, true);
+        updateRegion(region, "sqs", "sqs.eu-south-1.amazonaws.com", false, true);
 
         region = new Region("eu-west-1", "amazonaws.com");
         ret.add(region);

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/regions/Regions.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/regions/Regions.java
@@ -38,6 +38,9 @@ public enum Regions {
     /** us-west-2. */
     US_WEST_2("us-west-2"),
 
+    /** eu-south-1/ */
+    EU_SOUTH_1("eu-south-1"),
+
     /** eu-west-1/ */
     EU_WEST_1("eu-west-1"),
 
@@ -84,7 +87,10 @@ public enum Regions {
     CN_NORTHWEST_1("cn-northwest-1"),
 
     /** me-south-1. */
-    ME_SOUTH_1("me-south-1");
+    ME_SOUTH_1("me-south-1"),
+
+    /** af-south-1. */
+    AF_SOUTH_1("af-south-1");
 
     /**
      * The default region that new customers in the US are encouraged to use

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/model/Region.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/model/Region.java
@@ -290,7 +290,31 @@ public enum Region {
      * When using buckets in this region, you must set the client endpoint to
      * <code>s3.me-south-1.amazonaws.com</code>.
      */
-    ME_Bahrain("me-south-1");
+    ME_Bahrain("me-south-1"),
+
+    /**
+     * The Europe (Milan) Region. This region uses Amazon S3 servers
+     * located in Milan.
+     * <p>
+     * When using buckets in this region, set the client endpoint to
+     * <code>s3-eu-south-1.amazonaws.com</code> on all requests to these buckets
+     * to reduce any latency experienced after the first hour of creating a
+     * bucket in this region.
+     * </p>
+     */
+    EU_Milan("eu-south-1"),
+
+    /**
+     * The Africa (Cape Town) Region. This region uses Amazon S3 servers
+     * located in Cape Town.
+     * <p>
+     * When using buckets in this region, set the client endpoint to
+     * <code>s3-af-south-1.amazonaws.com</code> on all requests to these buckets
+     * to reduce any latency experienced after the first hour of creating a
+     * bucket in this region.
+     * </p>
+     */
+    AP_CapeTown("af-south-1");
 
     /**
      * Used to extract the S3 regional id from an S3 end point. Note this


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added support for eu-south-1 'Europe (Milan)' and af-south-1 'Africa (Cape Town)' region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
