### PR TITLE
Add script to generate config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,13 @@ commands:
             aws configure --profile build_resources set region us-east-1
             echo -e "[build_resources]\naws_access_key_id=${BUILD_RESOURCES_AWS_ACCESS_KEY_ID_TEST}\naws_secret_access_key=${BUILD_RESOURCES_AWS_SECRET_ACCESS_KEY_TEST}\n" >> ~/.aws/credentials
 
+  build_test_config:
+    description: Runs the gradle task to build the testconfiguration.json file
+    steps:
+      - run:
+         name: run the script
+         command: bash gradlew buildTestConfig
+
   set_enviroment_variables:
     description: >-
       set environment variables
@@ -704,6 +711,7 @@ jobs:
     steps:
       - skip_job_if_required
       - set_enviroment_variables
+      - build_test_config
       - override_test_job
       - checkout
       - skip_test_job      

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 *.class
 
 # Generated files
-bin/
 gen/
 out/
 

--- a/bin/build_test_config.sh
+++ b/bin/build_test_config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+DEST_DIR=./aws-android-sdk-testutils/src/main/res/raw
+FILENAME=testconfiguration.json
+REPO=https://github.com/aws-amplify/amplify-ci-support
+SCRIPT=support/src/integ_test_resources/common/device_config_builder.py
+TMP_DIR=$HOME/.aws-amplify
+
+# Make directories if they don't exist
+mkdir -p "$TMP_DIR" "$DEST_DIR"
+
+# Remove previous repo
+rm -rf "${TMP_DIR}/support"
+
+# Clone the support repo into the temporary directory
+(cd "$TMP_DIR" && git clone "$REPO" support)
+
+# Generate file
+(cd "$TMP_DIR" && python "$SCRIPT" android > "$FILENAME")
+
+# Create symbolic link
+ln -f -s "${TMP_DIR}/${FILENAME}" "${DEST_DIR}/${FILENAME}"

--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,6 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
+task buildTestConfig(type:Exec) {
+  commandLine 'bin/build_test_config.sh'
+}


### PR DESCRIPTION
*Issue #, if available:* m/a

*Description of changes:* Add script to generate config file

We are generated a test configuration prior to running integration tests
using temporary credentials stored in the environment and configuration
properties stored in AWS Systems Manager Parameter Store. This commit:

- Adds a script to generate the file
- Creates a gradle task to run that script
- Adds a step to CircleCI in order to run the script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
