### PR TITLE
getTokens latency fix

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
@@ -180,7 +180,11 @@ public class AWSKeyValueStore {
      */
     public synchronized boolean contains(final String dataKey) {
         if (isPersistenceEnabled) {
-            return sharedPreferencesForData.contains(getDataKeyUsedInPersistentStore(dataKey));
+            if (cache.containsKey(dataKey)) {
+                return true;
+            } else {
+                return sharedPreferencesForData.contains(getDataKeyUsedInPersistentStore(dataKey));
+            }
         } else {
             return cache.containsKey(dataKey);
         }
@@ -201,7 +205,7 @@ public class AWSKeyValueStore {
             return null;
         }
 
-        if (!isPersistenceEnabled) {
+        if (cache.containsKey(dataKey) || !isPersistenceEnabled) {
             return cache.get(dataKey);
         }
 

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1762,7 +1762,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     @WorkerThread
     public Tokens getTokens() throws Exception {
         final InternalCallback<Tokens> internalCallback = new InternalCallback<Tokens>();
-        return internalCallback.await(_getTokens(internalCallback, true));
+        return internalCallback.await(_getTokens(internalCallback, false));
     }
 
     /**
@@ -1775,7 +1775,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     @AnyThread
     public void getTokens(final Callback<Tokens> callback) {
         final InternalCallback<Tokens> internalCallback = new InternalCallback<Tokens>(callback);
-        internalCallback.async(_getTokens(internalCallback, true));
+        internalCallback.async(_getTokens(internalCallback, false));
     }
 
     protected Tokens getTokens(boolean waitForSignIn) throws Exception {


### PR DESCRIPTION
Fixes issue #1722 with cached tokens taking hundreds of milliseconds to return.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
