### PR TITLE
Use SES simulator address for testing

### DIFF
--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientNetworkIssueTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientNetworkIssueTest.java
@@ -61,8 +61,9 @@ import static org.junit.Assert.fail;
  */
 @RunWith(AndroidJUnit4.class)
 public class AWSMobileClientNetworkIssueTest extends AWSMobileClientTestBase {
-    private static final String TAG = AWSMobileClientNetworkIssueTest.class.getSimpleName();
+    private static final String EMAIL = "success+user@simulator.amazonses.com";
     private static final String USERNAME = "somebody";
+    public static final String PASSWORD = "1234Password!";
 
     private Context appContext;
     private AWSMobileClient auth;
@@ -214,7 +215,7 @@ public class AWSMobileClientNetworkIssueTest extends AWSMobileClientTestBase {
     @Test
     public void testNetworkExceptionPropagation_getTokens_federationStep1() throws Exception {
         reinitialize();
-        auth.signIn(USERNAME, "1234Password!", null);
+        auth.signIn(USERNAME, PASSWORD, null);
 
         Object originalCib = getField(auth.provider, AWSAbstractCognitoIdentityProvider.class, "cib");
         setField(auth.provider, AWSAbstractCognitoIdentityProvider.class, "cib", mockIdentityLowLevelGetId);
@@ -237,7 +238,7 @@ public class AWSMobileClientNetworkIssueTest extends AWSMobileClientTestBase {
     @Test
     public void testNetworkExceptionPropagation_getTokens_federationStep2() throws Exception {
         reinitialize();
-        auth.signIn(USERNAME, "1234Password!", null);
+        auth.signIn(USERNAME, PASSWORD, null);
 
         Object originalCib = getField(auth.cognitoIdentity, CognitoCredentialsProvider.class, "cib");
         setField(auth.cognitoIdentity, CognitoCredentialsProvider.class, "cib", mockIdentityLowLevelGetIdAndGetCredentials);

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientPersistenceTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientPersistenceTest.java
@@ -66,7 +66,7 @@ import static org.junit.Assert.fail;
 public class AWSMobileClientPersistenceTest extends AWSMobileClientTestBase {
     private static final String TAG = AWSMobileClientPersistenceTest.class.getSimpleName();
 
-    private static final String EMAIL = "somebody@email.com";
+    private static final String EMAIL = "success+user@simulator.amazonses.com";
     private static final String USERNAME = "somebody";
     private static final String PASSWORD = "1234Password!";
 

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientPersistenceWithRestartabilityTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientPersistenceWithRestartabilityTest.java
@@ -77,7 +77,7 @@ import static org.junit.Assert.fail;
 public class AWSMobileClientPersistenceWithRestartabilityTest extends AWSMobileClientTestBase {
     private static final String TAG = AWSMobileClientPersistenceTest.class.getSimpleName();
 
-    private static final String EMAIL = "somebody@email.com";
+    private static final String EMAIL = "success+user@simulator.amazonses.com";
     private static final String USERNAME = "somebody";
     private static final String PASSWORD = "1234Password!";
 

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientSignUpNoVerificationTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientSignUpNoVerificationTest.java
@@ -64,7 +64,7 @@ import static org.junit.Assert.assertNull;
 public class AWSMobileClientSignUpNoVerificationTest extends AWSMobileClientTestBase {
     private static final String TAG = AWSMobileClientTest.class.getSimpleName();
 
-    private static final String EMAIL = "somebody@email.com";
+    private static final String EMAIL = "success+user@simulator.amazonses.com";
     private static final String USERNAME = "somebody";
     private static final String PASSWORD = "1234Password!";
     private static final long THREAD_WAIT_DURATION = 60;

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTest.java
@@ -96,9 +96,8 @@ import static org.junit.Assert.fail;
 public class AWSMobileClientTest extends AWSMobileClientTestBase {
     private static final String TAG = AWSMobileClientTest.class.getSimpleName();
 
-    private static final String EMAIL = "somebody@email.com";
-    private static final String EMAIL_ADMIN_API_USER = "sombody-temp@amazon.com";
-    private static final String BLURRED_EMAIL = "s***@e***.com";
+    private static final String EMAIL = "success+user@simulator.amazonses.com";
+    private static final String EMAIL_ADMIN_API_USER = "success+admin@simulator.amazonses.com";
     private static final String USERNAME = "somebody";
     private static final String USERNAME_ADMIN_API_USER = "somebody-temp";
     private static final String PASSWORD = "1234Password!";
@@ -314,7 +313,7 @@ public class AWSMobileClientTest extends AWSMobileClientTestBase {
 
         final UserCodeDeliveryDetails details = signUpResult.getUserCodeDeliveryDetails();
         if (details != null) {
-            assertEquals(BLURRED_EMAIL, details.getDestination());
+            assertEquals("s***@e***.com", details.getDestination());
             assertEquals("email", details.getAttributeName());
             assertEquals("EMAIL", details.getDeliveryMedium());
         }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Use SES simulator address for testing

This suite was previously using made up addresses in real domains causing us to bounce emails through Cognito. This change uses the simulator address to simulate a successful email without potentially bounces to a third party mail server.

See https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-simulator.html for details.

- Remove unused TAG constant in AWSMobileClientNetworkIssueTest
- Extract PASSWORD constant in AWSMobileClientNetworkIssueTest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
