### PR TITLE
Adds override for User Agent in AWSMobileClient

### DIFF
--- a/aws-android-sdk-auth-core/src/main/java/com/amazonaws/mobile/auth/core/IdentityManager.java
+++ b/aws-android-sdk-auth-core/src/main/java/com/amazonaws/mobile/auth/core/IdentityManager.java
@@ -223,9 +223,11 @@ public class IdentityManager {
                            final AWSConfiguration awsConfiguration) {
         this.appContext = context.getApplicationContext();
         this.awsConfiguration = awsConfiguration;
-        this.clientConfiguration = new ClientConfiguration().withUserAgent(awsConfiguration.getUserAgent());
+        this.clientConfiguration = new ClientConfiguration()
+                .withUserAgent(awsConfiguration.getUserAgent())
+                .withUserAgentOverride(awsConfiguration.getUserAgentOverride());
         this.credentialsProviderHolder = new AWSCredentialsProviderHolder();
-        createCredentialsProvider(this.appContext, this.clientConfiguration, awsConfiguration.getUserAgentOverride());
+        createCredentialsProvider(this.appContext, this.clientConfiguration);
         this.awsKeyValueStore = new AWSKeyValueStore(appContext, SHARED_PREF_NAME, isPersistenceEnabled);
     }
 
@@ -255,7 +257,7 @@ public class IdentityManager {
         }
 
         this.credentialsProviderHolder = new AWSCredentialsProviderHolder();
-        createCredentialsProvider(this.appContext, this.clientConfiguration, awsConfiguration.getUserAgentOverride());
+        createCredentialsProvider(this.appContext, this.clientConfiguration);
         this.awsKeyValueStore = new AWSKeyValueStore(appContext, SHARED_PREF_NAME, isPersistenceEnabled);
     }
 
@@ -904,8 +906,7 @@ public class IdentityManager {
      *   only useful for unauthenticated users.
      */
     private void createCredentialsProvider(final Context context,
-                                           final ClientConfiguration clientConfiguration,
-                                           final String userAgentOverride) {
+                                           final ClientConfiguration clientConfiguration) {
         Log.d(LOG_TAG, "Creating the Cognito Caching Credentials Provider "
                 + "with a refreshing Cognito Identity Provider.");
 
@@ -936,8 +937,8 @@ public class IdentityManager {
                         cognitoIdentityRegion,
                         clientConfiguration);
         cognitoCachingCredentialsProvider.setPersistenceEnabled(isPersistenceEnabled);
-        if (userAgentOverride != null) {
-            cognitoCachingCredentialsProvider.setUserAgentOverride(userAgentOverride);
+        if (clientConfiguration.getUserAgentOverride() != null) {
+            cognitoCachingCredentialsProvider.setUserAgentOverride(clientConfiguration.getUserAgentOverride());
         }
         credentialsProviderHolder.setUnderlyingProvider(cognitoCachingCredentialsProvider);
     }

--- a/aws-android-sdk-auth-core/src/main/java/com/amazonaws/mobile/auth/core/IdentityManager.java
+++ b/aws-android-sdk-auth-core/src/main/java/com/amazonaws/mobile/auth/core/IdentityManager.java
@@ -225,7 +225,7 @@ public class IdentityManager {
         this.awsConfiguration = awsConfiguration;
         this.clientConfiguration = new ClientConfiguration().withUserAgent(awsConfiguration.getUserAgent());
         this.credentialsProviderHolder = new AWSCredentialsProviderHolder();
-        createCredentialsProvider(this.appContext, this.clientConfiguration);
+        createCredentialsProvider(this.appContext, this.clientConfiguration, awsConfiguration.getUserAgentOverride());
         this.awsKeyValueStore = new AWSKeyValueStore(appContext, SHARED_PREF_NAME, isPersistenceEnabled);
     }
 
@@ -255,7 +255,7 @@ public class IdentityManager {
         }
 
         this.credentialsProviderHolder = new AWSCredentialsProviderHolder();
-        createCredentialsProvider(this.appContext, this.clientConfiguration);
+        createCredentialsProvider(this.appContext, this.clientConfiguration, awsConfiguration.getUserAgentOverride());
         this.awsKeyValueStore = new AWSKeyValueStore(appContext, SHARED_PREF_NAME, isPersistenceEnabled);
     }
 
@@ -904,8 +904,8 @@ public class IdentityManager {
      *   only useful for unauthenticated users.
      */
     private void createCredentialsProvider(final Context context,
-                                           final ClientConfiguration clientConfiguration) {
-
+                                           final ClientConfiguration clientConfiguration,
+                                           final String userAgentOverride) {
         Log.d(LOG_TAG, "Creating the Cognito Caching Credentials Provider "
                 + "with a refreshing Cognito Identity Provider.");
 
@@ -929,9 +929,16 @@ public class IdentityManager {
             new AWSRefreshingCognitoIdentityProvider(null, poolId,
                 clientConfiguration, cognitoIdentityRegion);
 
-        final CognitoCachingCredentialsProvider cognitoCachingCredentialsProvider = new CognitoCachingCredentialsProvider(context, refreshingCredentialsProvider,
-                cognitoIdentityRegion, clientConfiguration);
+        final CognitoCachingCredentialsProvider cognitoCachingCredentialsProvider =
+                new CognitoCachingCredentialsProvider(
+                        context,
+                        refreshingCredentialsProvider,
+                        cognitoIdentityRegion,
+                        clientConfiguration);
         cognitoCachingCredentialsProvider.setPersistenceEnabled(isPersistenceEnabled);
+        if (userAgentOverride != null) {
+            cognitoCachingCredentialsProvider.setUserAgentOverride(userAgentOverride);
+        }
         credentialsProviderHolder.setUnderlyingProvider(cognitoCachingCredentialsProvider);
     }
 

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
@@ -189,6 +189,7 @@ public class CognitoUserPool {
 
             final ClientConfiguration clientConfig = new ClientConfiguration();
             clientConfig.setUserAgent(awsConfiguration.getUserAgent());
+            clientConfig.setUserAgentOverride(awsConfiguration.getUserAgentOverride());
             this.client = new AmazonCognitoIdentityProviderClient(new AnonymousAWSCredentials(), clientConfig);
             this.client.setRegion(com.amazonaws.regions.Region.getRegion(Regions.fromName(userPoolConfiguration.getString("Region"))));
         } catch (Exception e) {

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -60,6 +60,12 @@ public class ClientConfiguration {
     private String userAgent = DEFAULT_USER_AGENT;
 
     /**
+     * The {@link #userAgent} string is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     */
+    private String userAgentOverride;
+
+    /**
      * The maximum number of times that a retryable failed request (ex: a 5xx
      * response from a service) will be retried. Or -1 if the user has not
      * explicitly set this value, in which case the configured RetryPolicy will
@@ -193,6 +199,7 @@ public class ClientConfiguration {
         this.preemptiveBasicProxyAuth = other.preemptiveBasicProxyAuth;
         this.socketTimeout = other.socketTimeout;
         this.userAgent = other.userAgent;
+        this.userAgentOverride = other.userAgentOverride;
         this.socketReceiveBufferSizeHint = other.socketReceiveBufferSizeHint;
         this.socketSendBufferSizeHint = other.socketSendBufferSizeHint;
         this.signerOverride = other.signerOverride;
@@ -323,6 +330,39 @@ public class ClientConfiguration {
     @SuppressWarnings("checkstyle:hiddenfield")
     public ClientConfiguration withUserAgent(String userAgent) {
         setUserAgent(userAgent);
+        return this;
+    }
+
+    /**
+     * The {@link #userAgent} string is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     *
+     * @return The string to use as the full user agent when sending requests.
+     */
+    public String getUserAgentOverride() {
+        return userAgentOverride;
+    }
+
+    /**
+     * The {@link #userAgent} string is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     *
+     * @param userAgentOverride The string to use as the full user agent when sending requests.
+     */
+    public void setUserAgentOverride(String userAgentOverride) {
+        this.userAgentOverride = userAgentOverride;
+    }
+
+    /**
+     * The {@link #userAgent} string is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     *
+     * @param userAgentOverride The string to use as the full user agent when sending requests.
+     * @return The updated ClientConfiguration object.
+     */
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public ClientConfiguration withUserAgentOverride(String userAgentOverride) {
+        setUserAgentOverride(userAgentOverride);
         return this;
     }
 

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
@@ -110,6 +110,7 @@ public class CognitoCachingCredentialsProvider
         }
     };
     private boolean isPersistenceEnabled = true;
+    private String userAgentOverride;
 
     /**
      * Constructs a new {@link CognitoCachingCredentialsProvider}, which will
@@ -660,7 +661,11 @@ public class CognitoCachingCredentialsProvider
 
     @Override
     protected String getUserAgent() {
-        return USER_AGENT;
+        if (userAgentOverride != null) {
+            return userAgentOverride;
+        } else {
+            return USER_AGENT;
+        }
     }
 
     // To support multiple identity pools in the same app, namespacing the keys
@@ -694,5 +699,15 @@ public class CognitoCachingCredentialsProvider
     public void setPersistenceEnabled(boolean isPersistenceEnabled) {
         this.isPersistenceEnabled = isPersistenceEnabled;
         this.awsKeyValueStore.setPersistenceEnabled(isPersistenceEnabled);
+    }
+
+    /**
+     * The user agent string is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     *
+     * @param userAgentOverride The string to use as the full user agent when sending requests.
+     */
+    public void setUserAgentOverride(String userAgentOverride) {
+        this.userAgentOverride = userAgentOverride;
     }
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
@@ -110,6 +110,7 @@ public class CognitoCachingCredentialsProvider
         }
     };
     private boolean isPersistenceEnabled = true;
+    private String userAgentOverride;
 
     /**
      * Constructs a new {@link CognitoCachingCredentialsProvider}, which will
@@ -694,5 +695,15 @@ public class CognitoCachingCredentialsProvider
     public void setPersistenceEnabled(boolean isPersistenceEnabled) {
         this.isPersistenceEnabled = isPersistenceEnabled;
         this.awsKeyValueStore.setPersistenceEnabled(isPersistenceEnabled);
+    }
+
+    /**
+     * The user agent string is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     *
+     * @param userAgentOverride The string to use as the full user agent when sending requests.
+     */
+    public void setUserAgentOverride(String userAgentOverride) {
+        this.userAgentOverride = userAgentOverride;
     }
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/CognitoCachingCredentialsProvider.java
@@ -110,7 +110,6 @@ public class CognitoCachingCredentialsProvider
         }
     };
     private boolean isPersistenceEnabled = true;
-    private String userAgentOverride;
 
     /**
      * Constructs a new {@link CognitoCachingCredentialsProvider}, which will
@@ -695,15 +694,5 @@ public class CognitoCachingCredentialsProvider
     public void setPersistenceEnabled(boolean isPersistenceEnabled) {
         this.isPersistenceEnabled = isPersistenceEnabled;
         this.awsKeyValueStore.setPersistenceEnabled(isPersistenceEnabled);
-    }
-
-    /**
-     * The user agent string is sometimes combined with other strings. If this property is set, it instructs the
-     * client to only use this as the full user agent string.
-     *
-     * @param userAgentOverride The string to use as the full user agent when sending requests.
-     */
-    public void setUserAgentOverride(String userAgentOverride) {
-        this.userAgentOverride = userAgentOverride;
     }
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -534,7 +534,8 @@ public class AmazonHttpClient {
         if (!ClientConfiguration.DEFAULT_USER_AGENT.equals(config.getUserAgent())) {
             userAgent = createUserAgentString(userAgent, config.getUserAgent());
         }
-        request.addHeader(HEADER_USER_AGENT, userAgent);
+        request.addHeader(HEADER_USER_AGENT,
+                config.getUserAgentOverride() != null ? config.getUserAgentOverride() : userAgent);
     }
 
     /**

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/mobile/config/AWSConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/mobile/config/AWSConfiguration.java
@@ -182,6 +182,20 @@ public class AWSConfiguration {
     }
 
     /**
+     * The user agent is sometimes combined with other strings. If this property is set, it instructs the
+     * client to only use this as the full user agent string.
+     *
+     * @return The user agent override specified in the configuration file.
+     */
+    public String getUserAgentOverride() {
+        try {
+            return this.mJSONObject.getString("UserAgentOverride");
+        } catch (JSONException je) {
+            return null;
+        }
+    }
+
+    /**
      * Change the settings that are being read in. This is "Default" by default.
      * 
      * @param configurationName the key used to differentiate between configuration settings

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -528,6 +528,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                             final String poolId = identityPoolJSON.getString("PoolId");
                             final String regionStr = identityPoolJSON.getString("Region");
                             final ClientConfiguration clientConfig = new ClientConfiguration();
+                            clientConfig.setUserAgent(DEFAULT_USER_AGENT + " " + awsConfiguration.getUserAgent());
                             if (userAgentOverride != null) {
                                 clientConfig.setUserAgentOverride(userAgentOverride);
                             }
@@ -1206,8 +1207,8 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                 try {
                                     if (
                                             awsConfiguration.optJsonObject(AUTH_KEY) != null &&
-                                                    awsConfiguration.optJsonObject(AUTH_KEY).has("authenticationFlowType") &&
-                                                    awsConfiguration.optJsonObject(AUTH_KEY).getString("authenticationFlowType").equals("CUSTOM_AUTH")
+                                            awsConfiguration.optJsonObject(AUTH_KEY).has("authenticationFlowType") &&
+                                            awsConfiguration.optJsonObject(AUTH_KEY).getString("authenticationFlowType").equals("CUSTOM_AUTH")
                                     ) {
                                         final HashMap<String, String> authParameters = new HashMap<String, String>();
                                         authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, authParameters, validationData));
@@ -1216,8 +1217,9 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                     }
                                 } catch (JSONException e) {
                                     e.printStackTrace();
-                                    authenticationContinuation.continueTask();
                                 }
+
+                                authenticationContinuation.continueTask();
                             }
 
                             @Override


### PR DESCRIPTION
Currently if the user agent value is set in the client config, it may be appended to other values. This PR adds the ability to set a user agent override value which will ensure that nothing is appended on to it and it is sent as the final user agent.

The reason for this change is that Amplify Auth uses AWSMobileClient which uses underlying User Pool and Identity Pool SDKs. This is how user agents are currently handled:

- Someone uses aws-android-sdk-auth-userpools: User Agent = userpools_UA
- Someone uses aws-android-sdk-cognitoidentityprovider: User Agent = cognitoidentityprovider_UA
- Someone uses AWSMobileClient:
   - Methods using userpools: User Agent = userpools_UA + AMC_string
   - Methods using cognito identity provider: User Agent = cognitoidentityprovider_UA + AMC_string

Until now, someone using Amplify Auth would have the same user agent sent as AWSMobileClient because it uses AWSMobileClient. This is a problem since Amplify Auth usage can't be correctly attributed. The solution requested by the product team is that someone using Amplify Auth has the Amplify user agent sent, completely overriding any of the other user agents the SDKs currently use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
