### PR TITLE
fix: remove apache http use from s3

### DIFF
--- a/aws-android-sdk-ddb-mapper/src/test/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/S3LinkTest.java
+++ b/aws-android-sdk-ddb-mapper/src/test/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/S3LinkTest.java
@@ -167,7 +167,7 @@ public class S3LinkTest
         S3Object mockObj = EasyMock.createMock(S3Object.class);
 
         ByteArrayInputStream bis = new ByteArrayInputStream(mockResponseBytes);
-        S3ObjectInputStream s3is = new S3ObjectInputStream(bis, null);
+        S3ObjectInputStream s3is = new S3ObjectInputStream(bis);
 
         EasyMock.expect(mockS3.getObject(anyObject(GetObjectRequest.class))).andReturn(mockObj);
         EasyMock.expect(mockObj.getObjectContent()).andReturn(s3is);

--- a/aws-android-sdk-s3-test/build.gradle
+++ b/aws-android-sdk-s3-test/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     androidTestImplementation 'androidx.appcompat:appcompat:1.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'commons-logging:commons-logging:1.2'
     androidTestImplementation 'org.apache.commons:commons-io:1.3.2'
     androidTestImplementation project(':aws-android-sdk-testutils')
 }

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/PresignedUrlIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/PresignedUrlIntegrationTest.java
@@ -32,14 +32,6 @@ import com.amazonaws.services.s3.util.SpecialObjectKeyNameGenerator;
 import com.amazonaws.util.BinaryUtils;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -171,13 +163,6 @@ public class PresignedUrlIntegrationTest extends S3IntegrationTestBase {
                 s3, new GeneratePresignedUrlRequest(bucketName, key));
         assertEquals(200, connection.getResponseCode());
         assertFileEqualsStream(file, connection.getInputStream());
-
-        // Test the URL works with Apache HttpClient
-        HttpResponse response = connectToPresignUrlWithApacheHttpClient(
-                s3, new GeneratePresignedUrlRequest(bucketName, key));
-        assertEquals(200, response.getStatusLine().getStatusCode());
-        assertFileEqualsStream(file, response.getEntity().getContent());
-
     }
 
     /**
@@ -366,35 +351,6 @@ public class PresignedUrlIntegrationTest extends S3IntegrationTestBase {
         connection.connect();
 
         return connection;
-    }
-
-    private HttpResponse connectToPresignUrlWithApacheHttpClient(AmazonS3Client s3,
-            GeneratePresignedUrlRequest request) throws Exception {
-        URL url = s3.generatePresignedUrl(request);
-
-        HttpMethod httpMethod = request.getMethod();
-        HttpRequestBase httpRequest = null;
-        switch (httpMethod) {
-            case GET:
-                httpRequest = new HttpGet(URI.create(url.toExternalForm()));
-                break;
-            case PUT:
-                httpRequest = new HttpPut(URI.create(url.toExternalForm()));
-                break;
-            case HEAD:
-                httpRequest = new HttpHead(URI.create(url.toExternalForm()));
-                break;
-            case DELETE:
-                httpRequest = new HttpDelete(URI.create(url.toExternalForm()));
-                break;
-            case POST:
-                httpRequest = new HttpPost(URI.create(url.toExternalForm()));
-                break;
-            default:
-                fail("Unrecognized http method.");
-        }
-        HttpResponse response = new DefaultHttpClient().execute(httpRequest);
-        return response;
     }
 
     private HttpURLConnection connectToPresignedUrlWithHeaders(GeneratePresignedUrlRequest request)

--- a/aws-android-sdk-s3/build.gradle
+++ b/aws-android-sdk-s3/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         minSdkVersion 15
@@ -22,6 +21,5 @@ dependencies {
     testImplementation 'org.apache.commons:commons-io:1.3.2'
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.robolectric:robolectric:4.3.1'
-    testRuntimeOnly 'org.apache.httpcomponents:httpclient:4.5.12'
 }
 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/EncryptionUtils.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/EncryptionUtils.java
@@ -420,8 +420,7 @@ public class EncryptionUtils {
 
         InputStream decryptedInputStream = new RepeatableCipherInputStream(objectContent,
                 instruction.getCipherFactory());
-        object.setObjectContent(new S3ObjectInputStream(decryptedInputStream, objectContent
-                .getHttpRequest()));
+        object.setObjectContent(new S3ObjectInputStream(decryptedInputStream));
         return object;
     }
 
@@ -584,8 +583,7 @@ public class EncryptionUtils {
                 S3ObjectInputStream objectContent = object.getObjectContent();
                 InputStream adjustedRangeContents = new AdjustedRangeInputStream(objectContent,
                         range[0], range[1]);
-                object.setObjectContent(new S3ObjectInputStream(adjustedRangeContents,
-                        objectContent.getHttpRequest()));
+                object.setObjectContent(new S3ObjectInputStream(adjustedRangeContents));
                 return object;
             } catch (IOException e) {
                 throw new AmazonClientException("Error adjusting output to desired byte range: "

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/S3CryptoModuleAE.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/S3CryptoModuleAE.java
@@ -329,7 +329,7 @@ class S3CryptoModuleAE extends S3CryptoModuleBase<MultipartUploadCryptoContext> 
         try {
             final S3ObjectInputStream objectContent = s3object.getObjectContent();
             final InputStream adjustedRangeContents = new AdjustedRangeInputStream(objectContent, range[0], range[1]);
-            s3object.setObjectContent(new S3ObjectInputStream(adjustedRangeContents, objectContent.getHttpRequest()));
+            s3object.setObjectContent(new S3ObjectInputStream(adjustedRangeContents));
             return s3object;
         } catch (final IOException e) {
             throw new AmazonClientException("Error adjusting output to desired byte range: " + e.getMessage());
@@ -418,11 +418,9 @@ class S3CryptoModuleAE extends S3CryptoModuleBase<MultipartUploadCryptoContext> 
     private S3ObjectWrapper decrypt(S3ObjectWrapper wrapper,
             ContentCryptoMaterial cekMaterial, long[] range) {
         final S3ObjectInputStream objectContent = wrapper.getObjectContent();
-        wrapper.setObjectContent(new S3ObjectInputStream(
-                new CipherLiteInputStream(objectContent,
-                    cekMaterial.getCipherLite(),
-                    DEFAULT_BUFFER_SIZE),
-                    objectContent.getHttpRequest()));
+        wrapper.setObjectContent(new S3ObjectInputStream(new CipherLiteInputStream(
+            objectContent, cekMaterial.getCipherLite(), DEFAULT_BUFFER_SIZE
+        )));
         return wrapper;
     }
 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/model/S3Object.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/model/S3Object.java
@@ -126,8 +126,7 @@ public class S3Object implements Closeable, Serializable, S3RequesterChargedResu
      * @see S3Object#getObjectContent()
      */
     public void setObjectContent(InputStream objectContent) {
-        setObjectContent(new S3ObjectInputStream(objectContent,
-                this.objectContent != null ? this.objectContent.getHttpRequest() : null));
+        setObjectContent(new S3ObjectInputStream(objectContent));
     }
 
     /**

--- a/aws-android-sdk-s3/src/test/resources/log4j.properties
+++ b/aws-android-sdk-s3/src/test/resources/log4j.properties
@@ -8,14 +8,5 @@ log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 # Adjust to see more / less logging
 #log4j.logger.com.amazonaws.ec2=DEBUG
 
-# HttpClient 3 Wire Logging
-#log4j.logger.httpclient.wire=DEBUG
-
-# HttpClient 4 Wire Logging
-#log4j.logger.org.apache.http.wire=DEBUG
-log4j.logger.org.apache.http=DEBUG
-log4j.logger.org.apache.http.wire=WARN
-
 log4j.logger.com.amazonaws=DEBUG
-
 


### PR DESCRIPTION
The S3 module uses the Android `HttpUrlConnection` as its transport.

The S3 SDK contained deprecated code which stored an Apache HTTP object
in the S3ObjectInputStream. The time has come to make good of the
deprecation notice. Several dead constructors and a getter are being
removed, so that the dependency on Apache HTTP may fully be removed from
the S3 module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
