### PR TITLE
chore: use latest dependency versions

### DIFF
--- a/aws-android-sdk-auth-core/build.gradle
+++ b/aws-android-sdk-auth-core/build.gradle
@@ -17,7 +17,5 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-core')
-
-    testImplementation 'junit:junit:4.12'
 }
 

--- a/aws-android-sdk-auth-core/pom.xml
+++ b/aws-android-sdk-auth-core/pom.xml
@@ -27,12 +27,6 @@
       <optional>false</optional>
       <version>2.16.13</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/aws-android-sdk-auth-facebook/build.gradle
+++ b/aws-android-sdk-auth-facebook/build.gradle
@@ -18,8 +18,6 @@ android {
 dependencies {
     api project(':aws-android-sdk-auth-core')
     api 'com.facebook.android:facebook-android-sdk:4.1.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 

--- a/aws-android-sdk-auth-facebook/pom.xml
+++ b/aws-android-sdk-auth-facebook/pom.xml
@@ -35,32 +35,18 @@
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
-    </dependency>
-    <!-- import facebook-android-sdk while excluding its dependencies -->
-    <dependency>
       <groupId>com.facebook.android</groupId>
       <artifactId>facebook-android-sdk</artifactId>
       <version>4.1.0</version>
       <optional>false</optional>
       <type>aar</type>
-      <exclusions>
-        <exclusion>
-          <groupId>com.android.support</groupId>
-          <artifactId>support-v4</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
-    <!-- manually import facebook dependencies -->
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-v4</artifactId>
-      <version>23.0.1</version>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.1.0</version>
       <type>aar</type>
-      <optional>true</optional>
+      <optional>false</optional>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-auth-google/build.gradle
+++ b/aws-android-sdk-auth-google/build.gradle
@@ -17,9 +17,8 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-auth-core')
-    api 'com.google.android.gms:play-services-auth:9.8.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-
-    testImplementation 'junit:junit:4.12'
+    api 'com.google.android.gms:play-services-auth:18.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }
 

--- a/aws-android-sdk-auth-google/pom.xml
+++ b/aws-android-sdk-auth-google/pom.xml
@@ -35,24 +35,27 @@
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-v4</artifactId>
-      <version>23.0.1</version>
-      <optional>true</optional>
-      <type>aar</type>
-    </dependency>
-    <dependency>
       <groupId>com.google.android.gms</groupId>
       <artifactId>play-services-auth</artifactId>
-      <version>9.8.0</version>
+      <version>18.0.0</version>
       <optional>false</optional>
       <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>androidx.appcompat</groupId>
+      <artifactId>appcompat</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-auth-ui/build.gradle
+++ b/aws-android-sdk-auth-ui/build.gradle
@@ -18,8 +18,6 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-auth-core')
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }
 

--- a/aws-android-sdk-auth-ui/pom.xml
+++ b/aws-android-sdk-auth-ui/pom.xml
@@ -35,38 +35,9 @@
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-auth-google</artifactId>
-      <optional>true</optional>
-      <version>2.16.13</version>
-      <type>aar</type>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-auth-facebook</artifactId>
-      <optional>true</optional>
-      <version>2.16.13</version>
-      <type>aar</type>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-auth-userpools</artifactId>
-      <optional>true</optional>
-      <version>2.16.13</version>
-      <type>aar</type>
-    </dependency>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>appcompat-v7</artifactId>
-      <optional>true</optional>
-      <version>23.0.1</version>
-      <type>aar</type>
+      <groupId>androidx.appcompat</groupId>
+      <artifactId>appcompat</artifactId>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-auth-userpools/build.gradle
+++ b/aws-android-sdk-auth-userpools/build.gradle
@@ -18,8 +18,7 @@ android {
 dependencies {
     api project(':aws-android-sdk-auth-core')
     api project(':aws-android-sdk-cognitoidentityprovider')
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 

--- a/aws-android-sdk-auth-userpools/pom.xml
+++ b/aws-android-sdk-auth-userpools/pom.xml
@@ -29,28 +29,27 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-cognitoidentityprovider</artifactId>
-      <optional>false</optional>
-      <version>2.16.13</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-android-sdk-auth-core</artifactId>
       <optional>false</optional>
       <version>2.16.13</version>
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-android-sdk-cognitoidentityprovider</artifactId>
+      <optional>false</optional>
+      <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-v4</artifactId>
-      <optional>true</optional>
-      <version>23.0.1</version>
+      <groupId>androidx.appcompat</groupId>
+      <artifactId>appcompat</artifactId>
+      <version>1.1.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.1.0</version>
       <type>aar</type>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-autoscaling/build.gradle
+++ b/aws-android-sdk-autoscaling/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-cloudwatch/build.gradle
+++ b/aws-android-sdk-cloudwatch/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-cognito/build.gradle
+++ b/aws-android-sdk-cognito/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-cognito/pom.xml
+++ b/aws-android-sdk-cognito/pom.xml
@@ -27,12 +27,6 @@
       <optional>false</optional>
       <version>2.16.13</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>2.3.3</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -19,9 +19,7 @@ dependencies {
     api (project(':aws-android-sdk-core')) {
         exclude group: 'com.google.android', module: 'android'
     }
+    implementation 'androidx.browser:browser:1.2.0'
     implementation 'com.amazonaws:aws-android-sdk-cognitoidentityprovider-asf:1.0.0'
-    implementation 'androidx.browser:browser:1.0.0'
-
-    testImplementation 'junit:junit:4.12'
 }
 

--- a/aws-android-sdk-cognitoauth/pom.xml
+++ b/aws-android-sdk-cognitoauth/pom.xml
@@ -33,28 +33,21 @@
   </licenses>
   <dependencies>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-cognitoidentityprovider-asf</artifactId>
-      <optional>false</optional>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-android-sdk-core</artifactId>
       <optional>false</optional>
       <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>customtabs</artifactId>
-      <version>25.0.0</version>
-      <type>aar</type>
+      <groupId>androidx.browser</groupId>
+      <artifactId>browser</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-android-sdk-cognitoidentityprovider-asf</artifactId>
+      <optional>false</optional>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-cognitoidentityprovider-test/build.gradle
+++ b/aws-android-sdk-cognitoidentityprovider-test/build.gradle
@@ -18,13 +18,11 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.1'
-    androidTestImplementation 'com.google.dexmaker:dexmaker:1.1'
-    androidTestImplementation 'org.mockito:mockito-core:1.9.5'
-    androidTestImplementation 'org.mockito:mockito-core:2.19.0'
+    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
+    androidTestImplementation 'org.mockito:mockito-core:3.2.4'
     androidTestImplementation project(':aws-android-sdk-testutils')
 }
 

--- a/aws-android-sdk-cognitoidentityprovider/build.gradle
+++ b/aws-android-sdk-cognitoidentityprovider/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-comprehend/build.gradle
+++ b/aws-android-sdk-comprehend/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-connect/build.gradle
+++ b/aws-android-sdk-connect/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-connectparticipant/build.gradle
+++ b/aws-android-sdk-connectparticipant/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-core-test/build.gradle
+++ b/aws-android-sdk-core-test/build.gradle
@@ -18,10 +18,8 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation project(':aws-android-sdk-testutils')
 }
 

--- a/aws-android-sdk-core/build.gradle
+++ b/aws-android-sdk-core/build.gradle
@@ -9,7 +9,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
@@ -20,14 +19,14 @@ android {
 }
 
 dependencies {
-    api 'com.google.code.gson:gson:2.2.4'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.1.1'
+    api 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.11.0'
 
-    testImplementation 'joda-time:joda-time:2.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'joda-time:joda-time:2.8.1'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.apache.commons:commons-io:1.3.2'
     testImplementation 'org.easymock:easymock:3.1'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'xerces:xercesImpl:2.12.0'
     testRuntimeOnly 'org.apache.httpcomponents:httpclient:4.5.12'
 }

--- a/aws-android-sdk-core/pom.xml
+++ b/aws-android-sdk-core/pom.xml
@@ -16,35 +16,29 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.2.4</version>
+      <version>2.8.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.1.1</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.0</version>
+      <version>2.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -56,13 +50,19 @@
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>2.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-ddb-document/build.gradle
+++ b/aws-android-sdk-ddb-document/build.gradle
@@ -8,13 +8,12 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
 dependencies {
     api project(':aws-android-sdk-core')
-    implementation 'com.google.guava:guava:20.0'
     implementation project(':aws-android-sdk-ddb')
+    implementation 'com.google.guava:guava:29.0-android'
 }
 

--- a/aws-android-sdk-ddb-document/pom.xml
+++ b/aws-android-sdk-ddb-document/pom.xml
@@ -20,22 +20,16 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <optional>false</optional>
+      <version>29.0-android</version>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-android-sdk-ddb</artifactId>
       <optional>false</optional>
       <version>2.16.13</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <optional>false</optional>
-      <version>20.0</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-ddb-mapper/build.gradle
+++ b/aws-android-sdk-ddb-mapper/build.gradle
@@ -9,7 +9,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
@@ -17,7 +16,7 @@ dependencies {
     api project(':aws-android-sdk-ddb')
     api project(':aws-android-sdk-s3')
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.easymock:easymock:3.1'
     testRuntimeOnly 'org.apache.httpcomponents:httpclient:4.5.12'
 }

--- a/aws-android-sdk-ddb-mapper/pom.xml
+++ b/aws-android-sdk-ddb-mapper/pom.xml
@@ -15,12 +15,6 @@
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-core</artifactId>
-      <optional>false</optional>
-      <version>2.16.13</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-android-sdk-ddb</artifactId>
       <optional>false</optional>
       <version>2.16.13</version>
@@ -34,7 +28,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/aws-android-sdk-ddb/build.gradle
+++ b/aws-android-sdk-ddb/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-ddb/pom.xml
+++ b/aws-android-sdk-ddb/pom.xml
@@ -19,12 +19,6 @@
       <optional>false</optional>
       <version>2.16.13</version>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/aws-android-sdk-ec2/build.gradle
+++ b/aws-android-sdk-ec2/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-elb/build.gradle
+++ b/aws-android-sdk-elb/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -12,14 +12,14 @@ android {
 }
 
 dependencies {
-    api (project(':aws-android-sdk-core')){
+    api (project(':aws-android-sdk-core')) {
         exclude group: 'com.google.android', module: 'android'
     }
-    implementation 'org.conscrypt:conscrypt-android:2.0.0'
-    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.2'
+    implementation 'org.conscrypt:conscrypt-android:2.4.0'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.4'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 

--- a/aws-android-sdk-iot/pom.xml
+++ b/aws-android-sdk-iot/pom.xml
@@ -20,34 +20,34 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-android</artifactId>
+      <version>2.4.0</version>
+      <type>aar</type>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
       <optional>false</optional>
-      <version>1.2.2</version>
+      <version>1.2.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.robolectric</groupId>
-      <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-android</artifactId>
-      <version>2.0.0</version>
-      <type>aar</type>
+      <groupId>org.robolectric</groupId>
+      <artifactId>robolectric</artifactId>
+      <version>4.3.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-kinesis/build.gradle
+++ b/aws-android-sdk-kinesis/build.gradle
@@ -8,16 +8,15 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
 dependencies {
     api project(':aws-android-sdk-core')
 
-    testImplementation 'commons-lang:commons-lang:2.3'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'commons-lang:commons-lang:20030203.000129'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 

--- a/aws-android-sdk-kinesis/pom.xml
+++ b/aws-android-sdk-kinesis/pom.xml
@@ -20,27 +20,27 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>20030203.000129</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.3</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-kinesisvideo-archivedmedia/pom.xml
+++ b/aws-android-sdk-kinesisvideo-archivedmedia/pom.xml
@@ -20,10 +20,10 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-android-sdk-kinesisvideo</artifactId>
+      <optional>false</optional>
+      <version>2.16.13</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-kinesisvideo-signaling/build.gradle
+++ b/aws-android-sdk-kinesisvideo-signaling/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-kinesisvideo/build.gradle
+++ b/aws-android-sdk-kinesisvideo/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     api (project(':aws-android-sdk-core')) {
         exclude group: 'com.google.android', module: 'android'
     }
-    implementation 'androidx.annotation:annotation:1.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
     //noinspection DuplicatePlatformClasses
-    compileOnly 'org.apache.httpcomponents:httpclient:4.5.3'
+    compileOnly 'org.apache.httpcomponents:httpclient:4.5.12'
 }
 

--- a/aws-android-sdk-kinesisvideo/pom.xml
+++ b/aws-android-sdk-kinesisvideo/pom.xml
@@ -41,14 +41,14 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-annotations</artifactId>
-      <version>24.2.0</version>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.12</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-kms/build.gradle
+++ b/aws-android-sdk-kms/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-lambda/build.gradle
+++ b/aws-android-sdk-lambda/build.gradle
@@ -8,15 +8,14 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
 dependencies {
     api project(':aws-android-sdk-core')
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 

--- a/aws-android-sdk-lambda/pom.xml
+++ b/aws-android-sdk-lambda/pom.xml
@@ -22,19 +22,19 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-lex/build.gradle
+++ b/aws-android-sdk-lex/build.gradle
@@ -17,8 +17,6 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-core')
-    implementation 'com.google.guava:guava:20.0'
-
-    testImplementation 'junit:junit:4.12'
+    implementation 'com.google.guava:guava:29.0-android'
 }
 

--- a/aws-android-sdk-lex/pom.xml
+++ b/aws-android-sdk-lex/pom.xml
@@ -32,28 +32,10 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <optional>false</optional>
-      <version>20.0</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <version>3.1</version>
-      <scope>test</scope>
+      <version>29.0-android</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-android-sdk-logs/build.gradle
+++ b/aws-android-sdk-logs/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-machinelearning/build.gradle
+++ b/aws-android-sdk-machinelearning/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-mobile-client/build.gradle
+++ b/aws-android-sdk-mobile-client/build.gradle
@@ -9,7 +9,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     lintOptions {
@@ -39,7 +38,7 @@ dependencies {
     api(project(':aws-android-sdk-cognitoidentityprovider')) {
         exclude group: 'com.google.android', module: 'android'
     }
-    implementation 'androidx.core:core:1.0.0'
+    implementation 'androidx.core:core:1.3.0'
 
     // Optional dependencies
     compileOnly project(':aws-android-sdk-auth-ui')
@@ -47,14 +46,11 @@ dependencies {
     compileOnly project(':aws-android-sdk-auth-google')
     compileOnly project(':aws-android-sdk-auth-userpools')
     compileOnly project(':aws-android-sdk-cognitoauth')
-    compileOnly 'androidx.browser:browser:1.0.0'
+    compileOnly 'androidx.browser:browser:1.2.0'
 
-    testImplementation 'junit:junit:4.12'
-
-    androidTestImplementation 'androidx.appcompat:appcompat:1.0.0'
+    androidTestImplementation 'androidx.appcompat:appcompat:1.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
 
     androidTestImplementation (project(':aws-android-sdk-auth-facebook')) {
         exclude group: 'com.google.android', module: 'android'

--- a/aws-android-sdk-mobile-client/pom.xml
+++ b/aws-android-sdk-mobile-client/pom.xml
@@ -35,15 +35,16 @@
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-annotations</artifactId>
-      <version>27.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-android-sdk-cognitoidentityprovider</artifactId>
       <optional>false</optional>
       <version>2.16.13</version>
+    </dependency>
+    <dependency>
+      <groupId>androidx.core</groupId>
+      <artifactId>core</artifactId>
+      <optional>true</optional>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -53,22 +54,15 @@
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>appcompat-v7</artifactId>
-      <optional>true</optional>
-      <version>23.0.1</version>
-      <type>aar</type>
-    </dependency>
-    <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-auth-google</artifactId>
+      <artifactId>aws-android-sdk-auth-facebook</artifactId>
       <optional>true</optional>
       <version>2.16.13</version>
       <type>aar</type>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-android-sdk-auth-facebook</artifactId>
+      <artifactId>aws-android-sdk-auth-google</artifactId>
       <optional>true</optional>
       <version>2.16.13</version>
       <type>aar</type>
@@ -88,17 +82,9 @@
       <type>aar</type>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-v4</artifactId>
-      <optional>true</optional>
-      <version>23.0.1</version>
-      <type>aar</type>
-    </dependency>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>4.1.1.4</version>
-      <scope>provided</scope>
+      <groupId>androidx.browser</groupId>
+      <artifactId>browser</artifactId>
+      <version>1.2.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -125,3 +111,4 @@
     </plugins>
   </build>
 </project>
+

--- a/aws-android-sdk-mobileanalytics/build.gradle
+++ b/aws-android-sdk-mobileanalytics/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     lintOptions {
@@ -19,10 +18,10 @@ android {
 dependencies {
     api project(':aws-android-sdk-core')
 
-    testImplementation 'com.google.android:android-test:2.2.1'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'com.google.android:android-test:4.1.1.4'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 

--- a/aws-android-sdk-mobileanalytics/pom.xml
+++ b/aws-android-sdk-mobileanalytics/pom.xml
@@ -20,21 +20,15 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android-test</artifactId>
+      <version>4.1.1.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.robolectric</groupId>
-      <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -44,9 +38,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android-test</artifactId>
-      <version>2.2.1</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>robolectric</artifactId>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-pinpoint-test/build.gradle
+++ b/aws-android-sdk-pinpoint-test/build.gradle
@@ -18,7 +18,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation project(':aws-android-sdk-testutils')

--- a/aws-android-sdk-pinpoint/build.gradle
+++ b/aws-android-sdk-pinpoint/build.gradle
@@ -8,18 +8,16 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
 dependencies {
     api project(':aws-android-sdk-core')
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 

--- a/aws-android-sdk-pinpoint/pom.xml
+++ b/aws-android-sdk-pinpoint/pom.xml
@@ -20,39 +20,32 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>com.android.support</groupId>
-      <artifactId>support-v4</artifactId>
-      <optional>false</optional>
-      <version>27.1.1</version>
+      <groupId>androidx.appcompat</groupId>
+      <artifactId>appcompat</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>androidx.test</groupId>
+      <artifactId>core</artifactId>
+      <version>1.2.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4-rule</artifactId>
-      <version>1.6.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.6</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/analytics/MobileAnalyticsTestBase.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/analytics/MobileAnalyticsTestBase.java
@@ -16,20 +16,15 @@
 package com.amazonaws.mobileconnectors.pinpoint.analytics;
 
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 @RunWith(RobolectricTestRunner.class)
-@PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "android.*" })
-@Config(manifest = Config.NONE, sdk=23)
 public abstract class MobileAnalyticsTestBase {
-
     static {
         // redirect the Log.x output to stdout. Stdout will be recorded in the
         // test result report
         ShadowLog.stream = System.out;
     }
-
 }
+

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorderTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorderTest.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.internal.event;
 
+import android.database.Cursor;
+import android.net.Uri;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -22,17 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import com.amazonaws.logging.Log;
-import com.amazonaws.mobileconnectors.pinpoint.internal.core.configuration.AndroidPreferencesConfiguration;
-import com.amazonaws.mobileconnectors.pinpoint.targeting.endpointProfile.EndpointProfile;
-import com.amazonaws.services.pinpoint.model.BadRequestException;
-import com.amazonaws.services.pinpoint.model.EndpointItemResponse;
-import com.amazonaws.services.pinpoint.model.Event;
-import com.amazonaws.services.pinpoint.model.EventItemResponse;
-import com.amazonaws.services.pinpoint.model.EventsResponse;
-import com.amazonaws.services.pinpoint.model.ItemResponse;
-import com.amazonaws.services.pinpoint.model.PutEventsResult;
-import com.amazonaws.services.pinpoint.model.PutEventsRequest;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -45,20 +37,26 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.OngoingStubbing;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
+
+import com.amazonaws.logging.Log;
 import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent;
 import com.amazonaws.mobileconnectors.pinpoint.analytics.utils.AnalyticsContextBuilder;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.PinpointContext;
+import com.amazonaws.mobileconnectors.pinpoint.internal.core.configuration.AndroidPreferencesConfiguration;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.system.MockAppDetails;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.system.MockDeviceDetails;
+import com.amazonaws.mobileconnectors.pinpoint.targeting.endpointProfile.EndpointProfile;
+import com.amazonaws.services.pinpoint.model.BadRequestException;
+import com.amazonaws.services.pinpoint.model.EndpointItemResponse;
+import com.amazonaws.services.pinpoint.model.Event;
+import com.amazonaws.services.pinpoint.model.EventItemResponse;
+import com.amazonaws.services.pinpoint.model.EventsResponse;
+import com.amazonaws.services.pinpoint.model.ItemResponse;
+import com.amazonaws.services.pinpoint.model.PutEventsRequest;
+import com.amazonaws.services.pinpoint.model.PutEventsResult;
 import com.amazonaws.services.pinpointanalytics.AmazonPinpointAnalyticsClient;
-import android.database.Cursor;
-import android.net.Uri;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -70,10 +68,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(RobolectricTestRunner.class)
-@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
-@Config(manifest = Config.NONE, sdk=23)
+@RunWith(RobolectricTestRunner.class)
 public class EventRecorderTest {
     private static final String SDK_NAME = "AppIntelligenceSDK-Analytics";
     private static final String SDK_VERSION = "test";

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
@@ -15,11 +15,13 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.targeting.notification;
 
+import android.app.Service;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
-import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent;
-import com.amazonaws.mobileconnectors.pinpoint.internal.event.EventRecorder;
+import android.os.Bundle;
+import androidx.test.core.app.ApplicationProvider;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -31,46 +33,37 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
+
 import com.amazonaws.mobileconnectors.pinpoint.PinpointConfiguration;
 import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsClient;
+import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent;
 import com.amazonaws.mobileconnectors.pinpoint.analytics.MobileAnalyticsTestBase;
 import com.amazonaws.mobileconnectors.pinpoint.analytics.utils.AnalyticsContextBuilder;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.PinpointContext;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.configuration.AndroidPreferencesConfiguration;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.system.MockSystem;
+import com.amazonaws.mobileconnectors.pinpoint.internal.event.EventRecorder;
 import com.amazonaws.mobileconnectors.pinpoint.targeting.TargetingClient;
 import com.amazonaws.services.pinpoint.model.ChannelType;
-
-import android.app.Service;
-import android.os.Bundle;
 
 import java.util.Map;
 
 import static com.amazonaws.mobileconnectors.pinpoint.targeting.notification.NotificationClient.GCM_INTENT_ACTION;
-import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 @RunWith(RobolectricTestRunner.class)
-//@PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "android.*" })
-//@PrepareForTest(Static.class)
-@Config(manifest = Config.NONE)
 public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
-
-//    @Rule
-//    public PowerMockRule rule = new PowerMockRule();
-
     @Mock
     AndroidPreferencesConfiguration mockConfiguration;
     private NotificationClient target;
@@ -90,8 +83,7 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        final Context roboContext = RuntimeEnvironment.application
-            .getApplicationContext();
+        Context roboContext = ApplicationProvider.getApplicationContext();
         spiedRoboContext = Mockito.spy(roboContext);
         mockPinpointContext = new AnalyticsContextBuilder()
                                                       .withSystem(new MockSystem("JIMMY_CRACKED_CORN.and"))

--- a/aws-android-sdk-polly/build.gradle
+++ b/aws-android-sdk-polly/build.gradle
@@ -9,15 +9,14 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
 dependencies {
     api project(':aws-android-sdk-core')
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
     testRuntimeOnly 'org.apache.httpcomponents:httpclient:4.5.12'
 }
 

--- a/aws-android-sdk-polly/pom.xml
+++ b/aws-android-sdk-polly/pom.xml
@@ -22,13 +22,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/aws-android-sdk-rekognition/build.gradle
+++ b/aws-android-sdk-rekognition/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-rekognition/pom.xml
+++ b/aws-android-sdk-rekognition/pom.xml
@@ -19,18 +19,6 @@
       <optional>false</optional>
       <version>2.16.13</version>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/aws-android-sdk-s3-test/build.gradle
+++ b/aws-android-sdk-s3-test/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    androidTestImplementation 'androidx.appcompat:appcompat:1.0.0'
+    androidTestImplementation 'androidx.appcompat:appcompat:1.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'org.apache.commons:commons-io:1.3.2'

--- a/aws-android-sdk-s3/build.gradle
+++ b/aws-android-sdk-s3/build.gradle
@@ -9,7 +9,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
@@ -17,12 +16,12 @@ dependencies {
     api project(':aws-android-sdk-core')
     api project(':aws-android-sdk-kms')
 
-    testImplementation 'commons-logging:commons-logging:1.1.1'
-    testImplementation 'joda-time:joda-time:2.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'commons-logging:commons-logging:1.2'
+    testImplementation 'joda-time:joda-time:2.8.1'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.apache.commons:commons-io:1.3.2'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'org.mockito:mockito-all:1.10.19'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testRuntimeOnly 'org.apache.httpcomponents:httpclient:4.5.12'
 }
 

--- a/aws-android-sdk-s3/pom.xml
+++ b/aws-android-sdk-s3/pom.xml
@@ -28,19 +28,19 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.1.1</version>
+      <version>1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.0</version>
+      <version>2.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -52,13 +52,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/model/transform/BucketNotificationConfigurationStaxUnmarshallerTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/services/s3/model/transform/BucketNotificationConfigurationStaxUnmarshallerTest.java
@@ -26,13 +26,15 @@ import com.amazonaws.services.s3.model.TopicConfiguration;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
 
+@RunWith(RobolectricTestRunner.class)
 public class BucketNotificationConfigurationStaxUnmarshallerTest {
-
     private static final String TOPIC_INPUT = "TopicConfiguration.xml";
     private static final String QUEUE_INPUT = "QueueConfiguration.xml";
     private static final String LAMBDA_INPUT = "LambdaConfiguration.xml";

--- a/aws-android-sdk-sagemaker-runtime/build.gradle
+++ b/aws-android-sdk-sagemaker-runtime/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-sdb/build.gradle
+++ b/aws-android-sdk-sdb/build.gradle
@@ -8,15 +8,13 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 
 dependencies {
     api project(':aws-android-sdk-core')
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-all:1.10.5'
-    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 

--- a/aws-android-sdk-sdb/pom.xml
+++ b/aws-android-sdk-sdb/pom.xml
@@ -22,19 +22,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.5</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>3.8</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-android-sdk-ses/build.gradle
+++ b/aws-android-sdk-ses/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-sns/build.gradle
+++ b/aws-android-sdk-sns/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-sqs/build.gradle
+++ b/aws-android-sdk-sqs/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-testutils/build.gradle
+++ b/aws-android-sdk-testutils/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     api (project(':aws-android-sdk-core')) {
         exclude group: 'com.google.android', module: 'android'
     }
+    implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.test.ext:junit:1.1.1'
-
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.test:core:1.2.0'
 }
 

--- a/aws-android-sdk-textract/build.gradle
+++ b/aws-android-sdk-textract/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-transcribe/build.gradle
+++ b/aws-android-sdk-transcribe/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 

--- a/aws-android-sdk-translate/build.gradle
+++ b/aws-android-sdk-translate/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 }
 


### PR DESCRIPTION
The SDK has not been receiving regular updates to its dependencies. As a result, many of them have drifted out of date. This large "catch up" commit
updates all dependencies to the latest versions available from Maven.

This change may have impact to the consumer's dependency graph, and may be
considered a breaking change. It will go into the 2.17.0 release.

-------------

The `build.gradle` and `pom.xml` of each module is updated to include the latest
versions available through Maven.

The `pom.xml`s had drifted from the `build.gradle`s, so the change made here is not a directly matching update. After this commit, the `pom.xml`s should accurately reflect the current state of the
`build.gradle` dependencies. Future work will onboard a plugin to automatically
generate the `pom.xml`, to better ensure they are kept in sync.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
