### PR TITLE
chore(ci) Pin image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     resource_class: xlarge
     environment:
       JVM_OPTS: -Xmx8192m
@@ -319,7 +319,7 @@ jobs:
   unittest:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     resource_class: xlarge
     environment:
       JVM_OPTS: -Xmx8192m
@@ -369,7 +369,7 @@ jobs:
 
   release_javadoc:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     resource_class: xlarge
     environment:
       JVM_OPTS: -Xmx8192m
@@ -510,7 +510,7 @@ jobs:
 
   release_s3:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -576,7 +576,7 @@ jobs:
 
   pre_integrationtest:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -611,7 +611,7 @@ jobs:
 
   post_integrationtest:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -696,7 +696,7 @@ jobs:
   bump_sampleapp_version:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     resource_class: xlarge
     environment:
       JVM_OPTS: -Xmx8192m
@@ -730,7 +730,7 @@ jobs:
   bump_applifydocs_version:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     resource_class: xlarge
     environment:
       JVM_OPTS: -Xmx8192m
@@ -762,7 +762,7 @@ jobs:
       - bump_version_post
   bump_sdk_version:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -826,7 +826,7 @@ jobs:
 
   merge_to_main:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -869,7 +869,7 @@ jobs:
 
   prepare_release_sdk:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -898,7 +898,7 @@ jobs:
 
   create_pullrequest_for_modelupdate:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -915,7 +915,7 @@ jobs:
 
   check_sdk_on_maven:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -943,7 +943,7 @@ jobs:
 
   run_integrationtest_on_devicefarm:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -1008,7 +1008,7 @@ jobs:
               "https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/envvar?circle-token=${CIRCLE_API_USER_TOKEN}"
   check_testresult_on_devicefarm:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:2d4ef38bcef095335302e83a7b20e6f24087ed01594a7c232b114599b5271dc9
     environment:
       JVM_OPTS: -Xmx1024m
     steps:


### PR DESCRIPTION
This is a temporary solution to pin our CircleCI builds to an older image version, since they recently updated their default images to Java 11.  Ultimately, we need to actually update our project to work on the new images.

https://discuss.circleci.com/t/android-convenience-image-moving-to-java-v11-on-august-17th/36601


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
