### PR TITLE
chore: use latest gradle and agp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
     parameters:
       gradle_version:
         description: "The version of Gradle to install"
-        default: "6.3"
+        default: "6.5.1"
         type: string
     steps:
       - run:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.3'
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip


### PR DESCRIPTION
Android Gradle Plugin stable release version is 4.0.0; use it.
Gradle stable release version is 6.5.1; use it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
