### PR TITLE
Revert paho 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.16.13](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.13)
+
+### New Features
+
+- **AWS Mobile Client**
+  - Added client metadata as optional parameter to various methods
+- **AWS IoT**
+  - Model updates
+
 ## [Release 2.16.12](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.12)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Change Log - AWS SDK for Android
 
-## [Release 2.16.13](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.13)
-
-### New Features
-
-- **AWS Mobile Client**
-  - Added client metadata as optional parameter to various methods
-- **AWS IoT**
-  - Model updates
-
-### Bug Fixes
-
-- **AWS IoT**
-  - `AWSIoTMqttManager` is now compatible with Android < 7. See [Issue#1259](https://github.com/aws-amplify/aws-sdk-android/issues/1259) for details.
-
 ## [Release 2.16.12](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.12)
 
 ### New Features

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -23,7 +23,7 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
     implementation 'org.conscrypt:conscrypt-android:2.0.0'
-    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.3'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-all:1.10.5'

--- a/aws-android-sdk-iot/pom.xml
+++ b/aws-android-sdk-iot/pom.xml
@@ -24,7 +24,7 @@
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
       <optional>false</optional>
-      <version>1.2.3</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
87b8d3e83d4cb112196f9cfa6abdd5ece4aaa491 updated the IoT SDK's dependency on Paho, from 1.2.2 to 1.2.3. This update caused a regression, where-in IoT custom auth was broken.

Reverting 87b8d3e83d4cb112196f9cfa6abdd5ece4aaa491 will cause these IoT Custom Auth to go back to a passing/green state:

 1. `testWebSocketConnectionWithCustomAuth()`;
 2. `testWebsocketReconnectionWithCustomAuth()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
