### PR TITLE
feat: differentiate between timestamp formats in json unmarshaller

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
@@ -286,8 +286,9 @@ public class SimpleTypeJsonUnmarshallers {
          * @return the instance.
          */
         public static DateJsonUnmarshaller getInstance() {
-            if (instance == null)
+            if (instance == null) {
                 instance = new DateJsonUnmarshaller(TimestampFormat.UNIX_TIMESTAMP);
+            }
             return instance;
         }
 
@@ -296,8 +297,10 @@ public class SimpleTypeJsonUnmarshallers {
          * @return the instance.
          */
         public static DateJsonUnmarshaller getInstance(TimestampFormat format) {
-            if (instance == null || !instance.format.equals(format))
+            // Create a new on if existing singleton isn't of correct format
+            if (instance == null || !instance.format.equals(format)) {
                 instance = new DateJsonUnmarshaller(format);
+            }
             return instance;
         }
     }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
@@ -17,6 +17,7 @@ package com.amazonaws.transform;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.util.Base64;
+import com.amazonaws.util.DateUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -244,11 +245,16 @@ public class SimpleTypeJsonUnmarshallers {
     }
 
     /**
-     * Unmarshaller for Date values - JSON dates come in as epoch seconds.
+     * Unmarshaller for Date values.
      */
     public static class DateJsonUnmarshaller implements Unmarshaller<Date, JsonUnmarshallerContext> {
-
         private static final int DATE_MULTIPLIER = 1000;
+        private final TimestampFormat format;
+
+        private DateJsonUnmarshaller(TimestampFormat format) {
+            this.format = format;
+        }
+
         @Override
         public Date unmarshall(JsonUnmarshallerContext unmarshallerContext) throws Exception {
             String dateString = unmarshallerContext.getReader().nextString();
@@ -256,9 +262,17 @@ public class SimpleTypeJsonUnmarshallers {
                 return null;
 
             try {
-                Number number = NumberFormat.getInstance(new Locale("en")).parse(dateString);
-                return new Date(number.longValue() * DATE_MULTIPLIER);
-            } catch (ParseException e) {
+                switch (format) {
+                    case ISO_8601:
+                        return DateUtils.parseISO8601Date(dateString);
+                    case RFC_822:
+                        return DateUtils.parseRFC822Date(dateString);
+                    case UNIX_TIMESTAMP:
+                    default:
+                        Number number = NumberFormat.getInstance(new Locale("en")).parse(dateString);
+                        return new Date(number.longValue() * DATE_MULTIPLIER);
+                }
+            } catch (IllegalArgumentException | ParseException e) {
                 String errorMessage = "Unable to parse date '" + dateString + "':  "
                         + e.getMessage();
                 throw new AmazonClientException(errorMessage, e);
@@ -268,12 +282,22 @@ public class SimpleTypeJsonUnmarshallers {
         private static DateJsonUnmarshaller instance;
 
         /**
-         * Constructor.
+         * Constructor. Defaults to unix timestamp format.
          * @return the instance.
          */
         public static DateJsonUnmarshaller getInstance() {
             if (instance == null)
-                instance = new DateJsonUnmarshaller();
+                instance = new DateJsonUnmarshaller(TimestampFormat.UNIX_TIMESTAMP);
+            return instance;
+        }
+
+        /**
+         * Constructor.
+         * @return the instance.
+         */
+        public static DateJsonUnmarshaller getInstance(TimestampFormat format) {
+            if (instance == null || !instance.format.equals(format))
+                instance = new DateJsonUnmarshaller(format);
             return instance;
         }
     }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/transform/TimestampFormat.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/transform/TimestampFormat.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.transform;
+
+import com.amazonaws.util.DateUtils;
+
+/**
+ * Simple enum to differentiate timestamp format standards.
+ */
+enum TimestampFormat {
+    /**
+     * In epoch seconds.
+     */
+    UNIX_TIMESTAMP,
+
+    /**
+     * In either {@link DateUtils#ISO8601_DATE_PATTERN} or
+     * {@link DateUtils#ALTERNATE_ISO8601_DATE_PATTERN} pattern.
+     */
+    ISO_8601,
+
+    /**
+     * In {@link DateUtils#RFC822_DATE_PATTERN} pattern.
+     */
+    RFC_822
+}

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallerTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallerTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.amazonaws.util.Base64;
+import com.amazonaws.util.DateUtils;
 import com.amazonaws.util.StringUtils;
 import com.amazonaws.util.json.AwsJsonReader;
 import com.amazonaws.util.json.AwsJsonWriter;
@@ -176,6 +177,81 @@ public class SimpleTypeJsonUnmarshallerTest {
 
         SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller dateUnmarshaller = SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller
                 .getInstance();
+        Date unmarshalledDate = dateUnmarshaller.unmarshall(context);
+        assertEquals(unmarshalledDate.getTime(), date.getTime());
+    }
+
+    @Test
+    public void testDateUnixTimestampJsonUnmarshaller() throws Exception {
+        Date date = new Date();
+        date.setTime(1000);
+
+        StringWriter sw = new StringWriter();
+        AwsJsonWriter jw = JsonUtils.getJsonWriter(sw);
+        jw.beginObject();
+        jw.name("unix");
+        jw.value(date);
+        jw.endObject();
+        String json = sw.toString();
+
+        StringReader sr = new StringReader(json);
+        AwsJsonReader jr = JsonUtils.getJsonReader(sr);
+        JsonUnmarshallerContext context = new JsonUnmarshallerContext(jr);
+        context.getReader().beginObject();
+        context.getReader().nextName();
+
+        SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller dateUnmarshaller = SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller
+                .getInstance(TimestampFormat.UNIX_TIMESTAMP);
+        Date unmarshalledDate = dateUnmarshaller.unmarshall(context);
+        assertEquals(unmarshalledDate.getTime(), date.getTime());
+    }
+
+    @Test
+    public void testDateIso8601JsonUnmarshaller() throws Exception {
+        Date date = new Date();
+        date.setTime(1000);
+
+        StringWriter sw = new StringWriter();
+        AwsJsonWriter jw = JsonUtils.getJsonWriter(sw);
+        jw.beginObject();
+        jw.name("iso8601");
+        jw.value(DateUtils.formatISO8601Date(date));
+        jw.endObject();
+        String json = sw.toString();
+
+        StringReader sr = new StringReader(json);
+        AwsJsonReader jr = JsonUtils.getJsonReader(sr);
+        JsonUnmarshallerContext context = new JsonUnmarshallerContext(jr);
+        context.getReader().beginObject();
+        context.getReader().nextName();
+
+        SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller dateUnmarshaller = SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller
+                .getInstance(TimestampFormat.ISO_8601);
+        Date unmarshalledDate = dateUnmarshaller.unmarshall(context);
+        assertEquals(unmarshalledDate.getTime(), date.getTime());
+    }
+
+    @Test
+    public void testDateRfc822JsonUnmarshaller() throws Exception {
+        Date date = new Date();
+        date.setTime(1000);
+
+        StringWriter sw = new StringWriter();
+        AwsJsonWriter jw = JsonUtils.getJsonWriter(sw);
+        jw.beginObject();
+        jw.name("rfc822");
+        jw.value(DateUtils.formatRFC822Date(date));
+        jw.endObject();
+        String json = sw.toString();
+
+        StringReader sr = new StringReader(json);
+        AwsJsonReader jr = JsonUtils.getJsonReader(sr);
+        JsonUnmarshallerContext context = new JsonUnmarshallerContext(jr);
+        context.getReader().beginObject();
+        context.getReader().nextName();
+
+        SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller dateUnmarshaller = SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller
+                .getInstance(TimestampFormat.RFC_822);
         Date unmarshalledDate = dateUnmarshaller.unmarshall(context);
         assertEquals(unmarshalledDate.getTime(), date.getTime());
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `TimestampFormat` enum to be passed to the unmarshaller to more accurately unmarshall date strings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
