### PR TITLE
fix(aws-android-sdk-iot): workaround testrunner issue

### DIFF
--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -9,6 +9,7 @@ android {
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunnerArguments(['notClass': 'org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter'])
     }
 
     buildTypes {


### PR DESCRIPTION
The IoT tests don't run on Android 10. They produce the following error:

> java.lang.LinkageError: Method void
> org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter.connect(java.net.SocketAddress)
> overrides final method in class Lcom/android/org/conscrypt/ConscryptSocketBase;
> (declaration of 'org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter' appears
> in /data/app/com.amazonaws.iot.test-987m7jJF0YxP78CSDEBGgw==/base.apk)

Refer: https://github.com/google/conscrypt/issues/713

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
