### PR TITLE
Cleanup policy before iot tests

### DIFF
--- a/aws-android-sdk-iot-test/src/androidTest/java/com/amazonaws/mobileconnectors/iot/MqttManagerIntegrationTest.java
+++ b/aws-android-sdk-iot-test/src/androidTest/java/com/amazonaws/mobileconnectors/iot/MqttManagerIntegrationTest.java
@@ -79,6 +79,7 @@ public final class MqttManagerIntegrationTest extends AWSTestBase {
         );
         iotClient = new IotClient(credentialsProvider);
 
+        iotClient.cleanupPolicy(IOT_POLICY_NAME);
         keysAndCertificateInfo = iotClient.createAndAttachPolicy(IOT_POLICY_NAME, new JSONObject()
             .put("Version", "2012-10-17")
             .put("Statement", new JSONArray(Collections.singletonList(new JSONObject()


### PR DESCRIPTION
If the cleanup does not run in the @AfterClass (because the test
executable has stopped running before that point, for any
reason) then the policy cleanup won't happen.

To address this, run the policy cleanup as a first step in the
before-class setup.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your choice.
