### PR TITLE
fix: derrive min sdk values from android lint

### DIFF
--- a/aws-android-sdk-apigateway-core/build.gradle
+++ b/aws-android-sdk-apigateway-core/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-apigateway-test/build.gradle
+++ b/aws-android-sdk-apigateway-test/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
+        minSdkVersion 14 // junit ext
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-auth-core/build.gradle
+++ b/aws-android-sdk-auth-core/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 11
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-auth-facebook/build.gradle
+++ b/aws-android-sdk-auth-facebook/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14 // v4 support, brought from facebook sdk
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-auth-google/build.gradle
+++ b/aws-android-sdk-auth-google/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14 // gms auth brought by google sdk
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-auth-ui/build.gradle
+++ b/aws-android-sdk-auth-ui/build.gradle
@@ -4,15 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14 // appcompat
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-auth-userpools/build.gradle
+++ b/aws-android-sdk-auth-userpools/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14 // setAllCaps(), 11 otherwise
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-autoscaling/build.gradle
+++ b/aws-android-sdk-autoscaling/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-cloudwatch/build.gradle
+++ b/aws-android-sdk-cloudwatch/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-cognito/build.gradle
+++ b/aws-android-sdk-cognito/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -4,14 +4,15 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16 // androidx.browser
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
     }
 
-    lintOptions {
-        abortOnError false
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
 }
 

--- a/aws-android-sdk-cognitoidentityprovider-test/build.gradle
+++ b/aws-android-sdk-cognitoidentityprovider-test/build.gradle
@@ -5,11 +5,16 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
+        minSdkVersion 14 // junit ext
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
 }
 

--- a/aws-android-sdk-cognitoidentityprovider/build.gradle
+++ b/aws-android-sdk-cognitoidentityprovider/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-comprehend/build.gradle
+++ b/aws-android-sdk-comprehend/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-connect/build.gradle
+++ b/aws-android-sdk-connect/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-connectparticipant/build.gradle
+++ b/aws-android-sdk-connectparticipant/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-core-test/build.gradle
+++ b/aws-android-sdk-core-test/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
+        minSdkVersion 14 // junit ext
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-core/build.gradle
+++ b/aws-android-sdk-core/build.gradle
@@ -5,21 +5,18 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
 
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
-
-    lintOptions {
-        warning 'NewApi' // Guarding issues in KeyValueStore
-    }
 }
 
 dependencies {
     api 'com.google.code.gson:gson:2.8.6'
+    implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.11.0'
 
     testImplementation 'joda-time:joda-time:2.8.1'

--- a/aws-android-sdk-core/pom.xml
+++ b/aws-android-sdk-core/pom.xml
@@ -19,6 +19,11 @@
       <version>2.8.6</version>
     </dependency>
     <dependency>
+      <groupId>androidx.annotation</groupId>
+      <artifactId>annotation</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.11.0</version>

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
@@ -61,10 +61,6 @@ public class AWSKeyValueStore {
     // SecureRandom is expensive.
     private SecureRandom secureRandom;
 
-    private static final int ANDROID_API_LEVEL_23 = 23;
-    private static final int ANDROID_API_LEVEL_18 = 18;
-    private static final int ANDROID_API_LEVEL_10 = 10;
-
     private static final String CIPHER_AES_GCM_NOPADDING = "AES/GCM/NoPadding";
     private static final int CIPHER_AES_GCM_NOPADDING_IV_LENGTH_IN_BYTES = 12;
     private static final int CIPHER_AES_GCM_NOPADDING_TAG_LENGTH_LENGTH_IN_BITS = 128;
@@ -102,8 +98,6 @@ public class AWSKeyValueStore {
 
     private static final int AWS_KEY_VALUE_STORE_VERSION = 1;
 
-    private int apiLevel;
-
     private static Map<String, String> getCacheForKey(String key) {
         if (cacheFactory.containsKey(key)) {
             return cacheFactory.get(key);
@@ -129,7 +123,6 @@ public class AWSKeyValueStore {
         this.secureRandom = new SecureRandom();
         this.cache = getCacheForKey(sharedPreferencesName);
         this.sharedPreferencesName = sharedPreferencesName;
-        this.apiLevel = Build.VERSION.SDK_INT;
         this.context = context;
         setPersistenceEnabled(isPersistenceEnabled);
     }
@@ -156,7 +149,7 @@ public class AWSKeyValueStore {
 
                 initKeyProviderBasedOnAPILevel();
 
-                logger.info("Detected Android API Level = " + apiLevel);
+                logger.info("Detected Android API Level = " + Build.VERSION.SDK_INT);
                 logger.info("Creating the AWSKeyValueStore with key for " +
                         "sharedPreferencesForData = " + sharedPreferencesName);
 
@@ -471,11 +464,11 @@ public class AWSKeyValueStore {
     }
 
     private AlgorithmParameterSpec getAlgorithmParameterSpecForIV(byte[] iv) {
-        return
-            //@apiLevel23Start
-            apiLevel >= ANDROID_API_LEVEL_23 ? new GCMParameterSpec(CIPHER_AES_GCM_NOPADDING_TAG_LENGTH_LENGTH_IN_BITS, iv) :
-            //@apiLevel23End
-            new IvParameterSpec(iv);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return new GCMParameterSpec(CIPHER_AES_GCM_NOPADDING_TAG_LENGTH_LENGTH_IN_BITS, iv);
+        } else {
+            return new IvParameterSpec(iv);
+        }
     }
 
     private synchronized Key retrieveEncryptionKey(final String encryptionKeyAlias) {
@@ -516,20 +509,14 @@ public class AWSKeyValueStore {
     }
 
     private String getEncryptionKeyAlias() {
-        if (apiLevel >= ANDROID_API_LEVEL_23) {
-            //@apiLevel23Start
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             return sharedPreferencesName +
                     KeyProvider23.AWS_KEY_VALUE_STORE_VERSION_1_KEY_STORE_ALIAS_FOR_AES_SUFFIX;
-            //@apiLevel23End
-        } else if (apiLevel >= ANDROID_API_LEVEL_18) {
-            //@apiLevel18Start
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             return sharedPreferencesName +
                     KeyProvider18.AWS_KEY_VALUE_STORE_VERSION_1_KEY_STORE_ALIAS_FOR_RSA_SUFFIX;
-            //@apiLevel18End
-        } else if (apiLevel >= ANDROID_API_LEVEL_10) {
-            //@apiLevel10Start
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD_MR1) {
             return KeyProvider10.KEY_ALIAS;
-            //@apiLevel10End
         } else {
             logger.error("API Level " +
                     String.valueOf(Build.VERSION.SDK_INT) +
@@ -545,18 +532,12 @@ public class AWSKeyValueStore {
      * based on the Android API Level.
      */
     private void initKeyProviderBasedOnAPILevel() {
-        if (apiLevel >= ANDROID_API_LEVEL_23) {
-            //@apiLevel23Start
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             keyProvider = new KeyProvider23();
-            //@apiLevel23End
-        } else if (apiLevel >= ANDROID_API_LEVEL_18) {
-            //@apiLevel18Start
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             keyProvider = new KeyProvider18(context, sharedPreferencesForEncryptionMaterials);
-            //@apiLevel18End
-        } else if (apiLevel >= ANDROID_API_LEVEL_10) {
-            //@apiLevel10Start
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD_MR1) {
             keyProvider = new KeyProvider10(sharedPreferencesForEncryptionMaterials);
-            //@apiLevel10End
         } else {
             logger.error("API Level " +
                     String.valueOf(Build.VERSION.SDK_INT) +

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyNotGeneratedException.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyNotGeneratedException.java
@@ -16,8 +16,5 @@ public class KeyNotGeneratedException extends Exception {
     public KeyNotGeneratedException(Throwable throwable) {
         super(throwable);
     }
-
-    protected KeyNotGeneratedException(String s, Throwable throwable, boolean b, boolean b1) {
-        super(s, throwable, b, b1);
-    }
 }
+

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider18.java
@@ -17,7 +17,9 @@ package com.amazonaws.internal.keyvaluestore;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
+import androidx.annotation.RequiresApi;
 
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
@@ -52,6 +54,7 @@ import javax.security.auth.x500.X500Principal;
  * in SharedPreferences. The AES key is returned in the
  * getKey call.
  */
+@RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
 public class KeyProvider18 implements KeyProvider {
 
     private static final Log logger = LogFactory.getLog(KeyProvider18.class);

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/KeyProvider23.java
@@ -15,8 +15,10 @@
 
 package com.amazonaws.internal.keyvaluestore;
 
+import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
+import androidx.annotation.RequiresApi;
 
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
@@ -30,6 +32,7 @@ import javax.crypto.KeyGenerator;
  * This provider generates a AES 256-bit key using
  * AndroidKeyStore.
  */
+@RequiresApi(api = Build.VERSION_CODES.M)
 class KeyProvider23 implements KeyProvider {
 
     private static final Log logger = LogFactory.getLog(KeyProvider23.class);

--- a/aws-android-sdk-ddb-document/build.gradle
+++ b/aws-android-sdk-ddb-document/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-ddb-mapper/build.gradle
+++ b/aws-android-sdk-ddb-mapper/build.gradle
@@ -5,7 +5,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-ddb/build.gradle
+++ b/aws-android-sdk-ddb/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-ec2/build.gradle
+++ b/aws-android-sdk-ec2/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-elb/build.gradle
+++ b/aws-android-sdk-elb/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-iot-test/build.gradle
+++ b/aws-android-sdk-iot-test/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
+        minSdkVersion 14 // junit ext
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-iot/build.gradle
+++ b/aws-android-sdk-iot/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-kinesis/build.gradle
+++ b/aws-android-sdk-kinesis/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-kinesisvideo-archivedmedia/build.gradle
+++ b/aws-android-sdk-kinesisvideo-archivedmedia/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 21 // for kinesisvideo, which uses camera2 APIs.
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 
     packagingOptions {

--- a/aws-android-sdk-kinesisvideo-signaling/build.gradle
+++ b/aws-android-sdk-kinesisvideo-signaling/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-kinesisvideo/build.gradle
+++ b/aws-android-sdk-kinesisvideo/build.gradle
@@ -5,7 +5,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 21 // android.hardware.camera2
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
@@ -13,10 +13,6 @@ android {
 
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/encoding/ChunkDecoder.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/encoding/ChunkDecoder.java
@@ -26,7 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,7 +53,7 @@ public final class ChunkDecoder {
 
         try {
             final String headersAsString =
-                    readInputStream(inputStream, PAYLOAD_DELIMITER.getBytes(StandardCharsets.UTF_8));
+                    readInputStream(inputStream, PAYLOAD_DELIMITER.getBytes(Charset.forName("UTF-8")));
             for (final String line : headersAsString.split(LINE_DELIMITER)) {
                 headerParts = line.split(":", 2);
                 if (headerParts.length == 2) {
@@ -73,7 +73,7 @@ public final class ChunkDecoder {
 
     private static ResponseStatus parseStatusLine(final InputStream inputStream) {
         try {
-            final String statusLine = readInputStream(inputStream, LINE_DELIMITER.getBytes(StandardCharsets.UTF_8));
+            final String statusLine = readInputStream(inputStream, LINE_DELIMITER.getBytes(Charset.forName("UTF-8")));
             final String[] statusLineArray = statusLine.split("\\s");
 
             return ResponseStatus
@@ -110,7 +110,7 @@ public final class ChunkDecoder {
         do {
             result = inputStream.read(buffer, offset++, 1);
         } while (result > -1 && arrayIndexOf(buffer, 0, offset, delimiter) == -1);
-        return new String(buffer, 0 , offset, StandardCharsets.UTF_8);
+        return new String(buffer, 0 , offset, Charset.forName("UTF-8"));
     }
 
     public static int arrayIndexOf(final byte[] haystack, final int tail, final int head, final byte[] needle) {
@@ -144,7 +144,7 @@ public final class ChunkDecoder {
             System.arraycopy(buffer, tail, tmp, 0, buffer.length - tail);
             System.arraycopy(buffer, 0, tmp, buffer.length - tail, head);
         }
-        return Integer.parseInt(new String(tmp, 0, tmp.length, StandardCharsets.UTF_8).trim(), HEX_RADIX);
+        return Integer.parseInt(new String(tmp, 0, tmp.length, Charset.forName("UTF-8")).trim(), HEX_RADIX);
     }
 
     public static Response parseStatusLineAndHeaders(final InputStream inputStream) {
@@ -156,7 +156,7 @@ public final class ChunkDecoder {
     }
 
     public static Response parseEntireTextResponse(final InputStream inputStream) {
-        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.US_ASCII));
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName("US-ASCII")));
         return Response.builder()
                 .responseStatus(parseStatusLine(inputStream))
                 .responseHeaders(parseHeaders(inputStream))
@@ -181,7 +181,7 @@ public final class ChunkDecoder {
 
     public static Integer decodeAckInResponseBody(final InputStream inputStream,
                                                   final Consumer<String> ackTimestampConsumer) {
-        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.US_ASCII));
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName("US-ASCII")));
         String line;
         int chunkSize;
         int numBytesRead, offset, ackCount = 0;

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/internal/service/AckConsumer.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/internal/service/AckConsumer.java
@@ -27,7 +27,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -77,7 +77,7 @@ class AckConsumer implements Consumer<InputStream> {
 
                 String bytesString = null;
                 if (bytesRead > 0) {
-                    bytesString = new String(buffer, 0, bytesRead, StandardCharsets.UTF_8);
+                    bytesString = new String(buffer, 0, bytesRead, Charset.forName("UTF-8"));
                 }
 
                 // Check for end-of-stream and 0 before processing

--- a/aws-android-sdk-kms/build.gradle
+++ b/aws-android-sdk-kms/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-lambda/build.gradle
+++ b/aws-android-sdk-lambda/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-lex/build.gradle
+++ b/aws-android-sdk-lex/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 11
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        abortOnError false
     }
 }
 

--- a/aws-android-sdk-lex/src/main/java/com/amazonaws/mobileconnectors/lex/interactionkit/listeners/DefaultInteractionListener.java
+++ b/aws-android-sdk-lex/src/main/java/com/amazonaws/mobileconnectors/lex/interactionkit/listeners/DefaultInteractionListener.java
@@ -15,11 +15,13 @@
 
 package com.amazonaws.mobileconnectors.lex.interactionkit.listeners;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.lex.interactionkit.Response;
 import com.amazonaws.mobileconnectors.lex.interactionkit.continuations.LexServiceContinuation;
 
+@SuppressLint("LongLogTag")
 public class DefaultInteractionListener implements InteractionListener {
     private static final String TAG = "DefaultInteractionListener";
 

--- a/aws-android-sdk-logs/build.gradle
+++ b/aws-android-sdk-logs/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-machinelearning/build.gradle
+++ b/aws-android-sdk-machinelearning/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-mobile-client/build.gradle
+++ b/aws-android-sdk-mobile-client/build.gradle
@@ -5,14 +5,15 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14 // FB, Google, UI, UserPools all need 14, Hosted UI needs 16
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
     }
 
-    lintOptions {
-        abortOnError false
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
 }
 

--- a/aws-android-sdk-mobile-client/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-mobile-client/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <!--
-         The hostest UI requires API 16, for Custom Tabs support in the
+         The hosted UI requires API 16, for Custom Tabs support in the
          AnrdoidX Browser package. That's an optional feature, so don't
          bump the API level just for that.
     -->

--- a/aws-android-sdk-mobile-client/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-mobile-client/src/main/AndroidManifest.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
            xmlns:amazon="http://schemas.amazon.com/apk/res/android"
+           xmlns:tools="http://schemas.android.com/tools"
            package="com.amazonaws.mobile.client">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
- 
+
+    <!--
+         The hostest UI requires API 16, for Custom Tabs support in the
+         AnrdoidX Browser package. That's an optional feature, so don't
+         bump the API level just for that.
+    -->
+    <uses-sdk tools:overrideLibrary="androidx.browser, com.amazonaws.mobileconnectors.cognitoauth"  />
 </manifest>
+

--- a/aws-android-sdk-mobileanalytics/build.gradle
+++ b/aws-android-sdk-mobileanalytics/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-        warning 'LongLogTag'
     }
 }
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/internal/core/configuration/PreferencesConfiguration.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/internal/core/configuration/PreferencesConfiguration.java
@@ -17,6 +17,7 @@ package com.amazonaws.mobileconnectors.amazonmobileanalytics.internal.core.confi
 
 import static com.amazonaws.mobileconnectors.amazonmobileanalytics.internal.core.util.Preconditions.checkNotNull;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.internal.core.AnalyticsContext;
@@ -33,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class PreferencesConfiguration implements Configuration {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/internal/core/idresolver/SharedPrefsUniqueIdService.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/internal/core/idresolver/SharedPrefsUniqueIdService.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.internal.core.idresolver;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
@@ -27,6 +28,7 @@ import java.util.UUID;
 /**
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class SharedPrefsUniqueIdService implements UniqueIdService {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/internal/event/EventConstraintDecorator.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/internal/event/EventConstraintDecorator.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.internal.event;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.AnalyticsEvent;
@@ -28,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class EventConstraintDecorator implements InternalEvent {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/AmazonMonetizationEventBuilder.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/AmazonMonetizationEventBuilder.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.monetization;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
@@ -44,6 +45,7 @@ import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
  * </pre>
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class AmazonMonetizationEventBuilder extends MonetizationEventBuilder {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/CustomMonetizationEventBuilder.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/CustomMonetizationEventBuilder.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.monetization;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
@@ -65,6 +66,7 @@ import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
  * </pre>
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class CustomMonetizationEventBuilder extends MonetizationEventBuilder {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/GooglePlayMonetizationEventBuilder.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/GooglePlayMonetizationEventBuilder.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.monetization;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
@@ -57,6 +58,7 @@ import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
  * </pre>
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class GooglePlayMonetizationEventBuilder extends MonetizationEventBuilder {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/MonetizationEventBuilder.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/MonetizationEventBuilder.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.monetization;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.AnalyticsEvent;
@@ -43,6 +44,7 @@ import com.amazonaws.mobileconnectors.amazonmobileanalytics.internal.core.util.S
  * </ul>
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public abstract class MonetizationEventBuilder {
 

--- a/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/VirtualMonetizationEventBuilder.java
+++ b/aws-android-sdk-mobileanalytics/src/main/java/com/amazonaws/mobileconnectors/amazonmobileanalytics/monetization/VirtualMonetizationEventBuilder.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.mobileconnectors.amazonmobileanalytics.monetization;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
@@ -47,6 +48,7 @@ import com.amazonaws.mobileconnectors.amazonmobileanalytics.EventClient;
  * </pre>
  * @deprecated The Amazon Mobile Analytics SDK for Android is deprecated as of release 2.9.0. Please use the Amazon Pinpoint SDK for Android along with Amazon Pinpoint service instead.
  */
+@SuppressLint("LongLogTag")
 @Deprecated
 public class VirtualMonetizationEventBuilder extends MonetizationEventBuilder {
 

--- a/aws-android-sdk-pinpoint-test/build.gradle
+++ b/aws-android-sdk-pinpoint-test/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18 // For UIAutomator
+        minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-pinpoint/build.gradle
+++ b/aws-android-sdk-pinpoint/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 14 // androidx core, for NotificationCompat
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
@@ -13,7 +13,7 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-core')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core:1.3.0'
 
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'junit:junit:4.13'

--- a/aws-android-sdk-pinpoint/pom.xml
+++ b/aws-android-sdk-pinpoint/pom.xml
@@ -20,9 +20,9 @@
       <version>2.16.13</version>
     </dependency>
     <dependency>
-      <groupId>androidx.appcompat</groupId>
-      <artifactId>appcompat</artifactId>
-      <version>1.1.0</version>
+      <groupId>androidx.core</groupId>
+      <artifactId>core</artifactId>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>androidx.test</groupId>

--- a/aws-android-sdk-polly/build.gradle
+++ b/aws-android-sdk-polly/build.gradle
@@ -5,7 +5,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-rekognition/build.gradle
+++ b/aws-android-sdk-rekognition/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-s3-test/build.gradle
+++ b/aws-android-sdk-s3-test/build.gradle
@@ -3,9 +3,10 @@ apply plugin: 'devicefarm'
 
 android {
     compileSdkVersion 28
+    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator in testutils
+        minSdkVersion 14 // ext junit
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
@@ -25,7 +26,7 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    androidTestImplementation 'androidx.appcompat:appcompat:1.1.0'
+    androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'org.apache.commons:commons-io:1.3.2'

--- a/aws-android-sdk-s3/build.gradle
+++ b/aws-android-sdk-s3/build.gradle
@@ -5,7 +5,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-sagemaker-runtime/build.gradle
+++ b/aws-android-sdk-sagemaker-runtime/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-sdb/build.gradle
+++ b/aws-android-sdk-sdb/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-ses/build.gradle
+++ b/aws-android-sdk-ses/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-sns/build.gradle
+++ b/aws-android-sdk-sns/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-sqs/build.gradle
+++ b/aws-android-sdk-sqs/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-testutils/build.gradle
+++ b/aws-android-sdk-testutils/build.gradle
@@ -4,14 +4,10 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18 // UIAutomator, etc.
+        minSdkVersion 14 // junit ext
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'
-    }
-
-    lintOptions {
-       disable 'InvalidPackage'
     }
 }
 

--- a/aws-android-sdk-testutils/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-testutils/src/main/AndroidManifest.xml
@@ -1,2 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.amazonaws.testutils" />
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.amazonaws.testutils">
+    <!--
+        Not all tests will use the UIAutomator facilities. So don't
+        force their minSdkVersion up, unnecessarily.
+    -->
+    <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
+</manifest>
+

--- a/aws-android-sdk-textract/build.gradle
+++ b/aws-android-sdk-textract/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-transcribe/build.gradle
+++ b/aws-android-sdk-transcribe/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-translate/build.gradle
+++ b/aws-android-sdk-translate/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 9
         targetSdkVersion 28
         versionCode 1
         versionName '1.0'


### PR DESCRIPTION
For the purpose of re-enabling NewApi and other API-related Android Lint
warnings, all `abortOnError` options are removed. In response, some
unrelated lint warnings are being addressed or suppressed in code, as a
result of this commit.

To derive an appropriate `minSdkVersion` for each module, `minSdkVersion`
was stripped from all modules, and then updated according to the project
build requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
