### PR TITLE
Fix main branch issues related to manual release of 2.16.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - AWS SDK for Android
 
+## [Release 2.16.13](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.13)
+
+### New Features
+
+- **AWS Mobile Client**
+  - Added client metadata as optional parameter to various methods
+- **AWS IoT**
+  - Model updates
+
 ## [Release 2.16.12](https://github.com/aws/aws-sdk-android/releases/tag/release_v2.16.12)
 
 ### New Features

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {


### PR DESCRIPTION
In order to release 2.16.13, I manually made changes on the `main` branch, outside of the normal process of merging first to `develop` (https://github.com/aws-amplify/aws-sdk-android/pull/1979).  

All of the necessary changes have been added to the develop branch already:
  - Treat javadoc errors as warnings (https://github.com/aws-amplify/aws-sdk-android/pull/1978)
  - workaround mvn packaging R.txt error (https://github.com/aws-amplify/aws-sdk-android/pull/1977) 
  - Revert "Update Paho to 1.2.3" (https://github.com/aws-amplify/aws-sdk-android/pull/1975)


Some of those changes were unnecessary, and were simply part of the attempts to get the release working, but now should be reverted, which is what this PR is for.
 - Iot workaround test runner issue (reverted during release attempt, but this PR reverts the revert, since the change is okay)
 - Update CHANGELOG with notes for v2.16.13 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
