### PR TITLE
Consume snakeCase keys out of testconfiguration.json.

### DIFF
--- a/aws-android-sdk-testutils/src/main/java/com/amazonaws/testutils/AWSTestBase.java
+++ b/aws-android-sdk-testutils/src/main/java/com/amazonaws/testutils/AWSTestBase.java
@@ -80,19 +80,19 @@ public abstract class AWSTestBase {
         }
 
         String getAccessKey() throws KeyNotFoundException {
-            return extractStringByPath("Credentials.accessKey");
+            return extractStringByPath("credentials.accessKey");
         }
 
         String getSecretKey() throws KeyNotFoundException {
-            return extractStringByPath("Credentials.secretKey");
+            return extractStringByPath("credentials.secretKey");
         }
 
         String getSessionToken() throws KeyNotFoundException {
-            return extractStringByPath("Credentials.sessionToken");
+            return extractStringByPath("credentials.sessionToken");
         }
 
         String getAccountId() throws KeyNotFoundException {
-            return extractStringByPath("Credentials.accountId");
+            return extractStringByPath("credentials.accountId");
         }
 
         private String extractStringByPath(String path) throws KeyNotFoundException {

--- a/aws-android-sdk-testutils/src/main/java/com/amazonaws/testutils/AWSTestBase.java
+++ b/aws-android-sdk-testutils/src/main/java/com/amazonaws/testutils/AWSTestBase.java
@@ -68,7 +68,7 @@ public abstract class AWSTestBase {
 
         public JSONObject getPackageConfigure(String packageName) {
             try {
-                return mJSONObject.getJSONObject("Packages")
+                return mJSONObject.getJSONObject("packages")
                     .getJSONObject(packageName);
             }
             catch (JSONException | NullPointerException configurationFileError) {


### PR DESCRIPTION
The `testconfiguration.json` format has changed to use `"credentials"` and
`"packages"` at the top level of the JSON object.

The client needs to expect and read these values in snakeCase, not
PascalCase, as it currently does.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
