### PR TITLE
Change Gradle Android SDK values to be reuseable

### DIFF
--- a/aws-android-sdk-apigateway-core/build.gradle
+++ b/aws-android-sdk-apigateway-core/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-apigateway-test/build.gradle
+++ b/aws-android-sdk-apigateway-test/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/aws-android-sdk-auth-core/build.gradle
+++ b/aws-android-sdk-auth-core/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-auth-facebook/build.gradle
+++ b/aws-android-sdk-auth-facebook/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-auth-google/build.gradle
+++ b/aws-android-sdk-auth-google/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-auth-ui/build.gradle
+++ b/aws-android-sdk-auth-ui/build.gradle
@@ -1,14 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
-
     }
 
     lintOptions {

--- a/aws-android-sdk-auth-userpools/build.gradle
+++ b/aws-android-sdk-auth-userpools/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-autoscaling/build.gradle
+++ b/aws-android-sdk-autoscaling/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-cloudwatch/build.gradle
+++ b/aws-android-sdk-cloudwatch/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-cognito/build.gradle
+++ b/aws-android-sdk-cognito/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-cognitoidentityprovider-test/build.gradle
+++ b/aws-android-sdk-cognitoidentityprovider-test/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'devicefarm'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/aws-android-sdk-cognitoidentityprovider/build.gradle
+++ b/aws-android-sdk-cognitoidentityprovider/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-comprehend/build.gradle
+++ b/aws-android-sdk-comprehend/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-connect/build.gradle
+++ b/aws-android-sdk-connect/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-connectparticipant/build.gradle
+++ b/aws-android-sdk-connectparticipant/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-core-test/build.gradle
+++ b/aws-android-sdk-core-test/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'devicefarm'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/aws-android-sdk-core/build.gradle
+++ b/aws-android-sdk-core/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
 

--- a/aws-android-sdk-ddb-document/build.gradle
+++ b/aws-android-sdk-ddb-document/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-ddb-mapper/build.gradle
+++ b/aws-android-sdk-ddb-mapper/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-ddb/build.gradle
+++ b/aws-android-sdk-ddb/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-ec2/build.gradle
+++ b/aws-android-sdk-ec2/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-elb/build.gradle
+++ b/aws-android-sdk-elb/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-iot-test/build.gradle
+++ b/aws-android-sdk-iot-test/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-kinesis/build.gradle
+++ b/aws-android-sdk-kinesis/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-kinesisvideo-archivedmedia/build.gradle
+++ b/aws-android-sdk-kinesisvideo-archivedmedia/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-kinesisvideo-signaling/build.gradle
+++ b/aws-android-sdk-kinesisvideo-signaling/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-kinesisvideo/build.gradle
+++ b/aws-android-sdk-kinesisvideo/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-kms/build.gradle
+++ b/aws-android-sdk-kms/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-lambda/build.gradle
+++ b/aws-android-sdk-lambda/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-lex/build.gradle
+++ b/aws-android-sdk-lex/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-logs/build.gradle
+++ b/aws-android-sdk-logs/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-machinelearning/build.gradle
+++ b/aws-android-sdk-machinelearning/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-mobile-client/build.gradle
+++ b/aws-android-sdk-mobile-client/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'devicefarm'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-mobileanalytics/build.gradle
+++ b/aws-android-sdk-mobileanalytics/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-pinpoint-test/build.gradle
+++ b/aws-android-sdk-pinpoint-test/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'devicefarm'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // For UIAutomator
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/aws-android-sdk-pinpoint/build.gradle
+++ b/aws-android-sdk-pinpoint/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-polly/build.gradle
+++ b/aws-android-sdk-polly/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-rekognition/build.gradle
+++ b/aws-android-sdk-rekognition/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-s3-test/build.gradle
+++ b/aws-android-sdk-s3-test/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'devicefarm'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/aws-android-sdk-s3/build.gradle
+++ b/aws-android-sdk-s3/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-sagemaker-runtime/build.gradle
+++ b/aws-android-sdk-sagemaker-runtime/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-sdb/build.gradle
+++ b/aws-android-sdk-sdb/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-ses/build.gradle
+++ b/aws-android-sdk-ses/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-sns/build.gradle
+++ b/aws-android-sdk-sns/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-sqs/build.gradle
+++ b/aws-android-sdk-sqs/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-testutils/build.gradle
+++ b/aws-android-sdk-testutils/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator, etc.
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM_TEST
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-textract/build.gradle
+++ b/aws-android-sdk-textract/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-transcribe/build.gradle
+++ b/aws-android-sdk-transcribe/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/aws-android-sdk-translate/build.gradle
+++ b/aws-android-sdk-translate/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion AndroidSdk.COMPILE
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 28
+        minSdkVersion AndroidSdk.MINIMUM
+        targetSdkVersion AndroidSdk.TARGET
         versionCode 1
         versionName '1.0'
     }

--- a/buildSrc/src/main/java/AndroidSdk.java
+++ b/buildSrc/src/main/java/AndroidSdk.java
@@ -1,6 +1,6 @@
 class AndroidSdk {
-		public static final int COMPILE = 28;
-		public static final int MINIMUM = 15;
-		public static final int MINIMUM_TEST = 18; // UI Automator
-		public static final int TARGET = 28;
+    public static final int COMPILE = 28;
+    public static final int MINIMUM = 15;
+    public static final int MINIMUM_TEST = 18; // UI Automator
+    public static final int TARGET = 28;
 }

--- a/buildSrc/src/main/java/AndroidSdk.java
+++ b/buildSrc/src/main/java/AndroidSdk.java
@@ -1,0 +1,6 @@
+class AndroidSdk {
+		public static final int COMPILE = 28;
+		public static final int MINIMUM = 15;
+		public static final int MINIMUM_TEST = 18; // UI Automator
+		public static final int TARGET = 28;
+}


### PR DESCRIPTION
Dependencies can be organized this way as well but doing both in a single change feels too dangerous.

PTAL @jamesonwilliams 