### PR TITLE
fix: ddb mapper manifest does not use apache

### DIFF
--- a/aws-android-sdk-ddb-mapper/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-ddb-mapper/src/main/AndroidManifest.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.amazonaws.mobileconnectors.dynamodbv2.dynamodbmapper">
-    <application>
-        <uses-library android:name="org.apache.http.legacy" android:required="false" />
-    </application>
-</manifest>
+          package="com.amazonaws.mobileconnectors.dynamodbv2.dynamodbmapper" />
 


### PR DESCRIPTION
The AndroidManifest.xml for the aws-android-sdk-ddb-mapper module
wrongly claimed that this code uses the Apache HTTP client.

Remove that line from the manifest, to clarify the ambiguity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
