### PR TITLE
Removes unused HostedUI code

### DIFF
--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -9,10 +9,6 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName '1.0'
-
-        manifestPlaceholders = [
-                'authRedirectScheme': 'FOR_LIBRARY_CONSUMER_TO_OVERRIDE'
-        ]
     }
 
     compileOptions {

--- a/aws-android-sdk-cognitoauth/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-cognitoauth/src/main/AndroidManifest.xml
@@ -8,14 +8,5 @@
              android:exported="false"
              android:theme="@android:style/Theme.Translucent.NoTitleBar"
              android:launchMode="singleTask" />
-
-         <activity android:name=".activities.CustomTabsRedirectActivity" android:exported="true">
-             <intent-filter>
-                 <action android:name="android.intent.action.VIEW"/>
-                 <category android:name="android.intent.category.DEFAULT"/>
-                 <category android:name="android.intent.category.BROWSABLE"/>
-                 <data android:scheme="${authRedirectScheme}"/>
-             </intent-filter>
-         </activity>
      </application>
  </manifest>


### PR DESCRIPTION
Removes unused activity declaration code now that users are directed to declare the activity in their own manifest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
