### PR TITLE
ci: Replace master with main as default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ commands:
           command: |
             if [ -z "$target_branch" ]
             then 
-              target_branch="master"
+              target_branch="main"
             fi
 
             git config --local user.name "${GITHUB_BUMPVERSION_USER}"
@@ -166,7 +166,7 @@ commands:
           command: |
             if [ -z "$target_branch" ]
             then 
-              target_branch="master"
+              target_branch="main"
             fi          
             cd ${bumpversion_repo_name}
             git status
@@ -228,9 +228,9 @@ commands:
       - run:
           name: skip the test job if this is merged from develop by circleci
           command: |
-            skipflag=$(echo "${SKIPTEST_FOR_MASTER}") |  tr '[:upper:]' '[:lower:]' 
+            skipflag=$(echo "${SKIPTEST_FOR_MAIN}") |  tr '[:upper:]' '[:lower:]'
             commitmessage=$(git log --format=%B -n 1 ${CIRCLE_SHA1})
-            if [ "$skipflag" == "true" ] && [[ "$commitmessage" =~ .*"[Merge develop to master by circleci]".* ]] 
+            if [ "$skipflag" == "true" ] && [[ "$commitmessage" =~ .*"[Merge develop to main by circleci]".* ]] 
             then 
                echo "This is merged from develop by circleci. skip the test job"
                circleci step halt
@@ -241,12 +241,12 @@ commands:
       skip the test job is project variabe OVERRIDE_TEST is set with TRUE
     steps:
       - run:
-          name: skip test in master
+          name: skip test in main
           command: |
-              notskipflag=$(echo "${NOT_SKIPTESTINMASTER}" |  tr '[:upper:]' '[:lower:]')
-              if [ "${notskipflag}" != "true" ]  &&  [ "${CIRCLE_BRANCH}" == "master" ]
+              notskipflag=$(echo "${NOT_SKIPTESTINMAIN}" |  tr '[:upper:]' '[:lower:]')
+              if [ "${notskipflag}" != "true" ]  &&  [ "${CIRCLE_BRANCH}" == "main" ]
               then 
-                echo "bypass test job in master"
+                echo "bypass test job in main"
                 circleci step halt
               fi         
       - run:
@@ -281,7 +281,7 @@ commands:
           command: |
             echo "check if job can be skipped"
             # # we can add script here to halt a job for circleci script test
-            # declare -a jobs=("prepare_release_sdk" "merge_to_master" "bump_sdk_version")
+            # declare -a jobs=("prepare_release_sdk" "merge_to_main" "bump_sdk_version")
             # for i in "${jobs[@]}"
             # do
             #   echo "$i":"${CIRCLE_JOB}"
@@ -474,7 +474,7 @@ jobs:
           command: |
             git config --local user.name "${GITHUB_USER}"
             git checkout  gh-pages
-            git checkout master CircleciScripts/preserve_olddocument.sh
+            git checkout main CircleciScripts/preserve_olddocument.sh
             bash CircleciScripts/preserve_olddocument.sh
       - run:
           name: copy new document
@@ -880,7 +880,7 @@ jobs:
             python3 CircleciScripts/bump_sdk_version.py "$(pwd)/${bumpversion_repo_name}" $release_version
       - bump_version_post
 
-  merge_to_master:
+  merge_to_main:
     docker:
       - image: circleci/android:api-27-alpha
     environment:
@@ -890,11 +890,11 @@ jobs:
       - checkout
       - set_enviroment_variables
       - run:
-          name: merge change to master
+          name: merge change to main
           command: |
             git config --local user.name "${GITHUB_USER}"
             git status
-            git checkout master
+            git checkout main
             git status
             git fetch origin
             git status
@@ -904,7 +904,7 @@ jobs:
             git status
             git push https://${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git
             git status
-            commitlog=$(git log master -20)
+            commitlog=$(git log main -20)
             currentcommit="${CIRCLE_SHA1}"
             echo "currentcommit=$currentcommit"
             echo "$commitlog"
@@ -912,7 +912,7 @@ jobs:
             then
                echo "The change is already merged"
             else
-              echo "merge change from devlop to master"
+              echo "merge change from devlop to main"
               currentcommit="${CIRCLE_SHA1}"
               lastcommitmessage=$(git log --format=%B -n 1 ${currentcommit})
               git status
@@ -1109,7 +1109,7 @@ workflows:
           filters:
             branches:
               only:
-                - master      
+                - main      
     jobs:
       - check_sdk_on_maven  
   run_integrationtest_on_devicefarm:
@@ -1120,7 +1120,7 @@ workflows:
           filters:
             branches:
               only:
-                - master      
+                - main      
     jobs:
       - run_integrationtest_on_devicefarm  
 
@@ -1132,7 +1132,7 @@ workflows:
           filters:
             branches:
               only:
-                - master      
+                - main      
     jobs:
       - check_testresult_on_devicefarm    
   bump_sdk_version:
@@ -1168,7 +1168,7 @@ workflows:
            filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: apigateway
@@ -1178,7 +1178,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: autoscaling
@@ -1188,7 +1188,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: cloudwatch
@@ -1198,7 +1198,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: comprehend
@@ -1208,7 +1208,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: connect
@@ -1218,7 +1218,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: connectparticipant
@@ -1228,7 +1228,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: ddb-mapper
@@ -1238,7 +1238,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: ddb
@@ -1248,7 +1248,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: elb
@@ -1258,7 +1258,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: iot
@@ -1268,7 +1268,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: kinesis
@@ -1278,7 +1278,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       # - integrationtest:
       #     name: kinesisvideo-signaling
@@ -1288,7 +1288,7 @@ workflows:
       #     filters:
       #       branches:
       #         only:
-      #           - master
+      #           - main
       #           - develop
       - integrationtest:
           name: lambda
@@ -1298,7 +1298,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: pinpoint
@@ -1308,7 +1308,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: polly
@@ -1318,7 +1318,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: rekognition
@@ -1328,7 +1328,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: s3
@@ -1338,7 +1338,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: sdb
@@ -1348,7 +1348,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: ses
@@ -1358,7 +1358,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: sns
@@ -1368,7 +1368,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: sqs
@@ -1378,7 +1378,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: transcribe
@@ -1388,7 +1388,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: translate
@@ -1398,7 +1398,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: textract
@@ -1408,7 +1408,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: mobile-client
@@ -1418,7 +1418,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: CognitoIdentityProvider
@@ -1428,7 +1428,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: Core
@@ -1438,7 +1438,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: CognitoAuth
@@ -1448,7 +1448,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - develop
       - integrationtest:
           name: sagemakerruntime
@@ -1458,7 +1458,7 @@ workflows:
           filters:
             branches:
               only:
-              - master
+              - main
               - develop
       # - integrationtest:
       #     name: kinesisvideo
@@ -1468,7 +1468,7 @@ workflows:
       #     filters:
       #       branches:
       #         only:
-      #           - master
+      #           - main
       #           - develop   
       # - integrationtest:
       #     name: machinelearning
@@ -1478,7 +1478,7 @@ workflows:
       #     filters:
       #       branches:
       #         only:
-      #           - master
+      #           - main
       #           - develop
       # - integrationtest:
       #     name: kinesisvideo-archivedmedia
@@ -1488,7 +1488,7 @@ workflows:
       #     filters:
       #       branches:
       #         only:
-      #           - master
+      #           - main
       #           - develop
       - post_integrationtest:
           requires:
@@ -1524,7 +1524,7 @@ workflows:
             - Core
             - CognitoIdentityProvider
             - sagemakerruntime
-      - merge_to_master:
+      - merge_to_main:
           requires:
             - build_api10
             - build_api18
@@ -1545,7 +1545,7 @@ workflows:
           filters:
             branches:
               only:
-                - master         
+                - main
   release_sdk:
     jobs:
       - build:


### PR DESCRIPTION
This updates circle.yml to replace all references to `master` with `main` to support renaming our default branch to `main`.

Note: The build passes on this PR, but this doesn't necessarily confirm that these changes are safe, since some build steps only run on the default branch by design.  The only easy way to test is to merge this to the `main` branch and confirm the build still passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
