### PR TITLE
Add shipping ProGuard rules with artifacts

### DIFF
--- a/Proguard.md
+++ b/Proguard.md
@@ -1,32 +1,22 @@
-# Using Proguard with the AWS SDK for Android
+# Using ProGuard with the AWS SDK for Android
 
-## Modifying proguard-project.txt for the AWS SDK for Android
+* R8 users receive ProGuard rules automatically.
+  See [the `aws-android-sdk-core` package](aws-android-sdk-core/src/main/resources/META-INF/proguard/amazon-sdk.pro) and
+  [R8 conventions](https://developer.android.com/studio/build/shrink-code).
+* ProGuard users should include [rules](aws-android-sdk-core/src/main/resources/META-INF/proguard/amazon-sdk.pro)
+  on their own.
 
-When exporting your app using the AWS SDK for Android with the default, empty _proguard-project.txt_ file, you may notice that Eclipse reports errors. In order to correct these errors, add the following lines to the end of your _proguard-project.txt_ file:
-
-```
-# Class names are needed in reflection
--keepnames class com.amazonaws.**
--keepnames class com.amazon.**
-# Request handlers defined in request.handlers
--keep class com.amazonaws.services.**.*Handler
-# The following are referenced but aren't required to run
--dontwarn com.fasterxml.jackson.**
--dontwarn org.apache.commons.logging.**
-# Android 6.0 release removes support for the Apache HTTP client
--dontwarn org.apache.http.**
-# The SDK has several references of Apache HTTP client
--dontwarn com.amazonaws.http.**
--dontwarn com.amazonaws.metrics.**
-```
-
-**Note:** This configuration applies only to the AWS SDK for Android; if you are using other third-party libraries, you need to consult the documentation for those libraries to see if they require additional configuration to support the use of Proguard.
+**Note:** The ProGuard configuration mentioned above applies to the AWS SDK for Android.
+If you are using other third-party libraries, you need to consult the documentation
+for those libraries to see if they require additional configuration to support the use of ProGuard.
 
 ## Additional Resources
 
-The configuration provided in this article allows developers to ship apps using the AWS SDK for Android that use less of the user's storage.
+The configuration provided in this article allows developers to ship apps using the AWS SDK for Android
+that use less of the user’s storage.
 
-All samples in the AWS SDK for Android starting with version 1.3.0 ship with functional Proguard configuration. You can download the latest version of the AWS SDK for Android [here](http://aws.amazon.com/sdkforandroid).
+All samples in the AWS SDK for Android starting with version 1.3.0 ship with functional ProGuard configurations.
+You can download the latest version of the AWS SDK for Android [here](https://aws.amazon.com/amplify/).
 
 ## Questions?
 

--- a/aws-android-sdk-core/src/main/resources/META-INF/proguard/amazon-sdk.pro
+++ b/aws-android-sdk-core/src/main/resources/META-INF/proguard/amazon-sdk.pro
@@ -1,0 +1,17 @@
+# Class names are needed in reflection
+-keepnames class com.amazonaws.**
+-keepnames class com.amazon.**
+
+# Request handlers defined in request.handlers
+-keep class com.amazonaws.services.**.*Handler
+
+# The following are referenced but aren't required to run
+-dontwarn com.fasterxml.jackson.**
+-dontwarn org.apache.commons.logging.**
+
+# Android 6.0 release removes support for the Apache HTTP client
+-dontwarn org.apache.http.**
+
+# The SDK has several references of Apache HTTP client
+-dontwarn com.amazonaws.http.**
+-dontwarn com.amazonaws.metrics.**


### PR DESCRIPTION
It’s possible to include rules in JAR files which will be picked up by R8 (basically every modern AGP uses it).

* [Documentation](https://developer.android.com/studio/build/shrink-code#configuration-files) (see the _Library dependencies_ line).
* [Change](https://twitter.com/jakewharton/status/1004401938467876865).
* [Retrofit implementation](https://github.com/square/retrofit#r8--proguard).