### PR TITLE
fix(aws-android-sdk-iot): workaround mvn packaging

### DIFF
--- a/aws-android-sdk-iot/src/main/res/values/strings.xml
+++ b/aws-android-sdk-iot/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dummy">A dummy string.</string>
+</resources>
+


### PR DESCRIPTION
The Maven packaging task will fail to deploy the IoT artifact(s).
While attempting to do so, `maven deploy` will fail with this error:
    
> [ERROR] Failed to execute goal com.simpligility.maven.plugins:android-maven-plugin:4.5.0:generate-sources (default-generate-sources) on project aws-android-sdk-iot: Execution default-generate-sources of goal com.simpligility.maven.plugins:android-maven-plugin:4.5.0:generate-sources failed: java.nio.file.NoSuchFileException: /path/to/aws-sdk-android/aws-android-sdk-iot/target/R.txt -> [Help 1]
    
The reasons for this are not entirely clear.
    
However, adding at least one valid resource to the library project will
coerce the Maven plugin to "do the right thing," and continue the
build.
    
The contents of `aws-android-sdk-iot/target/R.txt` after this change
becomes:
```txt
int string dummy 0x7f020000
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
