### PR TITLE
fix: remove deprecated wifi management from tests

### DIFF
--- a/aws-android-sdk-mobile-client/build.gradle
+++ b/aws-android-sdk-mobile-client/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName '1.0'
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     compileOptions {
@@ -53,6 +54,7 @@ dependencies {
     androidTestImplementation 'androidx.appcompat:appcompat:1.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
 
     androidTestImplementation (project(':aws-android-sdk-auth-facebook')) {
         exclude group: 'com.google.android', module: 'android'

--- a/aws-android-sdk-mobile-client/src/androidTest/AndroidManifest.xml
+++ b/aws-android-sdk-mobile-client/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:amazon="http://schemas.amazon.com/apk/res/android"
-    package="com.amazonaws.mobile.client">
+    package="com.amazonaws.mobile.client.test">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientOfflineTest.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientOfflineTest.java
@@ -16,49 +16,42 @@
  */
 package com.amazonaws.mobile.client;
 
-import android.content.Context;
-import android.net.wifi.WifiManager;
-
-import androidx.test.core.app.ApplicationProvider;
-
+import com.amazonaws.mobile.client.test.R;
 import com.amazonaws.mobile.config.AWSConfiguration;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static com.amazonaws.testutils.util.InternetConnectivity.goOffline;
+import static com.amazonaws.testutils.util.InternetConnectivity.goOnline;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
- * Userpool and identity pool were create with Amplify CLI 0.1.23 Default configuration
+ * User pool and identity pool were create with Amplify CLI 0.1.23 Default configuration
  */
-public class AWSMobileClientOfflineTest extends AWSMobileClientTestBase {
-
-    Context appContext;
-    AWSMobileClient auth;
-    UserStateListener listener;
-
-    public static void setWifi(final Context appContext, final boolean state) {
-        WifiManager wifiManager = (WifiManager)appContext.getSystemService(Context.WIFI_SERVICE);
-        wifiManager.setWifiEnabled(state);
-    }
+public final class AWSMobileClientOfflineTest extends AWSMobileClientTestBase {
+    private static AWSMobileClient auth;
+    private UserStateListener listener;
 
     @BeforeClass
-    public static void setup() throws Exception {
-        Context appContext = ApplicationProvider.getApplicationContext();
-        setWifi(appContext, false);
-        final CountDownLatch latch = new CountDownLatch(1);
-        AWSMobileClient.getInstance().initialize(appContext, new Callback<UserStateDetails>() {
+    public static void beforeSuite() throws Exception {
+        goOffline();
+        CountDownLatch latch = new CountDownLatch(1);
+        auth = AWSMobileClient.getInstance();
+        AWSConfiguration config = new AWSConfiguration(getApplicationContext(), R.raw.fakeawsconfiguration);
+        auth.initialize(getApplicationContext(), config, new Callback<UserStateDetails>() {
             @Override
             public void onResult(UserStateDetails result) {
                 latch.countDown();
@@ -71,68 +64,56 @@ public class AWSMobileClientOfflineTest extends AWSMobileClientTestBase {
         });
         latch.await();
 
-        final AWSConfiguration awsConfiguration = AWSMobileClient.getInstance().getConfiguration();
-
-        assertNotNull(awsConfiguration.optJsonObject("CognitoUserPool"));
-        try {
-            assertEquals("us-west-2", awsConfiguration.optJsonObject("CognitoUserPool").getString("Region"));
-        } catch (JSONException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        AWSConfiguration awsConfiguration = auth.getConfiguration();
+        JSONObject userPoolConfig = awsConfiguration.optJsonObject("CognitoUserPool");
+        assertNotNull(userPoolConfig);
+        assertEquals("us-west-2", userPoolConfig.getString("Region"));
     }
 
     @Before
-    public void cleanUp() {
-        appContext = ApplicationProvider.getApplicationContext();
-        auth = AWSMobileClient.getInstance();
+    public void beforeTest() {
         auth.signOut();
     }
 
     @After
-    public void cleanAfter() {
+    public void afterTest() {
         auth.removeUserStateListener(listener);
         auth.listeners.clear();
     }
 
+    @AfterClass
+    public static void afterSuite() {
+        goOnline();
+    }
+
     @Test
-    public void useAppContext() throws Exception {
-        // Context of the app under test.
-        Context appContext = ApplicationProvider.getApplicationContext();
-
-        final AWSConfiguration awsConfiguration = new AWSConfiguration(appContext);
-
-        assertNotNull(awsConfiguration.optJsonObject("CognitoUserPool"));
-        assertEquals("us-west-2", awsConfiguration.optJsonObject("CognitoUserPool").getString("Region"));
-
-        assertEquals("com.amazonaws.mobile.client.test", appContext.getPackageName());
+    public void useAppContext() throws JSONException {
+        AWSConfiguration awsConfiguration = new AWSConfiguration(getApplicationContext(), R.raw.fakeawsconfiguration);
+        JSONObject userPoolConfig = awsConfiguration.optJsonObject("CognitoUserPool");
+        assertNotNull(userPoolConfig);
+        assertEquals("us-west-2", userPoolConfig.getString("Region"));
+        assertEquals(
+            "com.amazonaws.mobile.client.test",
+            getApplicationContext().getPackageName()
+        );
     }
 
     @Test
     public void testGetConfiguration() throws JSONException {
-        final AWSConfiguration awsConfiguration = AWSMobileClient.getInstance().getConfiguration();
-
-        assertNotNull(awsConfiguration.optJsonObject("CognitoUserPool"));
-        try {
-            assertEquals("us-west-2", awsConfiguration.optJsonObject("CognitoUserPool").getString("Region"));
-        } catch (JSONException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        AWSConfiguration awsConfiguration = auth.getConfiguration();
+        JSONObject userPoolConfig = awsConfiguration.optJsonObject("CognitoUserPool");
+        assertNotNull(userPoolConfig);
+        assertEquals(
+            "us-west-2",
+            userPoolConfig.getString("Region")
+        );
     }
 
-    @Ignore("If network is on on the emulator, this test may get stuck")
     @Test
-    public void testSignInWaitOIDCOffline() throws Exception {
-        final Queue<UserStateDetails> allChanges = new ConcurrentLinkedQueue<UserStateDetails>();
-
-        setTokensDirectly(appContext, AWSMobileClient.getInstance().getLoginKey(), "fakeToken", "someIdentityId");
-        listener = new UserStateListener() {
-            @Override
-            public void onUserStateChanged(UserStateDetails details) {
-                allChanges.add(details);
-            }
-        };
+    public void testSignInWaitOIDCOffline() {
+        Queue<UserStateDetails> allChanges = new ConcurrentLinkedQueue<>();
+        setTokensDirectly(getApplicationContext(), auth.getLoginKey(), "fakeToken", "someIdentityId");
+        listener = allChanges::add;
         auth.addUserStateListener(listener);
         assertTrue("User is offline and tokens are invalid", auth.isSignedIn());
 
@@ -144,5 +125,4 @@ public class AWSMobileClientOfflineTest extends AWSMobileClientTestBase {
         assertEquals("1 signed-in events should not have been triggered, because tokens swapped underneath", 1, allChanges.size());
         assertEquals(UserState.SIGNED_IN, allChanges.remove().getUserState());
    }
-
 }

--- a/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTestBase.java
+++ b/aws-android-sdk-mobile-client/src/androidTest/java/com/amazonaws/mobile/client/AWSMobileClientTestBase.java
@@ -18,7 +18,6 @@
 package com.amazonaws.mobile.client;
 
 import android.content.Context;
-import android.net.wifi.WifiManager;
 import androidx.test.core.app.ApplicationProvider;
 import android.util.Base64;
 
@@ -46,11 +45,6 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
 
     public static JSONObject getPackageConfigure()  {
         return getPackageConfigure(PACKAGE_NAME);
-    }
-
-    public static void setWifi(final Context appContext, final boolean wifiState) {
-        WifiManager wifiManager = (WifiManager) appContext.getSystemService(Context.WIFI_SERVICE);
-        wifiManager.setWifiEnabled(wifiState);
     }
 
     public static void setTokensDirectly(final Context appContext,
@@ -110,7 +104,7 @@ public abstract class AWSMobileClientTestBase extends AWSTestBase {
         epoch = epoch + expiryInSecs;
         String accessToken_p1_Base64 = "eyJ0eXAiOiAiSldUIiwgImFsZyI6IlJTMjU2In0=";
         String accessToken_p3_Base64 = "e0VuY3J5cHRlZF9LZXl9";
-        String accessToken_p2_Str = "{\"iss\": \"userPoolId\",\"sub\": \"my@email.com\",\"aud\": \"https:aws.cognito.com\",\"exp\": \"" + String.valueOf(epoch) + "\"}";
+        String accessToken_p2_Str = "{\"iss\": \"userPoolId\",\"sub\": \"my@email.com\",\"aud\": \"https:aws.cognito.com\",\"exp\": \"" + epoch + "\"}";
         byte[] accessToken_p2_UTF8 = accessToken_p2_Str.getBytes(StringUtils.UTF8);
         String accessToken_p2_Base64 = new String(Base64.encode(accessToken_p2_UTF8, Base64.DEFAULT));
         return accessToken_p1_Base64 + "." + accessToken_p2_Base64 + "." + accessToken_p3_Base64;

--- a/aws-android-sdk-mobile-client/src/androidTest/res/raw/fakeawsconfiguration.json
+++ b/aws-android-sdk-mobile-client/src/androidTest/res/raw/fakeawsconfiguration.json
@@ -1,0 +1,25 @@
+{
+  "UserAgent": "aws-amplify/cli",
+  "Version": "0.1.0",
+  "IdentityManager": {
+    "Default": {}
+  },
+  "CredentialsProvider": {
+    "CognitoIdentity": {
+      "Default": {
+        "__comment": "This was never a real pool. Just a random uuid.",
+        "PoolId": "us-west-2:d7dd1ff8-908d-4d46-a5e2-a33be23bdade",
+        "Region": "us-west-2"
+      }
+    }
+  },
+  "CognitoUserPool": {
+    "Default": {
+      "PoolId": "us-west-2_K00lpooL5",
+      "AppClientId": "app22client44SecretId0",
+      "AppClientSecret": "appclientsecret5500secretyes",
+      "Region": "us-west-2"
+    }
+  }
+}
+

--- a/aws-android-sdk-pinpoint-test/build.gradle
+++ b/aws-android-sdk-pinpoint-test/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 18 // UIAutomator
         targetSdkVersion 29
         versionCode 1
         versionName '1.0'

--- a/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/EndpointProfileIntegrationTest.java
+++ b/aws-android-sdk-pinpoint-test/src/androidTest/java/com/amazonaws/mobileconnectors/pinpoint/analytics/EndpointProfileIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -15,11 +15,6 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.analytics;
 
-import android.content.Context;
-import android.net.wifi.WifiManager;
-
-import androidx.test.core.app.ApplicationProvider;
-
 import com.amazonaws.auth.CognitoCachingCredentialsProvider;
 import com.amazonaws.mobileconnectors.pinpoint.PinpointConfiguration;
 import com.amazonaws.mobileconnectors.pinpoint.PinpointManager;
@@ -30,14 +25,15 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.pinpoint.model.ChannelType;
 import com.amazonaws.testutils.AWSTestBase;
 
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 
-import static junit.framework.TestCase.assertTrue;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static com.amazonaws.testutils.util.InternetConnectivity.goOnline;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -48,53 +44,31 @@ import static org.junit.Assert.assertNull;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 public class EndpointProfileIntegrationTest extends AWSTestBase {
-
-    private static Context appContext;
-
     private PinpointManager pinpointManager;
-    private PinpointConfiguration pinpointConfiguration;
     private CognitoCachingCredentialsProvider credentialsProvider;
-    private WifiManager wifiManager;
-
-    private String appId;
-    private Regions regions;
-
-    private static String TAG = EndpointProfileIntegrationTest.class.getSimpleName();
 
     @Before
     public void setUp() throws Exception {
-        final String identityPoolId = getPackageConfigure("pinpoint")
-                .getString("identity_pool_id");
+        JSONObject testConfig = getPackageConfigure("pinpoint");
+        String identityPoolId = testConfig.getString("identity_pool_id");
+        String appId = testConfig.getString("AppId");
+        Regions regions = Regions.fromName(testConfig.getString("Region"));
 
-        appId = getPackageConfigure("pinpoint")
-                .getString("AppId");
-        regions = Regions.fromName(getPackageConfigure("pinpoint")
-                .getString("Region"));
+        getApplicationContext().deleteDatabase("awspinpoint.db");
+        goOnline();
 
-        appContext = ApplicationProvider.getApplicationContext();
-        appContext.deleteDatabase("awspinpoint.db");
-
-        wifiManager = (WifiManager) ApplicationProvider.getApplicationContext()
-                .getSystemService(Context.WIFI_SERVICE);
-        assertTrue(wifiManager.setWifiEnabled(true));
-
-        credentialsProvider = new CognitoCachingCredentialsProvider(
-                appContext,
-                identityPoolId,
-                regions);
-        pinpointConfiguration = new PinpointConfiguration(appContext,
-                appId,
-                regions,
-                ChannelType.GCM,
-                credentialsProvider);
+        credentialsProvider =
+            new CognitoCachingCredentialsProvider(getApplicationContext(), identityPoolId, regions);
+        PinpointConfiguration pinpointConfiguration =
+            new PinpointConfiguration(getApplicationContext(), appId, regions, ChannelType.GCM, credentialsProvider);
         pinpointManager = new PinpointManager(pinpointConfiguration);
     }
 
     @After
     public void tearDown() {
-        assertTrue(wifiManager.setWifiEnabled(true));
+        goOnline();
         pinpointManager.getAnalyticsClient().closeDB();
-        appContext.deleteDatabase("awspinpoint.db");
+        getApplicationContext().deleteDatabase("awspinpoint.db");
     }
 
     @Test
@@ -116,18 +90,18 @@ public class EndpointProfileIntegrationTest extends AWSTestBase {
         targetingClient.updateEndpointProfile();
         endpointProfile = targetingClient.currentEndpoint();
         assertNotNull(endpointProfile);
-        assertEquals(credentialsProvider.getIdentityId(),
-                endpointProfile.getUser().getUserId());
+        assertEquals(credentialsProvider.getIdentityId(), endpointProfile.getUser().getUserId());
         assertNotNull(endpointProfile.getUser().getUserAttributes());
-        assertEquals(Collections.singletonMap("user-key", Collections.singletonList("user-value")),
-                endpointProfile.getUser().getUserAttributes());
+        assertEquals(
+            Collections.singletonMap("user-key", Collections.singletonList("user-value")),
+            endpointProfile.getUser().getUserAttributes()
+        );
 
-        endpointProfile.addAttribute("key", Arrays.asList("value"));
+        endpointProfile.addAttribute("key", Collections.singletonList("value"));
         targetingClient.updateEndpointProfile();
         endpointProfile = targetingClient.currentEndpoint();
         assertNotNull(endpointProfile);
-        assertEquals(credentialsProvider.getIdentityId(),
-                endpointProfile.getUser().getUserId());
-        assertEquals("value", endpointProfile.getAllAttributes().get("key").get(0));
+        assertEquals(credentialsProvider.getIdentityId(), endpointProfile.getUser().getUserId());
+        assertEquals(Collections.singletonList("value"), endpointProfile.getAllAttributes().get("key"));
     }
 }


### PR DESCRIPTION
Use of the `WifiManager`'s `setWifiEnabled(...)` API was originally added to this
code base with the intention of toggling on/off connectivity, to test
offline scenarios. From the beginning, this usage was flawed. The
Android emulator will happily continue to serve traffic through a fake
cellular connection. So, unless you pre-arrange a device to not have any
other source of connectivity than WiFi, the call to `setWifiEnabled(...)` is
useless.

Worse, as of API 29, this method is officially deprecated. Oh well.

As a replacement, use the UIAutomator-based `InternetConnectivity` utility
that had recently been added to this codebase under `-testutils`. This
utility works by clicking the airplane mode button in the device's
settings drop down.

This change removes the use of a deprecated API, and also improves the
correctness of the offline tests. One that had been `@Ignore`d is
re-enabled.

This commit includes assorted code quality fixes in the effected files,
as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
