### PR TITLE
2.16.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Change Log - AWS SDK for Android
 
-## [Release 2.16.13](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.13)
-
-### New Features
-
-- **AWS Mobile Client**
-  - Added client metadata as optional parameter to various methods
-- **AWS IoT**
-  - Model updates
-
-### Bug Fixes
-
-- **AWS IoT**
-  - `AWSIoTMqttManager` is now compatible with Android < 7. See [Issue#1259](https://github.com/aws-amplify/aws-sdk-android/issues/1259) for details.
-
 ## [Release 2.16.12](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.12)
 
 ### New Features

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -8,6 +8,7 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -23,7 +23,7 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
     implementation 'org.conscrypt:conscrypt-android:2.0.0'
-    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.3'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-all:1.10.5'

--- a/aws-android-sdk-iot/pom.xml
+++ b/aws-android-sdk-iot/pom.xml
@@ -24,7 +24,7 @@
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
       <optional>false</optional>
-      <version>1.2.3</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/aws-android-sdk-iot/src/main/res/values/strings.xml
+++ b/aws-android-sdk-iot/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dummy">A dummy string.</string>
+</resources>
+

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
             <excludePackageNames>*.internal:*.transform</excludePackageNames>
             <minmemory>128m</minmemory>
             <maxmemory>1024m</maxmemory>
-            <doclint>none</doclint>
           </configuration>
         </plugin>
         <plugin>
@@ -181,6 +180,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This PR contains the changes that were just released in 2.16.13.   Since this was a manual release instead of via CircleCI, the commits are going to be a little messy unfortunately.  Once we merge this to `main`, I'll manually merge it into `develop`.

While I was debugging the release script, I reverted two recent commits to try and get the release script working.
 1. Update Paho to 1.2.3 (so 2.16.13 actually has Paho 1.2.2).  This is fine, since it needed to be reverted anyway.  However, the commit also included the 2.16.13 release notes in `CHANGELOG.md`, so the release doesn't actually have an updated `CHANGELOG.md`.
 2. fix(aws-android-sdk-iot): workaround testrunner issue - I reverted it in an attempt to get past some iot module failures.

After I tag the release, I'll un-revert these two changes, and submit another PR.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
