### PR TITLE
chore: Treat javadoc errors as warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
             <excludePackageNames>*.internal:*.transform</excludePackageNames>
             <minmemory>128m</minmemory>
             <maxmemory>1024m</maxmemory>
-            <doclint>none</doclint>
           </configuration>
         </plugin>
         <plugin>
@@ -181,6 +180,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
It is unclear what changed since the last release, but javadoc warnings are now being treated as errors and causing the `mvn deploy` to fail.  Here's a snippet of the failure from the build log:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project ***************-core: MavenReportException: Error while creating archive: 
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module.
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/auth/policy/conditions/ArnCondition.java:28: error: bad use of '>'
[ERROR]  * <b>arn:aws:&lt;vendor>:&lt;region>:&lt;namespace>:&lt;relative-id></b>
[ERROR]                         ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/auth/policy/conditions/ArnCondition.java:28: error: bad use of '>'
[ERROR]  * <b>arn:aws:&lt;vendor>:&lt;region>:&lt;namespace>:&lt;relative-id></b>
[ERROR]                                     ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/auth/policy/conditions/ArnCondition.java:28: error: bad use of '>'
[ERROR]  * <b>arn:aws:&lt;vendor>:&lt;region>:&lt;namespace>:&lt;relative-id></b>
[ERROR]                                                    ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/auth/policy/conditions/ArnCondition.java:28: error: bad use of '>'
[ERROR]  * <b>arn:aws:&lt;vendor>:&lt;region>:&lt;namespace>:&lt;relative-id></b>
[ERROR]                                                                     ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/auth/policy/conditions/ArnCondition.java:29: warning: empty <p> tag
[ERROR]  * <p>
[ERROR]    ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/auth/policy/conditions/ArnCondition.java:41: warning: empty <p> tag
[ERROR]  * <p>
[ERROR]    ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/logging/Log.java:38: error: unexpected end tag: </p>
[ERROR]  * as expected.</p>
[ERROR]                ^
[ERROR] /Users/distiller/project/***************-core/src/main/java/com/amazonaws/logging/Log.java:46: error: block element not allowed within inline element <code>: pre
[ERROR]  * <code><pre>
```

To solve this, we can update the `pom.xml` to treat javadoc errors as warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
