### PR TITLE
Passwordless Custom Authentication : Signin request fails(Error code: 400) within aws SDK

### DIFF
--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -7,12 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 16 // androidx.browser
         targetSdkVersion 29
-        versionCode 21800
-        versionName '2.18.0'
-
-        manifestPlaceholders = [
-                'authRedirectScheme': 'FOR_LIBRARY_CONSUMER_TO_OVERRIDE'
-        ]
+        versionCode 1
+        versionName '1.0'
     }
 
     compileOptions {

--- a/aws-android-sdk-cognitoauth/src/main/AndroidManifest.xml
+++ b/aws-android-sdk-cognitoauth/src/main/AndroidManifest.xml
@@ -8,14 +8,5 @@
              android:exported="false"
              android:theme="@android:style/Theme.Translucent.NoTitleBar"
              android:launchMode="singleTask" />
-
-         <activity android:name=".activities.CustomTabsRedirectActivity" android:exported="true">
-             <intent-filter>
-                 <action android:name="android.intent.action.VIEW"/>
-                 <category android:name="android.intent.category.DEFAULT"/>
-                 <category android:name="android.intent.category.BROWSABLE"/>
-                 <data android:scheme="${authRedirectScheme}"/>
-             </intent-filter>
-         </activity>
      </application>
  </manifest>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/AuthenticationDetails.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/continuations/AuthenticationDetails.java
@@ -95,6 +95,7 @@ public class AuthenticationDetails {
         if (authenticationParameters != null) {
             this.authenticationType = CognitoServiceConstants.CHLG_TYPE_CUSTOM_CHALLENGE;
             this.authenticationParameters = authenticationParameters;
+            setAuthenticationParameter(CognitoServiceConstants.AUTH_PARAM_USERNAME, userId);
             setValidationData(validationData);
         } else {
             this.authenticationType = null;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/AmazonCognitoIdentityProvider.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/AmazonCognitoIdentityProvider.java
@@ -194,17 +194,15 @@ public interface AmazonCognitoIdentityProvider {
      * If <code>MessageAction</code> is not set, the default is to send a
      * welcome message via email or phone (SMS).
      * </p>
-     * <note>
      * <p>
      * This message is based on a template that you configured in your call to
-     * or . This template includes your custom sign-up instructions and
-     * placeholders for user name and temporary password.
+     * create or update a user pool. This template includes your custom sign-up
+     * instructions and placeholders for user name and temporary password.
      * </p>
-     * </note>
      * <p>
-     * Alternatively, you can call AdminCreateUser with “SUPPRESS” for the
-     * <code>MessageAction</code> parameter, and Amazon Cognito will not send
-     * any email.
+     * Alternatively, you can call <code>AdminCreateUser</code> with “SUPPRESS”
+     * for the <code>MessageAction</code> parameter, and Amazon Cognito will not
+     * send any email.
      * </p>
      * <p>
      * In either case, the user will be in the
@@ -212,7 +210,7 @@ public interface AmazonCognitoIdentityProvider {
      * their password.
      * </p>
      * <p>
-     * AdminCreateUser requires developer credentials.
+     * <code>AdminCreateUser</code> requires developer credentials.
      * </p>
      * 
      * @param adminCreateUserRequest <p>
@@ -319,7 +317,9 @@ public interface AmazonCognitoIdentityProvider {
      * user, any link between that user and an existing user is removed. The
      * next time the external user (no longer attached to the previously linked
      * <code>DestinationUser</code>) signs in, they must create a new user
-     * account. See .
+     * account. See <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminLinkProviderForUser.html"
+     * >AdminLinkProviderForUser</a>.
      * </p>
      * <p>
      * This action is enabled only for admin access and requires developer
@@ -348,12 +348,12 @@ public interface AmazonCognitoIdentityProvider {
      * <code>ProviderAttributeName</code> and
      * <code>ProviderAttributeValue</code> must be the same values that were
      * used for the <code>SourceUser</code> when the identities were originally
-     * linked in the call. (If the linking was done with
-     * <code>ProviderAttributeName</code> set to <code>Cognito_Subject</code>,
-     * the same applies here). However, if the user has already signed in, the
-     * <code>ProviderAttributeName</code> must be <code>Cognito_Subject</code>
-     * and <code>ProviderAttributeValue</code> must be the subject of the SAML
-     * assertion.
+     * linked using <code> AdminLinkProviderForUser</code> call. (If the linking
+     * was done with <code>ProviderAttributeName</code> set to
+     * <code>Cognito_Subject</code>, the same applies here). However, if the
+     * user has already signed in, the <code>ProviderAttributeName</code> must
+     * be <code>Cognito_Subject</code> and <code>ProviderAttributeValue</code>
+     * must be the subject of the SAML assertion.
      * </p>
      * 
      * @param adminDisableProviderForUserRequest
@@ -587,7 +587,11 @@ public interface AmazonCognitoIdentityProvider {
      * federated user identity is used, the user signs in as the existing user
      * account.
      * </p>
-     * <important>
+     * <note>
+     * <p>
+     * The maximum number of federated identities linked to a user is 5.
+     * </p>
+     * </note> <important>
      * <p>
      * Because this API allows a user with an external federated identity to
      * sign in as an existing user in the user pool, it is critical that it only
@@ -595,9 +599,6 @@ public interface AmazonCognitoIdentityProvider {
      * have been trusted by the application owner.
      * </p>
      * </important>
-     * <p>
-     * See also .
-     * </p>
      * <p>
      * This action is enabled only for admin access and requires developer
      * credentials.
@@ -613,6 +614,7 @@ public interface AmazonCognitoIdentityProvider {
      * @throws NotAuthorizedException
      * @throws UserNotFoundException
      * @throws AliasExistsException
+     * @throws LimitExceededException
      * @throws InternalErrorException
      * @throws AmazonClientException If any internal errors are encountered
      *             inside the client while attempting to make the request or
@@ -918,8 +920,9 @@ public interface AmazonCognitoIdentityProvider {
      * <p>
      * <i>This action is no longer supported.</i> You can use it to configure
      * only SMS MFA. You can't use it to configure TOTP software token MFA. To
-     * configure either type of MFA, use the <a>AdminSetUserMFAPreference</a>
-     * action instead.
+     * configure either type of MFA, use <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserMFAPreference.html"
+     * >AdminSetUserMFAPreference</a> instead.
      * </p>
      * 
      * @param adminSetUserSettingsRequest <p>
@@ -1103,6 +1106,7 @@ public interface AmazonCognitoIdentityProvider {
      * @return associateSoftwareTokenResult The response from the
      *         AssociateSoftwareToken service method, as returned by Amazon
      *         Cognito Your User Pool.
+     * @throws ConcurrentModificationException
      * @throws InvalidParameterException
      * @throws NotAuthorizedException
      * @throws ResourceNotFoundException
@@ -1887,11 +1891,14 @@ public interface AmazonCognitoIdentityProvider {
      * confirmation code that is required to change the user's password. For the
      * <code>Username</code> parameter, you can use the username or user alias.
      * The method used to send the confirmation code is sent according to the
-     * specified AccountRecoverySetting. For more information, see <a
-     * href="">Recovering User Accounts</a> in the <i>Amazon Cognito Developer
+     * specified AccountRecoverySetting. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-recover-a-user-account.html"
+     * >Recovering User Accounts</a> in the <i>Amazon Cognito Developer
      * Guide</i>. If neither a verified phone number nor a verified email
      * exists, an <code>InvalidParameterException</code> is thrown. To use the
-     * confirmation code for resetting the password, call .
+     * confirmation code for resetting the password, call <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmForgotPassword.html"
+     * >ConfirmForgotPassword</a>.
      * </p>
      * 
      * @param forgotPasswordRequest <p>
@@ -2618,9 +2625,6 @@ public interface AmazonCognitoIdentityProvider {
      * to include the <code>UserPoolAddOns</code> key
      * <code>AdvancedSecurityMode</code>.
      * </p>
-     * <p>
-     * See .
-     * </p>
      * 
      * @param setRiskConfigurationRequest
      * @return setRiskConfigurationResult The response from the
@@ -2751,8 +2755,9 @@ public interface AmazonCognitoIdentityProvider {
      * <p>
      * <i>This action is no longer supported.</i> You can use it to configure
      * only SMS MFA. You can't use it to configure TOTP software token MFA. To
-     * configure either type of MFA, use the <a>SetUserMFAPreference</a> action
-     * instead.
+     * configure either type of MFA, use <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserMFAPreference.html"
+     * >SetUserMFAPreference</a> instead.
      * </p>
      * 
      * @param setUserSettingsRequest <p>
@@ -3136,7 +3141,9 @@ public interface AmazonCognitoIdentityProvider {
     /**
      * <p>
      * Updates the specified user pool with the specified attributes. You can
-     * get a list of the current user pool settings with .
+     * get a list of the current user pool settings using <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPool.html"
+     * >DescribeUserPool</a>.
      * </p>
      * <important>
      * <p>
@@ -3175,7 +3182,10 @@ public interface AmazonCognitoIdentityProvider {
     /**
      * <p>
      * Updates the specified user pool app client with the specified attributes.
-     * You can get a list of the current user pool app client settings with .
+     * You can get a list of the current user pool app client settings using <a
+     * href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPoolClient.html"
+     * >DescribeUserPoolClient</a>.
      * </p>
      * <important>
      * <p>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/AmazonCognitoIdentityProviderClient.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/AmazonCognitoIdentityProviderClient.java
@@ -575,17 +575,15 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * If <code>MessageAction</code> is not set, the default is to send a
      * welcome message via email or phone (SMS).
      * </p>
-     * <note>
      * <p>
      * This message is based on a template that you configured in your call to
-     * or . This template includes your custom sign-up instructions and
-     * placeholders for user name and temporary password.
+     * create or update a user pool. This template includes your custom sign-up
+     * instructions and placeholders for user name and temporary password.
      * </p>
-     * </note>
      * <p>
-     * Alternatively, you can call AdminCreateUser with “SUPPRESS” for the
-     * <code>MessageAction</code> parameter, and Amazon Cognito will not send
-     * any email.
+     * Alternatively, you can call <code>AdminCreateUser</code> with “SUPPRESS”
+     * for the <code>MessageAction</code> parameter, and Amazon Cognito will not
+     * send any email.
      * </p>
      * <p>
      * In either case, the user will be in the
@@ -593,7 +591,7 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * their password.
      * </p>
      * <p>
-     * AdminCreateUser requires developer credentials.
+     * <code>AdminCreateUser</code> requires developer credentials.
      * </p>
      * 
      * @param adminCreateUserRequest <p>
@@ -774,7 +772,9 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * user, any link between that user and an existing user is removed. The
      * next time the external user (no longer attached to the previously linked
      * <code>DestinationUser</code>) signs in, they must create a new user
-     * account. See .
+     * account. See <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminLinkProviderForUser.html"
+     * >AdminLinkProviderForUser</a>.
      * </p>
      * <p>
      * This action is enabled only for admin access and requires developer
@@ -803,12 +803,12 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * <code>ProviderAttributeName</code> and
      * <code>ProviderAttributeValue</code> must be the same values that were
      * used for the <code>SourceUser</code> when the identities were originally
-     * linked in the call. (If the linking was done with
-     * <code>ProviderAttributeName</code> set to <code>Cognito_Subject</code>,
-     * the same applies here). However, if the user has already signed in, the
-     * <code>ProviderAttributeName</code> must be <code>Cognito_Subject</code>
-     * and <code>ProviderAttributeValue</code> must be the subject of the SAML
-     * assertion.
+     * linked using <code> AdminLinkProviderForUser</code> call. (If the linking
+     * was done with <code>ProviderAttributeName</code> set to
+     * <code>Cognito_Subject</code>, the same applies here). However, if the
+     * user has already signed in, the <code>ProviderAttributeName</code> must
+     * be <code>Cognito_Subject</code> and <code>ProviderAttributeValue</code>
+     * must be the subject of the SAML assertion.
      * </p>
      * 
      * @param adminDisableProviderForUserRequest
@@ -1223,7 +1223,11 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * federated user identity is used, the user signs in as the existing user
      * account.
      * </p>
-     * <important>
+     * <note>
+     * <p>
+     * The maximum number of federated identities linked to a user is 5.
+     * </p>
+     * </note> <important>
      * <p>
      * Because this API allows a user with an external federated identity to
      * sign in as an existing user in the user pool, it is critical that it only
@@ -1231,9 +1235,6 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * have been trusted by the application owner.
      * </p>
      * </important>
-     * <p>
-     * See also .
-     * </p>
      * <p>
      * This action is enabled only for admin access and requires developer
      * credentials.
@@ -1249,6 +1250,7 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * @throws NotAuthorizedException
      * @throws UserNotFoundException
      * @throws AliasExistsException
+     * @throws LimitExceededException
      * @throws InternalErrorException
      * @throws AmazonClientException If any internal errors are encountered
      *             inside the client while attempting to make the request or
@@ -1792,8 +1794,9 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * <p>
      * <i>This action is no longer supported.</i> You can use it to configure
      * only SMS MFA. You can't use it to configure TOTP software token MFA. To
-     * configure either type of MFA, use the <a>AdminSetUserMFAPreference</a>
-     * action instead.
+     * configure either type of MFA, use <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserMFAPreference.html"
+     * >AdminSetUserMFAPreference</a> instead.
      * </p>
      * 
      * @param adminSetUserSettingsRequest <p>
@@ -2112,6 +2115,7 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * @return associateSoftwareTokenResult The response from the
      *         AssociateSoftwareToken service method, as returned by Amazon
      *         Cognito Your User Pool.
+     * @throws ConcurrentModificationException
      * @throws InvalidParameterException
      * @throws NotAuthorizedException
      * @throws ResourceNotFoundException
@@ -3607,11 +3611,14 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * confirmation code that is required to change the user's password. For the
      * <code>Username</code> parameter, you can use the username or user alias.
      * The method used to send the confirmation code is sent according to the
-     * specified AccountRecoverySetting. For more information, see <a
-     * href="">Recovering User Accounts</a> in the <i>Amazon Cognito Developer
+     * specified AccountRecoverySetting. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-recover-a-user-account.html"
+     * >Recovering User Accounts</a> in the <i>Amazon Cognito Developer
      * Guide</i>. If neither a verified phone number nor a verified email
      * exists, an <code>InvalidParameterException</code> is thrown. To use the
-     * confirmation code for resetting the password, call .
+     * confirmation code for resetting the password, call <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmForgotPassword.html"
+     * >ConfirmForgotPassword</a>.
      * </p>
      * 
      * @param forgotPasswordRequest <p>
@@ -4976,9 +4983,6 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * to include the <code>UserPoolAddOns</code> key
      * <code>AdvancedSecurityMode</code>.
      * </p>
-     * <p>
-     * See .
-     * </p>
      * 
      * @param setRiskConfigurationRequest
      * @return setRiskConfigurationResult The response from the
@@ -5218,8 +5222,9 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
      * <p>
      * <i>This action is no longer supported.</i> You can use it to configure
      * only SMS MFA. You can't use it to configure TOTP software token MFA. To
-     * configure either type of MFA, use the <a>SetUserMFAPreference</a> action
-     * instead.
+     * configure either type of MFA, use <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserMFAPreference.html"
+     * >SetUserMFAPreference</a> instead.
      * </p>
      * 
      * @param setUserSettingsRequest <p>
@@ -5925,7 +5930,9 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
     /**
      * <p>
      * Updates the specified user pool with the specified attributes. You can
-     * get a list of the current user pool settings with .
+     * get a list of the current user pool settings using <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPool.html"
+     * >DescribeUserPool</a>.
      * </p>
      * <important>
      * <p>
@@ -5990,7 +5997,10 @@ public class AmazonCognitoIdentityProviderClient extends AmazonWebServiceClient 
     /**
      * <p>
      * Updates the specified user pool app client with the specified attributes.
-     * You can get a list of the current user pool app client settings with .
+     * You can get a list of the current user pool app client settings using <a
+     * href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPoolClient.html"
+     * >DescribeUserPoolClient</a>.
      * </p>
      * <important>
      * <p>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminCreateUserRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminCreateUserRequest.java
@@ -27,24 +27,22 @@ import com.amazonaws.AmazonWebServiceRequest;
  * If <code>MessageAction</code> is not set, the default is to send a welcome
  * message via email or phone (SMS).
  * </p>
- * <note>
  * <p>
- * This message is based on a template that you configured in your call to or .
- * This template includes your custom sign-up instructions and placeholders for
- * user name and temporary password.
+ * This message is based on a template that you configured in your call to
+ * create or update a user pool. This template includes your custom sign-up
+ * instructions and placeholders for user name and temporary password.
  * </p>
- * </note>
  * <p>
- * Alternatively, you can call AdminCreateUser with “SUPPRESS” for the
- * <code>MessageAction</code> parameter, and Amazon Cognito will not send any
- * email.
+ * Alternatively, you can call <code>AdminCreateUser</code> with “SUPPRESS” for
+ * the <code>MessageAction</code> parameter, and Amazon Cognito will not send
+ * any email.
  * </p>
  * <p>
  * In either case, the user will be in the <code>FORCE_CHANGE_PASSWORD</code>
  * state until they sign in and change their password.
  * </p>
  * <p>
- * AdminCreateUser requires developer credentials.
+ * <code>AdminCreateUser</code> requires developer credentials.
  * </p>
  */
 public class AdminCreateUserRequest extends AmazonWebServiceRequest implements Serializable {
@@ -77,10 +75,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * An array of name-value pairs that contain user attributes and attribute
      * values to be set for the user to be created. You can create a user
      * without specifying any attributes other than <code>Username</code>.
-     * However, any attributes that you specify as required (in or in the
-     * <b>Attributes</b> tab of the console) must be supplied either by you (in
-     * your call to <code>AdminCreateUser</code>) or by the user (when he or she
-     * signs up in response to your welcome message).
+     * However, any attributes that you specify as required (when creating a
+     * user pool or in the <b>Attributes</b> tab of the console) must be
+     * supplied either by you (in your call to <code>AdminCreateUser</code>) or
+     * by the user (when he or she signs up in response to your welcome
+     * message).
      * </p>
      * <p>
      * For custom attributes, you must prepend the <code>custom:</code> prefix
@@ -96,7 +95,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * In your call to <code>AdminCreateUser</code>, you can set the
      * <code>email_verified</code> attribute to <code>True</code>, and you can
      * set the <code>phone_number_verified</code> attribute to <code>True</code>
-     * . (You can also do this by calling .)
+     * . (You can also do this by calling <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     * >AdminUpdateUserAttributes</a>.)
      * </p>
      * <ul>
      * <li>
@@ -400,10 +401,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * An array of name-value pairs that contain user attributes and attribute
      * values to be set for the user to be created. You can create a user
      * without specifying any attributes other than <code>Username</code>.
-     * However, any attributes that you specify as required (in or in the
-     * <b>Attributes</b> tab of the console) must be supplied either by you (in
-     * your call to <code>AdminCreateUser</code>) or by the user (when he or she
-     * signs up in response to your welcome message).
+     * However, any attributes that you specify as required (when creating a
+     * user pool or in the <b>Attributes</b> tab of the console) must be
+     * supplied either by you (in your call to <code>AdminCreateUser</code>) or
+     * by the user (when he or she signs up in response to your welcome
+     * message).
      * </p>
      * <p>
      * For custom attributes, you must prepend the <code>custom:</code> prefix
@@ -419,7 +421,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * In your call to <code>AdminCreateUser</code>, you can set the
      * <code>email_verified</code> attribute to <code>True</code>, and you can
      * set the <code>phone_number_verified</code> attribute to <code>True</code>
-     * . (You can also do this by calling .)
+     * . (You can also do this by calling <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     * >AdminUpdateUserAttributes</a>.)
      * </p>
      * <ul>
      * <li>
@@ -447,10 +451,10 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *         attribute values to be set for the user to be created. You can
      *         create a user without specifying any attributes other than
      *         <code>Username</code>. However, any attributes that you specify
-     *         as required (in or in the <b>Attributes</b> tab of the console)
-     *         must be supplied either by you (in your call to
-     *         <code>AdminCreateUser</code>) or by the user (when he or she
-     *         signs up in response to your welcome message).
+     *         as required (when creating a user pool or in the
+     *         <b>Attributes</b> tab of the console) must be supplied either by
+     *         you (in your call to <code>AdminCreateUser</code>) or by the user
+     *         (when he or she signs up in response to your welcome message).
      *         </p>
      *         <p>
      *         For custom attributes, you must prepend the <code>custom:</code>
@@ -466,7 +470,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *         In your call to <code>AdminCreateUser</code>, you can set the
      *         <code>email_verified</code> attribute to <code>True</code>, and
      *         you can set the <code>phone_number_verified</code> attribute to
-     *         <code>True</code>. (You can also do this by calling .)
+     *         <code>True</code>. (You can also do this by calling <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     *         >AdminUpdateUserAttributes</a>.)
      *         </p>
      *         <ul>
      *         <li>
@@ -498,10 +504,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * An array of name-value pairs that contain user attributes and attribute
      * values to be set for the user to be created. You can create a user
      * without specifying any attributes other than <code>Username</code>.
-     * However, any attributes that you specify as required (in or in the
-     * <b>Attributes</b> tab of the console) must be supplied either by you (in
-     * your call to <code>AdminCreateUser</code>) or by the user (when he or she
-     * signs up in response to your welcome message).
+     * However, any attributes that you specify as required (when creating a
+     * user pool or in the <b>Attributes</b> tab of the console) must be
+     * supplied either by you (in your call to <code>AdminCreateUser</code>) or
+     * by the user (when he or she signs up in response to your welcome
+     * message).
      * </p>
      * <p>
      * For custom attributes, you must prepend the <code>custom:</code> prefix
@@ -517,7 +524,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * In your call to <code>AdminCreateUser</code>, you can set the
      * <code>email_verified</code> attribute to <code>True</code>, and you can
      * set the <code>phone_number_verified</code> attribute to <code>True</code>
-     * . (You can also do this by calling .)
+     * . (You can also do this by calling <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     * >AdminUpdateUserAttributes</a>.)
      * </p>
      * <ul>
      * <li>
@@ -545,10 +554,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *            attribute values to be set for the user to be created. You can
      *            create a user without specifying any attributes other than
      *            <code>Username</code>. However, any attributes that you
-     *            specify as required (in or in the <b>Attributes</b> tab of the
-     *            console) must be supplied either by you (in your call to
-     *            <code>AdminCreateUser</code>) or by the user (when he or she
-     *            signs up in response to your welcome message).
+     *            specify as required (when creating a user pool or in the
+     *            <b>Attributes</b> tab of the console) must be supplied either
+     *            by you (in your call to <code>AdminCreateUser</code>) or by
+     *            the user (when he or she signs up in response to your welcome
+     *            message).
      *            </p>
      *            <p>
      *            For custom attributes, you must prepend the
@@ -566,7 +576,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *            <code>email_verified</code> attribute to <code>True</code>,
      *            and you can set the <code>phone_number_verified</code>
      *            attribute to <code>True</code>. (You can also do this by
-     *            calling .)
+     *            calling <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     *            >AdminUpdateUserAttributes</a>.)
      *            </p>
      *            <ul>
      *            <li>
@@ -604,10 +616,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * An array of name-value pairs that contain user attributes and attribute
      * values to be set for the user to be created. You can create a user
      * without specifying any attributes other than <code>Username</code>.
-     * However, any attributes that you specify as required (in or in the
-     * <b>Attributes</b> tab of the console) must be supplied either by you (in
-     * your call to <code>AdminCreateUser</code>) or by the user (when he or she
-     * signs up in response to your welcome message).
+     * However, any attributes that you specify as required (when creating a
+     * user pool or in the <b>Attributes</b> tab of the console) must be
+     * supplied either by you (in your call to <code>AdminCreateUser</code>) or
+     * by the user (when he or she signs up in response to your welcome
+     * message).
      * </p>
      * <p>
      * For custom attributes, you must prepend the <code>custom:</code> prefix
@@ -623,7 +636,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * In your call to <code>AdminCreateUser</code>, you can set the
      * <code>email_verified</code> attribute to <code>True</code>, and you can
      * set the <code>phone_number_verified</code> attribute to <code>True</code>
-     * . (You can also do this by calling .)
+     * . (You can also do this by calling <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     * >AdminUpdateUserAttributes</a>.)
      * </p>
      * <ul>
      * <li>
@@ -654,10 +669,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *            attribute values to be set for the user to be created. You can
      *            create a user without specifying any attributes other than
      *            <code>Username</code>. However, any attributes that you
-     *            specify as required (in or in the <b>Attributes</b> tab of the
-     *            console) must be supplied either by you (in your call to
-     *            <code>AdminCreateUser</code>) or by the user (when he or she
-     *            signs up in response to your welcome message).
+     *            specify as required (when creating a user pool or in the
+     *            <b>Attributes</b> tab of the console) must be supplied either
+     *            by you (in your call to <code>AdminCreateUser</code>) or by
+     *            the user (when he or she signs up in response to your welcome
+     *            message).
      *            </p>
      *            <p>
      *            For custom attributes, you must prepend the
@@ -675,7 +691,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *            <code>email_verified</code> attribute to <code>True</code>,
      *            and you can set the <code>phone_number_verified</code>
      *            attribute to <code>True</code>. (You can also do this by
-     *            calling .)
+     *            calling <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     *            >AdminUpdateUserAttributes</a>.)
      *            </p>
      *            <ul>
      *            <li>
@@ -716,10 +734,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * An array of name-value pairs that contain user attributes and attribute
      * values to be set for the user to be created. You can create a user
      * without specifying any attributes other than <code>Username</code>.
-     * However, any attributes that you specify as required (in or in the
-     * <b>Attributes</b> tab of the console) must be supplied either by you (in
-     * your call to <code>AdminCreateUser</code>) or by the user (when he or she
-     * signs up in response to your welcome message).
+     * However, any attributes that you specify as required (when creating a
+     * user pool or in the <b>Attributes</b> tab of the console) must be
+     * supplied either by you (in your call to <code>AdminCreateUser</code>) or
+     * by the user (when he or she signs up in response to your welcome
+     * message).
      * </p>
      * <p>
      * For custom attributes, you must prepend the <code>custom:</code> prefix
@@ -735,7 +754,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      * In your call to <code>AdminCreateUser</code>, you can set the
      * <code>email_verified</code> attribute to <code>True</code>, and you can
      * set the <code>phone_number_verified</code> attribute to <code>True</code>
-     * . (You can also do this by calling .)
+     * . (You can also do this by calling <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     * >AdminUpdateUserAttributes</a>.)
      * </p>
      * <ul>
      * <li>
@@ -766,10 +787,11 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *            attribute values to be set for the user to be created. You can
      *            create a user without specifying any attributes other than
      *            <code>Username</code>. However, any attributes that you
-     *            specify as required (in or in the <b>Attributes</b> tab of the
-     *            console) must be supplied either by you (in your call to
-     *            <code>AdminCreateUser</code>) or by the user (when he or she
-     *            signs up in response to your welcome message).
+     *            specify as required (when creating a user pool or in the
+     *            <b>Attributes</b> tab of the console) must be supplied either
+     *            by you (in your call to <code>AdminCreateUser</code>) or by
+     *            the user (when he or she signs up in response to your welcome
+     *            message).
      *            </p>
      *            <p>
      *            For custom attributes, you must prepend the
@@ -787,7 +809,9 @@ public class AdminCreateUserRequest extends AmazonWebServiceRequest implements S
      *            <code>email_verified</code> attribute to <code>True</code>,
      *            and you can set the <code>phone_number_verified</code>
      *            attribute to <code>True</code>. (You can also do this by
-     *            calling .)
+     *            calling <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html"
+     *            >AdminUpdateUserAttributes</a>.)
      *            </p>
      *            <ul>
      *            <li>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminDisableProviderForUserRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminDisableProviderForUserRequest.java
@@ -28,7 +28,9 @@ import com.amazonaws.AmazonWebServiceRequest;
  * between that user and an existing user is removed. The next time the external
  * user (no longer attached to the previously linked
  * <code>DestinationUser</code>) signs in, they must create a new user account.
- * See .
+ * See <a href=
+ * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminLinkProviderForUser.html"
+ * >AdminLinkProviderForUser</a>.
  * </p>
  * <p>
  * This action is enabled only for admin access and requires developer
@@ -56,9 +58,10 @@ import com.amazonaws.AmazonWebServiceRequest;
  * identity has not yet been used to sign-in, the
  * <code>ProviderAttributeName</code> and <code>ProviderAttributeValue</code>
  * must be the same values that were used for the <code>SourceUser</code> when
- * the identities were originally linked in the call. (If the linking was done
- * with <code>ProviderAttributeName</code> set to <code>Cognito_Subject</code>,
- * the same applies here). However, if the user has already signed in, the
+ * the identities were originally linked using
+ * <code> AdminLinkProviderForUser</code> call. (If the linking was done with
+ * <code>ProviderAttributeName</code> set to <code>Cognito_Subject</code>, the
+ * same applies here). However, if the user has already signed in, the
  * <code>ProviderAttributeName</code> must be <code>Cognito_Subject</code> and
  * <code>ProviderAttributeValue</code> must be the subject of the SAML
  * assertion.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminGetUserResult.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminGetUserResult.java
@@ -119,8 +119,8 @@ public class AdminGetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the
-     * <a>AdminGetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      */
     private java.util.List<MFAOptionType> mFAOptions;
@@ -943,8 +943,8 @@ public class AdminGetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the
-     * <a>AdminGetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      *
      * @return <p>
@@ -952,8 +952,7 @@ public class AdminGetUserResult implements Serializable {
      *         provides information only about SMS MFA configurations. It
      *         doesn't provide information about TOTP software token MFA
      *         configurations. To look up information about either type of MFA
-     *         configuration, use the
-     *         <a>AdminGetUserResponse$UserMFASettingList</a> response instead.
+     *         configuration, use UserMFASettingList instead.
      *         </p>
      */
     public java.util.List<MFAOptionType> getMFAOptions() {
@@ -965,8 +964,8 @@ public class AdminGetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the
-     * <a>AdminGetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      *
      * @param mFAOptions <p>
@@ -974,9 +973,7 @@ public class AdminGetUserResult implements Serializable {
      *            provides information only about SMS MFA configurations. It
      *            doesn't provide information about TOTP software token MFA
      *            configurations. To look up information about either type of
-     *            MFA configuration, use the
-     *            <a>AdminGetUserResponse$UserMFASettingList</a> response
-     *            instead.
+     *            MFA configuration, use UserMFASettingList instead.
      *            </p>
      */
     public void setMFAOptions(java.util.Collection<MFAOptionType> mFAOptions) {
@@ -993,8 +990,8 @@ public class AdminGetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the
-     * <a>AdminGetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -1005,9 +1002,7 @@ public class AdminGetUserResult implements Serializable {
      *            provides information only about SMS MFA configurations. It
      *            doesn't provide information about TOTP software token MFA
      *            configurations. To look up information about either type of
-     *            MFA configuration, use the
-     *            <a>AdminGetUserResponse$UserMFASettingList</a> response
-     *            instead.
+     *            MFA configuration, use UserMFASettingList instead.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -1027,8 +1022,8 @@ public class AdminGetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the
-     * <a>AdminGetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -1039,9 +1034,7 @@ public class AdminGetUserResult implements Serializable {
      *            provides information only about SMS MFA configurations. It
      *            doesn't provide information about TOTP software token MFA
      *            configurations. To look up information about either type of
-     *            MFA configuration, use the
-     *            <a>AdminGetUserResponse$UserMFASettingList</a> response
-     *            instead.
+     *            MFA configuration, use UserMFASettingList instead.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminInitiateAuthRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminInitiateAuthRequest.java
@@ -141,7 +141,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -149,21 +149,23 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>
+     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1224,7 +1226,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1232,21 +1234,23 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>
+     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1262,7 +1266,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *         For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      *         <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required
      *         if the app client is configured with a client secret),
-     *         <code>DEVICE_KEY</code>
+     *         <code>DEVICE_KEY</code>.
      *         </p>
      *         </li>
      *         <li>
@@ -1270,7 +1274,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *         For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      *         <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code>
      *         (required if the app client is configured with a client secret),
-     *         <code>DEVICE_KEY</code>
+     *         <code>DEVICE_KEY</code>.
      *         </p>
      *         </li>
      *         <li>
@@ -1278,14 +1282,17 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *         For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code>
      *         (required), <code>SECRET_HASH</code> (if app client is configured
      *         with client secret), <code>PASSWORD</code> (required),
-     *         <code>DEVICE_KEY</code>
+     *         <code>DEVICE_KEY</code>.
      *         </p>
      *         </li>
      *         <li>
      *         <p>
      *         For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      *         <code>SECRET_HASH</code> (if app client is configured with client
-     *         secret), <code>DEVICE_KEY</code>
+     *         secret), <code>DEVICE_KEY</code>. To start the authentication
+     *         flow with password verification, include
+     *         <code>ChallengeName: SRP_A</code> and
+     *         <code>SRP_A: (The SRP_A Value)</code>.
      *         </p>
      *         </li>
      *         </ul>
@@ -1305,7 +1312,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1313,21 +1320,23 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>
+     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1343,7 +1352,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *            For <code>USER_SRP_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SRP_A</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
@@ -1351,7 +1360,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *            For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      *            <code>REFRESH_TOKEN</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
@@ -1359,14 +1368,17 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *            For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SECRET_HASH</code> (if app client is
      *            configured with client secret), <code>PASSWORD</code>
-     *            (required), <code>DEVICE_KEY</code>
+     *            (required), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
      *            <p>
      *            For <code>CUSTOM_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SECRET_HASH</code> (if app client is
-     *            configured with client secret), <code>DEVICE_KEY</code>
+     *            configured with client secret), <code>DEVICE_KEY</code>. To
+     *            start the authentication flow with password verification,
+     *            include <code>ChallengeName: SRP_A</code> and
+     *            <code>SRP_A: (The SRP_A Value)</code>.
      *            </p>
      *            </li>
      *            </ul>
@@ -1386,7 +1398,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1394,21 +1406,23 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>
+     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1427,7 +1441,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *            For <code>USER_SRP_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SRP_A</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
@@ -1435,7 +1449,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *            For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      *            <code>REFRESH_TOKEN</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
@@ -1443,14 +1457,17 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      *            For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SECRET_HASH</code> (if app client is
      *            configured with client secret), <code>PASSWORD</code>
-     *            (required), <code>DEVICE_KEY</code>
+     *            (required), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
      *            <p>
      *            For <code>CUSTOM_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SECRET_HASH</code> (if app client is
-     *            configured with client secret), <code>DEVICE_KEY</code>
+     *            configured with client secret), <code>DEVICE_KEY</code>. To
+     *            start the authentication flow with password verification,
+     *            include <code>ChallengeName: SRP_A</code> and
+     *            <code>SRP_A: (The SRP_A Value)</code>.
      *            </p>
      *            </li>
      *            </ul>
@@ -1473,7 +1490,7 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1481,21 +1498,23 @@ public class AdminInitiateAuthRequest extends AmazonWebServiceRequest implements
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>ADMIN_NO_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>
+     * secret), <code>PASSWORD</code> (required), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminLinkProviderForUserRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminLinkProviderForUserRequest.java
@@ -34,7 +34,11 @@ import com.amazonaws.AmazonWebServiceRequest;
  * API links that user to a federated user identity, so that when the federated
  * user identity is used, the user signs in as the existing user account.
  * </p>
- * <important>
+ * <note>
+ * <p>
+ * The maximum number of federated identities linked to a user is 5.
+ * </p>
+ * </note> <important>
  * <p>
  * Because this API allows a user with an external federated identity to sign in
  * as an existing user in the user pool, it is critical that it only be used
@@ -42,9 +46,6 @@ import com.amazonaws.AmazonWebServiceRequest;
  * trusted by the application owner.
  * </p>
  * </important>
- * <p>
- * See also .
- * </p>
  * <p>
  * This action is enabled only for admin access and requires developer
  * credentials.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminRespondToAuthChallengeRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminRespondToAuthChallengeRequest.java
@@ -53,7 +53,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -314,7 +316,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -323,7 +327,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @return <p>
-     *         The challenge name. For more information, see .
+     *         The challenge name. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *         >AdminInitiateAuth</a>.
      *         </p>
      * @see ChallengeNameType
      */
@@ -333,7 +339,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -342,7 +350,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @see ChallengeNameType
      */
@@ -352,7 +362,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -364,7 +376,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -377,7 +391,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -386,7 +402,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @see ChallengeNameType
      */
@@ -396,7 +414,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -408,7 +428,9 @@ public class AdminRespondToAuthChallengeRequest extends AmazonWebServiceRequest 
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminRespondToAuthChallengeResult.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminRespondToAuthChallengeResult.java
@@ -25,7 +25,9 @@ import java.io.Serializable;
 public class AdminRespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
-     * The name of the challenge. For more information, see .
+     * The name of the challenge. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -38,10 +40,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -51,7 +52,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      */
     private java.util.Map<String, String> challengeParameters;
@@ -66,7 +69,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The name of the challenge. For more information, see .
+     * The name of the challenge. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -75,7 +80,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @return <p>
-     *         The name of the challenge. For more information, see .
+     *         The name of the challenge. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *         >AdminInitiateAuth</a>.
      *         </p>
      * @see ChallengeNameType
      */
@@ -85,7 +92,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The name of the challenge. For more information, see .
+     * The name of the challenge. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -94,7 +103,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The name of the challenge. For more information, see .
+     *            The name of the challenge. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @see ChallengeNameType
      */
@@ -104,7 +115,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The name of the challenge. For more information, see .
+     * The name of the challenge. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -116,7 +129,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The name of the challenge. For more information, see .
+     *            The name of the challenge. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -129,7 +144,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The name of the challenge. For more information, see .
+     * The name of the challenge. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -138,7 +155,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The name of the challenge. For more information, see .
+     *            The name of the challenge. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @see ChallengeNameType
      */
@@ -148,7 +167,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The name of the challenge. For more information, see .
+     * The name of the challenge. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -160,7 +181,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The name of the challenge. For more information, see .
+     *            The name of the challenge. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -174,10 +197,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -185,11 +207,10 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      *
      * @return <p>
      *         The session which should be passed both ways in
-     *         challenge-response calls to the service. If the or API call
-     *         determines that the caller needs to go through another challenge,
-     *         they return a session with other challenge parameters. This
-     *         session should be passed as it is to the next
-     *         <code>RespondToAuthChallenge</code> API call.
+     *         challenge-response calls to the service. If the caller needs to
+     *         go through another challenge, they return a session with other
+     *         challenge parameters. This session should be passed as it is to
+     *         the next <code>RespondToAuthChallenge</code> API call.
      *         </p>
      */
     public String getSession() {
@@ -199,10 +220,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -210,11 +230,11 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      *
      * @param session <p>
      *            The session which should be passed both ways in
-     *            challenge-response calls to the service. If the or API call
-     *            determines that the caller needs to go through another
-     *            challenge, they return a session with other challenge
-     *            parameters. This session should be passed as it is to the next
-     *            <code>RespondToAuthChallenge</code> API call.
+     *            challenge-response calls to the service. If the caller needs
+     *            to go through another challenge, they return a session with
+     *            other challenge parameters. This session should be passed as
+     *            it is to the next <code>RespondToAuthChallenge</code> API
+     *            call.
      *            </p>
      */
     public void setSession(String session) {
@@ -224,10 +244,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -238,11 +257,11 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
      *
      * @param session <p>
      *            The session which should be passed both ways in
-     *            challenge-response calls to the service. If the or API call
-     *            determines that the caller needs to go through another
-     *            challenge, they return a session with other challenge
-     *            parameters. This session should be passed as it is to the next
-     *            <code>RespondToAuthChallenge</code> API call.
+     *            challenge-response calls to the service. If the caller needs
+     *            to go through another challenge, they return a session with
+     *            other challenge parameters. This session should be passed as
+     *            it is to the next <code>RespondToAuthChallenge</code> API
+     *            call.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -254,11 +273,15 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      *
      * @return <p>
-     *         The challenge parameters. For more information, see .
+     *         The challenge parameters. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *         >AdminInitiateAuth</a>.
      *         </p>
      */
     public java.util.Map<String, String> getChallengeParameters() {
@@ -267,11 +290,15 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      *
      * @param challengeParameters <p>
-     *            The challenge parameters. For more information, see .
+     *            The challenge parameters. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      */
     public void setChallengeParameters(java.util.Map<String, String> challengeParameters) {
@@ -280,14 +307,18 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
      * together.
      *
      * @param challengeParameters <p>
-     *            The challenge parameters. For more information, see .
+     *            The challenge parameters. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     *            >AdminInitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -300,7 +331,9 @@ public class AdminRespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html"
+     * >AdminInitiateAuth</a>.
      * </p>
      * <p>
      * The method adds a new key-value pair into ChallengeParameters parameter,

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminSetUserSettingsRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AdminSetUserSettingsRequest.java
@@ -23,7 +23,9 @@ import com.amazonaws.AmazonWebServiceRequest;
  * <p>
  * <i>This action is no longer supported.</i> You can use it to configure only
  * SMS MFA. You can't use it to configure TOTP software token MFA. To configure
- * either type of MFA, use the <a>AdminSetUserMFAPreference</a> action instead.
+ * either type of MFA, use <a href=
+ * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserMFAPreference.html"
+ * >AdminSetUserMFAPreference</a> instead.
  * </p>
  */
 public class AdminSetUserSettingsRequest extends AmazonWebServiceRequest implements Serializable {

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AnalyticsConfigurationType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/AnalyticsConfigurationType.java
@@ -24,9 +24,10 @@ import java.io.Serializable;
  * </p>
  * <note>
  * <p>
- * Cognito User Pools only supports sending events to Amazon Pinpoint projects
- * in the US East (N. Virginia) us-east-1 Region, regardless of the region in
- * which the user pool resides.
+ * In regions where Pinpoint is not available, Cognito User Pools only supports
+ * sending events to Amazon Pinpoint projects in us-east-1. In regions where
+ * Pinpoint is available, Cognito User Pools will support sending events to
+ * Amazon Pinpoint projects within that same region.
  * </p>
  * </note>
  */
@@ -40,6 +41,22 @@ public class AnalyticsConfigurationType implements Serializable {
      * <b>Pattern: </b>^[0-9a-fA-F]+$<br/>
      */
     private String applicationId;
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of an Amazon Pinpoint project. You can use
+     * the Amazon Pinpoint project for Pinpoint integration with the chosen User
+     * Pool Client. Amazon Cognito publishes events to the pinpoint project
+     * declared by the app ARN.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Length: </b>20 - 2048<br/>
+     * <b>Pattern:
+     * </b>arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=
+     * /,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?<br/>
+     */
+    private String applicationArn;
 
     /**
      * <p>
@@ -122,6 +139,89 @@ public class AnalyticsConfigurationType implements Serializable {
      */
     public AnalyticsConfigurationType withApplicationId(String applicationId) {
         this.applicationId = applicationId;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of an Amazon Pinpoint project. You can use
+     * the Amazon Pinpoint project for Pinpoint integration with the chosen User
+     * Pool Client. Amazon Cognito publishes events to the pinpoint project
+     * declared by the app ARN.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Length: </b>20 - 2048<br/>
+     * <b>Pattern:
+     * </b>arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=
+     * /,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?<br/>
+     *
+     * @return <p>
+     *         The Amazon Resource Name (ARN) of an Amazon Pinpoint project. You
+     *         can use the Amazon Pinpoint project for Pinpoint integration with
+     *         the chosen User Pool Client. Amazon Cognito publishes events to
+     *         the pinpoint project declared by the app ARN.
+     *         </p>
+     */
+    public String getApplicationArn() {
+        return applicationArn;
+    }
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of an Amazon Pinpoint project. You can use
+     * the Amazon Pinpoint project for Pinpoint integration with the chosen User
+     * Pool Client. Amazon Cognito publishes events to the pinpoint project
+     * declared by the app ARN.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Length: </b>20 - 2048<br/>
+     * <b>Pattern:
+     * </b>arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=
+     * /,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?<br/>
+     *
+     * @param applicationArn <p>
+     *            The Amazon Resource Name (ARN) of an Amazon Pinpoint project.
+     *            You can use the Amazon Pinpoint project for Pinpoint
+     *            integration with the chosen User Pool Client. Amazon Cognito
+     *            publishes events to the pinpoint project declared by the app
+     *            ARN.
+     *            </p>
+     */
+    public void setApplicationArn(String applicationArn) {
+        this.applicationArn = applicationArn;
+    }
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of an Amazon Pinpoint project. You can use
+     * the Amazon Pinpoint project for Pinpoint integration with the chosen User
+     * Pool Client. Amazon Cognito publishes events to the pinpoint project
+     * declared by the app ARN.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Length: </b>20 - 2048<br/>
+     * <b>Pattern:
+     * </b>arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=
+     * /,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?<br/>
+     *
+     * @param applicationArn <p>
+     *            The Amazon Resource Name (ARN) of an Amazon Pinpoint project.
+     *            You can use the Amazon Pinpoint project for Pinpoint
+     *            integration with the chosen User Pool Client. Amazon Cognito
+     *            publishes events to the pinpoint project declared by the app
+     *            ARN.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public AnalyticsConfigurationType withApplicationArn(String applicationArn) {
+        this.applicationArn = applicationArn;
         return this;
     }
 
@@ -326,6 +426,8 @@ public class AnalyticsConfigurationType implements Serializable {
         sb.append("{");
         if (getApplicationId() != null)
             sb.append("ApplicationId: " + getApplicationId() + ",");
+        if (getApplicationArn() != null)
+            sb.append("ApplicationArn: " + getApplicationArn() + ",");
         if (getRoleArn() != null)
             sb.append("RoleArn: " + getRoleArn() + ",");
         if (getExternalId() != null)
@@ -343,6 +445,8 @@ public class AnalyticsConfigurationType implements Serializable {
 
         hashCode = prime * hashCode
                 + ((getApplicationId() == null) ? 0 : getApplicationId().hashCode());
+        hashCode = prime * hashCode
+                + ((getApplicationArn() == null) ? 0 : getApplicationArn().hashCode());
         hashCode = prime * hashCode + ((getRoleArn() == null) ? 0 : getRoleArn().hashCode());
         hashCode = prime * hashCode + ((getExternalId() == null) ? 0 : getExternalId().hashCode());
         hashCode = prime * hashCode
@@ -365,6 +469,11 @@ public class AnalyticsConfigurationType implements Serializable {
             return false;
         if (other.getApplicationId() != null
                 && other.getApplicationId().equals(this.getApplicationId()) == false)
+            return false;
+        if (other.getApplicationArn() == null ^ this.getApplicationArn() == null)
+            return false;
+        if (other.getApplicationArn() != null
+                && other.getApplicationArn().equals(this.getApplicationArn()) == false)
             return false;
         if (other.getRoleArn() == null ^ this.getRoleArn() == null)
             return false;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/ConfirmForgotPasswordRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/ConfirmForgotPasswordRequest.java
@@ -64,7 +64,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
     /**
      * <p>
      * The confirmation code sent by a user's request to retrieve a forgotten
-     * password. For more information, see
+     * password. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     * >ForgotPassword</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -346,7 +348,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
     /**
      * <p>
      * The confirmation code sent by a user's request to retrieve a forgotten
-     * password. For more information, see
+     * password. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     * >ForgotPassword</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -355,7 +359,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
      *
      * @return <p>
      *         The confirmation code sent by a user's request to retrieve a
-     *         forgotten password. For more information, see
+     *         forgotten password. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     *         >ForgotPassword</a>.
      *         </p>
      */
     public String getConfirmationCode() {
@@ -365,7 +371,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
     /**
      * <p>
      * The confirmation code sent by a user's request to retrieve a forgotten
-     * password. For more information, see
+     * password. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     * >ForgotPassword</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -374,7 +382,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
      *
      * @param confirmationCode <p>
      *            The confirmation code sent by a user's request to retrieve a
-     *            forgotten password. For more information, see
+     *            forgotten password. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     *            >ForgotPassword</a>.
      *            </p>
      */
     public void setConfirmationCode(String confirmationCode) {
@@ -384,7 +394,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
     /**
      * <p>
      * The confirmation code sent by a user's request to retrieve a forgotten
-     * password. For more information, see
+     * password. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     * >ForgotPassword</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -396,7 +408,9 @@ public class ConfirmForgotPasswordRequest extends AmazonWebServiceRequest implem
      *
      * @param confirmationCode <p>
      *            The confirmation code sent by a user's request to retrieve a
-     *            forgotten password. For more information, see
+     *            forgotten password. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html"
+     *            >ForgotPassword</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/CreateIdentityProviderRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/CreateIdentityProviderRequest.java
@@ -66,7 +66,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -82,6 +82,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -170,11 +197,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <p>
      * jwks_uri <i>if not available from discovery URL specified by oidc_issuer
      * key</i>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * authorize_scopes
      * </p>
      * </li>
      * </ul>
@@ -439,7 +461,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -455,6 +477,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -545,11 +594,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * key</i>
      * </p>
      * </li>
-     * <li>
-     * <p>
-     * authorize_scopes
-     * </p>
-     * </li>
      * </ul>
      * </li>
      * <li>
@@ -578,7 +622,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *         <ul>
      *         <li>
      *         <p>
-     *         For Google, Facebook and Login with Amazon:
+     *         For Google and Login with Amazon:
      *         </p>
      *         <ul>
      *         <li>
@@ -594,6 +638,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *         <li>
      *         <p>
      *         authorize_scopes
+     *         </p>
+     *         </li>
+     *         </ul>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         For Facebook:
+     *         </p>
+     *         <ul>
+     *         <li>
+     *         <p>
+     *         client_id
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         client_secret
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         authorize_scopes
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         api_version
      *         </p>
      *         </li>
      *         </ul>
@@ -684,11 +755,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *         oidc_issuer key</i>
      *         </p>
      *         </li>
-     *         <li>
-     *         <p>
-     *         authorize_scopes
-     *         </p>
-     *         </li>
      *         </ul>
      *         </li>
      *         <li>
@@ -722,7 +788,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -738,6 +804,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -828,11 +921,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * key</i>
      * </p>
      * </li>
-     * <li>
-     * <p>
-     * authorize_scopes
-     * </p>
-     * </li>
      * </ul>
      * </li>
      * <li>
@@ -861,7 +949,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *            <ul>
      *            <li>
      *            <p>
-     *            For Google, Facebook and Login with Amazon:
+     *            For Google and Login with Amazon:
      *            </p>
      *            <ul>
      *            <li>
@@ -877,6 +965,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *            <li>
      *            <p>
      *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            </ul>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            For Facebook:
+     *            </p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            client_id
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            client_secret
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            api_version
      *            </p>
      *            </li>
      *            </ul>
@@ -965,11 +1080,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *            <p>
      *            jwks_uri <i>if not available from discovery URL specified by
      *            oidc_issuer key</i>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            authorize_scopes
      *            </p>
      *            </li>
      *            </ul>
@@ -1005,7 +1115,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -1021,6 +1131,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -1111,11 +1248,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * key</i>
      * </p>
      * </li>
-     * <li>
-     * <p>
-     * authorize_scopes
-     * </p>
-     * </li>
      * </ul>
      * </li>
      * <li>
@@ -1147,7 +1279,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *            <ul>
      *            <li>
      *            <p>
-     *            For Google, Facebook and Login with Amazon:
+     *            For Google and Login with Amazon:
      *            </p>
      *            <ul>
      *            <li>
@@ -1163,6 +1295,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *            <li>
      *            <p>
      *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            </ul>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            For Facebook:
+     *            </p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            client_id
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            client_secret
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            api_version
      *            </p>
      *            </li>
      *            </ul>
@@ -1251,11 +1410,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      *            <p>
      *            jwks_uri <i>if not available from discovery URL specified by
      *            oidc_issuer key</i>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            authorize_scopes
      *            </p>
      *            </li>
      *            </ul>
@@ -1295,7 +1449,7 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -1311,6 +1465,33 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -1399,11 +1580,6 @@ public class CreateIdentityProviderRequest extends AmazonWebServiceRequest imple
      * <p>
      * jwks_uri <i>if not available from discovery URL specified by oidc_issuer
      * key</i>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * authorize_scopes
      * </p>
      * </li>
      * </ul>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/CreateUserPoolClientRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/CreateUserPoolClientRequest.java
@@ -63,9 +63,41 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      */
     private Integer refreshTokenValidity;
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the access token
+     * is no longer valid and cannot be used. This value will be overridden if
+     * you have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     */
+    private Integer accessTokenValidity;
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the ID token is
+     * no longer valid and cannot be used. This value will be overridden if you
+     * have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     */
+    private Integer idTokenValidity;
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     */
+    private TokenValidityUnitsType tokenValidityUnits;
 
     /**
      * <p>
@@ -285,9 +317,10 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      */
@@ -318,51 +351,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -576,7 +564,7 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @return <p>
      *         The time limit, in days, after which the refresh token is no
@@ -594,7 +582,7 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @param refreshTokenValidity <p>
      *            The time limit, in days, after which the refresh token is no
@@ -615,7 +603,7 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @param refreshTokenValidity <p>
      *            The time limit, in days, after which the refresh token is no
@@ -626,6 +614,198 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      */
     public CreateUserPoolClientRequest withRefreshTokenValidity(Integer refreshTokenValidity) {
         this.refreshTokenValidity = refreshTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the access token
+     * is no longer valid and cannot be used. This value will be overridden if
+     * you have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @return <p>
+     *         The time limit, between 5 minutes and 1 day, after which the
+     *         access token is no longer valid and cannot be used. This value
+     *         will be overridden if you have entered a value in
+     *         TokenValidityUnits.
+     *         </p>
+     */
+    public Integer getAccessTokenValidity() {
+        return accessTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the access token
+     * is no longer valid and cannot be used. This value will be overridden if
+     * you have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param accessTokenValidity <p>
+     *            The time limit, between 5 minutes and 1 day, after which the
+     *            access token is no longer valid and cannot be used. This value
+     *            will be overridden if you have entered a value in
+     *            TokenValidityUnits.
+     *            </p>
+     */
+    public void setAccessTokenValidity(Integer accessTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the access token
+     * is no longer valid and cannot be used. This value will be overridden if
+     * you have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param accessTokenValidity <p>
+     *            The time limit, between 5 minutes and 1 day, after which the
+     *            access token is no longer valid and cannot be used. This value
+     *            will be overridden if you have entered a value in
+     *            TokenValidityUnits.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public CreateUserPoolClientRequest withAccessTokenValidity(Integer accessTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the ID token is
+     * no longer valid and cannot be used. This value will be overridden if you
+     * have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @return <p>
+     *         The time limit, between 5 minutes and 1 day, after which the ID
+     *         token is no longer valid and cannot be used. This value will be
+     *         overridden if you have entered a value in TokenValidityUnits.
+     *         </p>
+     */
+    public Integer getIdTokenValidity() {
+        return idTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the ID token is
+     * no longer valid and cannot be used. This value will be overridden if you
+     * have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param idTokenValidity <p>
+     *            The time limit, between 5 minutes and 1 day, after which the
+     *            ID token is no longer valid and cannot be used. This value
+     *            will be overridden if you have entered a value in
+     *            TokenValidityUnits.
+     *            </p>
+     */
+    public void setIdTokenValidity(Integer idTokenValidity) {
+        this.idTokenValidity = idTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, between 5 minutes and 1 day, after which the ID token is
+     * no longer valid and cannot be used. This value will be overridden if you
+     * have entered a value in TokenValidityUnits.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param idTokenValidity <p>
+     *            The time limit, between 5 minutes and 1 day, after which the
+     *            ID token is no longer valid and cannot be used. This value
+     *            will be overridden if you have entered a value in
+     *            TokenValidityUnits.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public CreateUserPoolClientRequest withIdTokenValidity(Integer idTokenValidity) {
+        this.idTokenValidity = idTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     *
+     * @return <p>
+     *         The units in which the validity times are represented in. Default
+     *         for RefreshToken is days, and default for ID and access tokens
+     *         are hours.
+     *         </p>
+     */
+    public TokenValidityUnitsType getTokenValidityUnits() {
+        return tokenValidityUnits;
+    }
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     *
+     * @param tokenValidityUnits <p>
+     *            The units in which the validity times are represented in.
+     *            Default for RefreshToken is days, and default for ID and
+     *            access tokens are hours.
+     *            </p>
+     */
+    public void setTokenValidityUnits(TokenValidityUnitsType tokenValidityUnits) {
+        this.tokenValidityUnits = tokenValidityUnits;
+    }
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     *
+     * @param tokenValidityUnits <p>
+     *            The units in which the validity times are represented in.
+     *            Default for RefreshToken is days, and default for ID and
+     *            access tokens are hours.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public CreateUserPoolClientRequest withTokenValidityUnits(
+            TokenValidityUnitsType tokenValidityUnits) {
+        this.tokenValidityUnits = tokenValidityUnits;
         return this;
     }
 
@@ -2439,9 +2619,10 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      *
@@ -2451,9 +2632,11 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *         </p>
      *         <note>
      *         <p>
-     *         Cognito User Pools only supports sending events to Amazon
-     *         Pinpoint projects in the US East (N. Virginia) us-east-1 Region,
-     *         regardless of the region in which the user pool resides.
+     *         In regions where Pinpoint is not available, Cognito User Pools
+     *         only supports sending events to Amazon Pinpoint projects in
+     *         us-east-1. In regions where Pinpoint is available, Cognito User
+     *         Pools will support sending events to Amazon Pinpoint projects
+     *         within that same region.
      *         </p>
      *         </note>
      */
@@ -2468,9 +2651,10 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      *
@@ -2480,10 +2664,11 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            </p>
      *            <note>
      *            <p>
-     *            Cognito User Pools only supports sending events to Amazon
-     *            Pinpoint projects in the US East (N. Virginia) us-east-1
-     *            Region, regardless of the region in which the user pool
-     *            resides.
+     *            In regions where Pinpoint is not available, Cognito User Pools
+     *            only supports sending events to Amazon Pinpoint projects in
+     *            us-east-1. In regions where Pinpoint is available, Cognito
+     *            User Pools will support sending events to Amazon Pinpoint
+     *            projects within that same region.
      *            </p>
      *            </note>
      */
@@ -2498,9 +2683,10 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      * <p>
@@ -2513,10 +2699,11 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            </p>
      *            <note>
      *            <p>
-     *            Cognito User Pools only supports sending events to Amazon
-     *            Pinpoint projects in the US East (N. Virginia) us-east-1
-     *            Region, regardless of the region in which the user pool
-     *            resides.
+     *            In regions where Pinpoint is not available, Cognito User Pools
+     *            only supports sending events to Amazon Pinpoint projects in
+     *            us-east-1. In regions where Pinpoint is available, Cognito
+     *            User Pools will support sending events to Amazon Pinpoint
+     *            projects within that same region.
      *            </p>
      *            </note>
      * @return A reference to this updated object so that method calls can be
@@ -2553,51 +2740,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -2639,51 +2781,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *         <p>
      *         <code>LEGACY</code> - This represents the old behavior of Cognito
      *         where user existence related errors are not prevented.
-     *         </p>
-     *         </li>
-     *         </ul>
-     *         <p>
-     *         This setting affects the behavior of following APIs:
-     *         </p>
-     *         <ul>
-     *         <li>
-     *         <p>
-     *         <a>AdminInitiateAuth</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>AdminRespondToAuthChallenge</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>InitiateAuth</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>RespondToAuthChallenge</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ForgotPassword</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ConfirmForgotPassword</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ConfirmSignUp</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ResendConfirmationCode</a>
      *         </p>
      *         </li>
      *         </ul>
@@ -2729,51 +2826,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -2813,51 +2865,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -2903,51 +2910,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -2990,51 +2952,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -3084,51 +3001,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -3168,51 +3040,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -3256,51 +3083,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -3349,51 +3131,6 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            </p>
      *            </li>
      *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
-     *            </p>
-     *            </li>
-     *            </ul>
      *            <note>
      *            <p>
      *            After February 15th 2020, the value of
@@ -3431,6 +3168,12 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
             sb.append("GenerateSecret: " + getGenerateSecret() + ",");
         if (getRefreshTokenValidity() != null)
             sb.append("RefreshTokenValidity: " + getRefreshTokenValidity() + ",");
+        if (getAccessTokenValidity() != null)
+            sb.append("AccessTokenValidity: " + getAccessTokenValidity() + ",");
+        if (getIdTokenValidity() != null)
+            sb.append("IdTokenValidity: " + getIdTokenValidity() + ",");
+        if (getTokenValidityUnits() != null)
+            sb.append("TokenValidityUnits: " + getTokenValidityUnits() + ",");
         if (getReadAttributes() != null)
             sb.append("ReadAttributes: " + getReadAttributes() + ",");
         if (getWriteAttributes() != null)
@@ -3471,6 +3214,12 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
                 + ((getGenerateSecret() == null) ? 0 : getGenerateSecret().hashCode());
         hashCode = prime * hashCode
                 + ((getRefreshTokenValidity() == null) ? 0 : getRefreshTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getAccessTokenValidity() == null) ? 0 : getAccessTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getIdTokenValidity() == null) ? 0 : getIdTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getTokenValidityUnits() == null) ? 0 : getTokenValidityUnits().hashCode());
         hashCode = prime * hashCode
                 + ((getReadAttributes() == null) ? 0 : getReadAttributes().hashCode());
         hashCode = prime * hashCode
@@ -3535,6 +3284,21 @@ public class CreateUserPoolClientRequest extends AmazonWebServiceRequest impleme
             return false;
         if (other.getRefreshTokenValidity() != null
                 && other.getRefreshTokenValidity().equals(this.getRefreshTokenValidity()) == false)
+            return false;
+        if (other.getAccessTokenValidity() == null ^ this.getAccessTokenValidity() == null)
+            return false;
+        if (other.getAccessTokenValidity() != null
+                && other.getAccessTokenValidity().equals(this.getAccessTokenValidity()) == false)
+            return false;
+        if (other.getIdTokenValidity() == null ^ this.getIdTokenValidity() == null)
+            return false;
+        if (other.getIdTokenValidity() != null
+                && other.getIdTokenValidity().equals(this.getIdTokenValidity()) == false)
+            return false;
+        if (other.getTokenValidityUnits() == null ^ this.getTokenValidityUnits() == null)
+            return false;
+        if (other.getTokenValidityUnits() != null
+                && other.getTokenValidityUnits().equals(this.getTokenValidityUnits()) == false)
             return false;
         if (other.getReadAttributes() == null ^ this.getReadAttributes() == null)
             return false;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/CreateUserPoolRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/CreateUserPoolRequest.java
@@ -218,7 +218,9 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      */
     private UsernameConfigurationType usernameConfiguration;
@@ -233,15 +235,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * absence of this setting, Cognito uses the legacy behavior to determine
      * the recovery method where SMS is preferred over email.
      * </p>
-     * <note>
-     * <p>
-     * Starting February 1, 2020, the value of
-     * <code>AccountRecoverySetting</code> will default to
-     * <code>verified_email</code> first and <code>verified_phone_number</code>
-     * as the second option for newly created user pools if no value is
-     * provided.
-     * </p>
-     * </note>
      */
     private AccountRecoverySettingType accountRecoverySetting;
 
@@ -1573,7 +1566,9 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      *
      * @return <p>
@@ -1581,7 +1576,9 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      *         the selected sign-in option. For example, when this is set to
      *         <code>False</code>, users will be able to sign in using either
      *         "username" or "Username". This configuration is immutable once it
-     *         has been set. For more information, see .
+     *         has been set. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     *         >UsernameConfigurationType</a>.
      *         </p>
      */
     public UsernameConfigurationType getUsernameConfiguration() {
@@ -1594,7 +1591,9 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      *
      * @param usernameConfiguration <p>
@@ -1602,7 +1601,10 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      *            for the selected sign-in option. For example, when this is set
      *            to <code>False</code>, users will be able to sign in using
      *            either "username" or "Username". This configuration is
-     *            immutable once it has been set. For more information, see .
+     *            immutable once it has been set. For more information, see <a
+     *            href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     *            >UsernameConfigurationType</a>.
      *            </p>
      */
     public void setUsernameConfiguration(UsernameConfigurationType usernameConfiguration) {
@@ -1615,7 +1617,9 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -1626,7 +1630,10 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      *            for the selected sign-in option. For example, when this is set
      *            to <code>False</code>, users will be able to sign in using
      *            either "username" or "Username". This configuration is
-     *            immutable once it has been set. For more information, see .
+     *            immutable once it has been set. For more information, see <a
+     *            href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     *            >UsernameConfigurationType</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -1647,15 +1654,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * absence of this setting, Cognito uses the legacy behavior to determine
      * the recovery method where SMS is preferred over email.
      * </p>
-     * <note>
-     * <p>
-     * Starting February 1, 2020, the value of
-     * <code>AccountRecoverySetting</code> will default to
-     * <code>verified_email</code> first and <code>verified_phone_number</code>
-     * as the second option for newly created user pools if no value is
-     * provided.
-     * </p>
-     * </note>
      *
      * @return <p>
      *         Use this setting to define which verified available method a user
@@ -1667,15 +1665,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      *         this setting, Cognito uses the legacy behavior to determine the
      *         recovery method where SMS is preferred over email.
      *         </p>
-     *         <note>
-     *         <p>
-     *         Starting February 1, 2020, the value of
-     *         <code>AccountRecoverySetting</code> will default to
-     *         <code>verified_email</code> first and
-     *         <code>verified_phone_number</code> as the second option for newly
-     *         created user pools if no value is provided.
-     *         </p>
-     *         </note>
      */
     public AccountRecoverySettingType getAccountRecoverySetting() {
         return accountRecoverySetting;
@@ -1691,15 +1680,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * absence of this setting, Cognito uses the legacy behavior to determine
      * the recovery method where SMS is preferred over email.
      * </p>
-     * <note>
-     * <p>
-     * Starting February 1, 2020, the value of
-     * <code>AccountRecoverySetting</code> will default to
-     * <code>verified_email</code> first and <code>verified_phone_number</code>
-     * as the second option for newly created user pools if no value is
-     * provided.
-     * </p>
-     * </note>
      *
      * @param accountRecoverySetting <p>
      *            Use this setting to define which verified available method a
@@ -1712,15 +1692,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      *            legacy behavior to determine the recovery method where SMS is
      *            preferred over email.
      *            </p>
-     *            <note>
-     *            <p>
-     *            Starting February 1, 2020, the value of
-     *            <code>AccountRecoverySetting</code> will default to
-     *            <code>verified_email</code> first and
-     *            <code>verified_phone_number</code> as the second option for
-     *            newly created user pools if no value is provided.
-     *            </p>
-     *            </note>
      */
     public void setAccountRecoverySetting(AccountRecoverySettingType accountRecoverySetting) {
         this.accountRecoverySetting = accountRecoverySetting;
@@ -1736,15 +1707,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      * absence of this setting, Cognito uses the legacy behavior to determine
      * the recovery method where SMS is preferred over email.
      * </p>
-     * <note>
-     * <p>
-     * Starting February 1, 2020, the value of
-     * <code>AccountRecoverySetting</code> will default to
-     * <code>verified_email</code> first and <code>verified_phone_number</code>
-     * as the second option for newly created user pools if no value is
-     * provided.
-     * </p>
-     * </note>
      * <p>
      * Returns a reference to this object so that method calls can be chained
      * together.
@@ -1760,15 +1722,6 @@ public class CreateUserPoolRequest extends AmazonWebServiceRequest implements Se
      *            legacy behavior to determine the recovery method where SMS is
      *            preferred over email.
      *            </p>
-     *            <note>
-     *            <p>
-     *            Starting February 1, 2020, the value of
-     *            <code>AccountRecoverySetting</code> will default to
-     *            <code>verified_email</code> first and
-     *            <code>verified_phone_number</code> as the second option for
-     *            newly created user pools if no value is provided.
-     *            </p>
-     *            </note>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
      */

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/ForgotPasswordRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/ForgotPasswordRequest.java
@@ -25,11 +25,14 @@ import com.amazonaws.AmazonWebServiceRequest;
  * confirmation code that is required to change the user's password. For the
  * <code>Username</code> parameter, you can use the username or user alias. The
  * method used to send the confirmation code is sent according to the specified
- * AccountRecoverySetting. For more information, see <a href="">Recovering User
- * Accounts</a> in the <i>Amazon Cognito Developer Guide</i>. If neither a
- * verified phone number nor a verified email exists, an
+ * AccountRecoverySetting. For more information, see <a href=
+ * "https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-recover-a-user-account.html"
+ * >Recovering User Accounts</a> in the <i>Amazon Cognito Developer Guide</i>.
+ * If neither a verified phone number nor a verified email exists, an
  * <code>InvalidParameterException</code> is thrown. To use the confirmation
- * code for resetting the password, call .
+ * code for resetting the password, call <a href=
+ * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmForgotPassword.html"
+ * >ConfirmForgotPassword</a>.
  * </p>
  */
 public class ForgotPasswordRequest extends AmazonWebServiceRequest implements Serializable {

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/GetUserResult.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/GetUserResult.java
@@ -51,8 +51,8 @@ public class GetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the use the
-     * <a>GetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      */
     private java.util.List<MFAOptionType> mFAOptions;
@@ -243,8 +243,8 @@ public class GetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the use the
-     * <a>GetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      *
      * @return <p>
@@ -252,8 +252,7 @@ public class GetUserResult implements Serializable {
      *         provides information only about SMS MFA configurations. It
      *         doesn't provide information about TOTP software token MFA
      *         configurations. To look up information about either type of MFA
-     *         configuration, use the use the
-     *         <a>GetUserResponse$UserMFASettingList</a> response instead.
+     *         configuration, use UserMFASettingList instead.
      *         </p>
      */
     public java.util.List<MFAOptionType> getMFAOptions() {
@@ -265,8 +264,8 @@ public class GetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the use the
-     * <a>GetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      *
      * @param mFAOptions <p>
@@ -274,8 +273,7 @@ public class GetUserResult implements Serializable {
      *            provides information only about SMS MFA configurations. It
      *            doesn't provide information about TOTP software token MFA
      *            configurations. To look up information about either type of
-     *            MFA configuration, use the use the
-     *            <a>GetUserResponse$UserMFASettingList</a> response instead.
+     *            MFA configuration, use UserMFASettingList instead.
      *            </p>
      */
     public void setMFAOptions(java.util.Collection<MFAOptionType> mFAOptions) {
@@ -292,8 +290,8 @@ public class GetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the use the
-     * <a>GetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -304,8 +302,7 @@ public class GetUserResult implements Serializable {
      *            provides information only about SMS MFA configurations. It
      *            doesn't provide information about TOTP software token MFA
      *            configurations. To look up information about either type of
-     *            MFA configuration, use the use the
-     *            <a>GetUserResponse$UserMFASettingList</a> response instead.
+     *            MFA configuration, use UserMFASettingList instead.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -325,8 +322,8 @@ public class GetUserResult implements Serializable {
      * <i>This response parameter is no longer supported.</i> It provides
      * information only about SMS MFA configurations. It doesn't provide
      * information about TOTP software token MFA configurations. To look up
-     * information about either type of MFA configuration, use the use the
-     * <a>GetUserResponse$UserMFASettingList</a> response instead.
+     * information about either type of MFA configuration, use
+     * UserMFASettingList instead.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -337,8 +334,7 @@ public class GetUserResult implements Serializable {
      *            provides information only about SMS MFA configurations. It
      *            doesn't provide information about TOTP software token MFA
      *            configurations. To look up information about either type of
-     *            MFA configuration, use the use the
-     *            <a>GetUserResponse$UserMFASettingList</a> response instead.
+     *            MFA configuration, use UserMFASettingList instead.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/IdentityProviderType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/IdentityProviderType.java
@@ -64,7 +64,7 @@ public class IdentityProviderType implements Serializable {
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -80,6 +80,33 @@ public class IdentityProviderType implements Serializable {
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -451,7 +478,7 @@ public class IdentityProviderType implements Serializable {
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -467,6 +494,33 @@ public class IdentityProviderType implements Serializable {
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -590,7 +644,7 @@ public class IdentityProviderType implements Serializable {
      *         <ul>
      *         <li>
      *         <p>
-     *         For Google, Facebook and Login with Amazon:
+     *         For Google and Login with Amazon:
      *         </p>
      *         <ul>
      *         <li>
@@ -606,6 +660,33 @@ public class IdentityProviderType implements Serializable {
      *         <li>
      *         <p>
      *         authorize_scopes
+     *         </p>
+     *         </li>
+     *         </ul>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         For Facebook:
+     *         </p>
+     *         <ul>
+     *         <li>
+     *         <p>
+     *         client_id
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         client_secret
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         authorize_scopes
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         api_version
      *         </p>
      *         </li>
      *         </ul>
@@ -734,7 +815,7 @@ public class IdentityProviderType implements Serializable {
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -750,6 +831,33 @@ public class IdentityProviderType implements Serializable {
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -873,7 +981,7 @@ public class IdentityProviderType implements Serializable {
      *            <ul>
      *            <li>
      *            <p>
-     *            For Google, Facebook and Login with Amazon:
+     *            For Google and Login with Amazon:
      *            </p>
      *            <ul>
      *            <li>
@@ -889,6 +997,33 @@ public class IdentityProviderType implements Serializable {
      *            <li>
      *            <p>
      *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            </ul>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            For Facebook:
+     *            </p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            client_id
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            client_secret
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            api_version
      *            </p>
      *            </li>
      *            </ul>
@@ -1017,7 +1152,7 @@ public class IdentityProviderType implements Serializable {
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -1033,6 +1168,33 @@ public class IdentityProviderType implements Serializable {
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>
@@ -1159,7 +1321,7 @@ public class IdentityProviderType implements Serializable {
      *            <ul>
      *            <li>
      *            <p>
-     *            For Google, Facebook and Login with Amazon:
+     *            For Google and Login with Amazon:
      *            </p>
      *            <ul>
      *            <li>
@@ -1175,6 +1337,33 @@ public class IdentityProviderType implements Serializable {
      *            <li>
      *            <p>
      *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            </ul>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            For Facebook:
+     *            </p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            client_id
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            client_secret
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            authorize_scopes
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            api_version
      *            </p>
      *            </li>
      *            </ul>
@@ -1306,7 +1495,7 @@ public class IdentityProviderType implements Serializable {
      * <ul>
      * <li>
      * <p>
-     * For Google, Facebook and Login with Amazon:
+     * For Google and Login with Amazon:
      * </p>
      * <ul>
      * <li>
@@ -1322,6 +1511,33 @@ public class IdentityProviderType implements Serializable {
      * <li>
      * <p>
      * authorize_scopes
+     * </p>
+     * </li>
+     * </ul>
+     * </li>
+     * <li>
+     * <p>
+     * For Facebook:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * client_id
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * client_secret
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * authorize_scopes
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * api_version
      * </p>
      * </li>
      * </ul>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/InitiateAuthRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/InitiateAuthRequest.java
@@ -112,7 +112,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -120,14 +120,16 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1045,7 +1047,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1053,14 +1055,16 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1076,7 +1080,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      *         For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      *         <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required
      *         if the app client is configured with a client secret),
-     *         <code>DEVICE_KEY</code>
+     *         <code>DEVICE_KEY</code>.
      *         </p>
      *         </li>
      *         <li>
@@ -1084,14 +1088,17 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      *         For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      *         <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code>
      *         (required if the app client is configured with a client secret),
-     *         <code>DEVICE_KEY</code>
+     *         <code>DEVICE_KEY</code>.
      *         </p>
      *         </li>
      *         <li>
      *         <p>
      *         For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      *         <code>SECRET_HASH</code> (if app client is configured with client
-     *         secret), <code>DEVICE_KEY</code>
+     *         secret), <code>DEVICE_KEY</code>. To start the authentication
+     *         flow with password verification, include
+     *         <code>ChallengeName: SRP_A</code> and
+     *         <code>SRP_A: (The SRP_A Value)</code>.
      *         </p>
      *         </li>
      *         </ul>
@@ -1111,7 +1118,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1119,14 +1126,16 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1142,7 +1151,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      *            For <code>USER_SRP_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SRP_A</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
@@ -1150,14 +1159,17 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      *            For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      *            <code>REFRESH_TOKEN</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
      *            <p>
      *            For <code>CUSTOM_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SECRET_HASH</code> (if app client is
-     *            configured with client secret), <code>DEVICE_KEY</code>
+     *            configured with client secret), <code>DEVICE_KEY</code>. To
+     *            start the authentication flow with password verification,
+     *            include <code>ChallengeName: SRP_A</code> and
+     *            <code>SRP_A: (The SRP_A Value)</code>.
      *            </p>
      *            </li>
      *            </ul>
@@ -1177,7 +1189,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1185,14 +1197,16 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>
@@ -1211,7 +1225,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      *            For <code>USER_SRP_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SRP_A</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
@@ -1219,14 +1233,17 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      *            For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      *            <code>REFRESH_TOKEN</code> (required),
      *            <code>SECRET_HASH</code> (required if the app client is
-     *            configured with a client secret), <code>DEVICE_KEY</code>
+     *            configured with a client secret), <code>DEVICE_KEY</code>.
      *            </p>
      *            </li>
      *            <li>
      *            <p>
      *            For <code>CUSTOM_AUTH</code>: <code>USERNAME</code>
      *            (required), <code>SECRET_HASH</code> (if app client is
-     *            configured with client secret), <code>DEVICE_KEY</code>
+     *            configured with client secret), <code>DEVICE_KEY</code>. To
+     *            start the authentication flow with password verification,
+     *            include <code>ChallengeName: SRP_A</code> and
+     *            <code>SRP_A: (The SRP_A Value)</code>.
      *            </p>
      *            </li>
      *            </ul>
@@ -1249,7 +1266,7 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * <p>
      * For <code>USER_SRP_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SRP_A</code> (required), <code>SECRET_HASH</code> (required if the
-     * app client is configured with a client secret), <code>DEVICE_KEY</code>
+     * app client is configured with a client secret), <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
@@ -1257,14 +1274,16 @@ public class InitiateAuthRequest extends AmazonWebServiceRequest implements Seri
      * For <code>REFRESH_TOKEN_AUTH/REFRESH_TOKEN</code>:
      * <code>REFRESH_TOKEN</code> (required), <code>SECRET_HASH</code> (required
      * if the app client is configured with a client secret),
-     * <code>DEVICE_KEY</code>
+     * <code>DEVICE_KEY</code>.
      * </p>
      * </li>
      * <li>
      * <p>
      * For <code>CUSTOM_AUTH</code>: <code>USERNAME</code> (required),
      * <code>SECRET_HASH</code> (if app client is configured with client
-     * secret), <code>DEVICE_KEY</code>
+     * secret), <code>DEVICE_KEY</code>. To start the authentication flow with
+     * password verification, include <code>ChallengeName: SRP_A</code> and
+     * <code>SRP_A: (The SRP_A Value)</code>.
      * </p>
      * </li>
      * </ul>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/InitiateAuthResult.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/InitiateAuthResult.java
@@ -89,10 +89,9 @@ public class InitiateAuthResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -755,10 +754,9 @@ public class InitiateAuthResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -766,11 +764,10 @@ public class InitiateAuthResult implements Serializable {
      *
      * @return <p>
      *         The session which should be passed both ways in
-     *         challenge-response calls to the service. If the or API call
-     *         determines that the caller needs to go through another challenge,
-     *         they return a session with other challenge parameters. This
-     *         session should be passed as it is to the next
-     *         <code>RespondToAuthChallenge</code> API call.
+     *         challenge-response calls to the service. If the caller needs to
+     *         go through another challenge, they return a session with other
+     *         challenge parameters. This session should be passed as it is to
+     *         the next <code>RespondToAuthChallenge</code> API call.
      *         </p>
      */
     public String getSession() {
@@ -780,10 +777,9 @@ public class InitiateAuthResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -791,11 +787,11 @@ public class InitiateAuthResult implements Serializable {
      *
      * @param session <p>
      *            The session which should be passed both ways in
-     *            challenge-response calls to the service. If the or API call
-     *            determines that the caller needs to go through another
-     *            challenge, they return a session with other challenge
-     *            parameters. This session should be passed as it is to the next
-     *            <code>RespondToAuthChallenge</code> API call.
+     *            challenge-response calls to the service. If the caller needs
+     *            to go through another challenge, they return a session with
+     *            other challenge parameters. This session should be passed as
+     *            it is to the next <code>RespondToAuthChallenge</code> API
+     *            call.
      *            </p>
      */
     public void setSession(String session) {
@@ -805,10 +801,9 @@ public class InitiateAuthResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -819,11 +814,11 @@ public class InitiateAuthResult implements Serializable {
      *
      * @param session <p>
      *            The session which should be passed both ways in
-     *            challenge-response calls to the service. If the or API call
-     *            determines that the caller needs to go through another
-     *            challenge, they return a session with other challenge
-     *            parameters. This session should be passed as it is to the next
-     *            <code>RespondToAuthChallenge</code> API call.
+     *            challenge-response calls to the service. If the caller needs
+     *            to go through another challenge, they return a session with
+     *            other challenge parameters. This session should be passed as
+     *            it is to the next <code>RespondToAuthChallenge</code> API
+     *            call.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/MFAOptionType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/MFAOptionType.java
@@ -22,15 +22,6 @@ import java.io.Serializable;
  * <i>This data type is no longer supported.</i> You can use it only for SMS MFA
  * configurations. You can't use it for TOTP software token MFA configurations.
  * </p>
- * <p>
- * To set either type of MFA configuration, use the
- * <a>AdminSetUserMFAPreference</a> or <a>SetUserMFAPreference</a> actions.
- * </p>
- * <p>
- * To look up information about either type of MFA configuration, use the
- * <a>AdminGetUserResponse$UserMFASettingList</a> or
- * <a>GetUserResponse$UserMFASettingList</a> responses.
- * </p>
  */
 public class MFAOptionType implements Serializable {
     /**

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/RespondToAuthChallengeRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/RespondToAuthChallengeRequest.java
@@ -38,7 +38,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -250,7 +252,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -262,7 +266,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @return <p>
-     *         The challenge name. For more information, see .
+     *         The challenge name. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *         >InitiateAuth</a>.
      *         </p>
      *         <p>
      *         <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -275,7 +281,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -287,7 +295,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      *            <p>
      *            <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -300,7 +310,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -315,7 +327,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      *            <p>
      *            <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -331,7 +345,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -343,7 +359,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      *            <p>
      *            <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -356,7 +374,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.
@@ -371,7 +391,9 @@ public class RespondToAuthChallengeRequest extends AmazonWebServiceRequest imple
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      *            <p>
      *            <code>ADMIN_NO_SRP_AUTH</code> is not a valid value.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/RespondToAuthChallengeResult.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/RespondToAuthChallengeResult.java
@@ -25,7 +25,9 @@ import java.io.Serializable;
 public class RespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -38,10 +40,9 @@ public class RespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -51,7 +52,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      */
     private java.util.Map<String, String> challengeParameters;
@@ -66,7 +69,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -75,7 +80,9 @@ public class RespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @return <p>
-     *         The challenge name. For more information, see .
+     *         The challenge name. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *         >InitiateAuth</a>.
      *         </p>
      * @see ChallengeNameType
      */
@@ -85,7 +92,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -94,7 +103,9 @@ public class RespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      * @see ChallengeNameType
      */
@@ -104,7 +115,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -116,7 +129,9 @@ public class RespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -129,7 +144,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -138,7 +155,9 @@ public class RespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      * @see ChallengeNameType
      */
@@ -148,7 +167,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge name. For more information, see .
+     * The challenge name. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -160,7 +181,9 @@ public class RespondToAuthChallengeResult implements Serializable {
      * DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
      *
      * @param challengeName <p>
-     *            The challenge name. For more information, see .
+     *            The challenge name. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -174,10 +197,9 @@ public class RespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -185,11 +207,10 @@ public class RespondToAuthChallengeResult implements Serializable {
      *
      * @return <p>
      *         The session which should be passed both ways in
-     *         challenge-response calls to the service. If the or API call
-     *         determines that the caller needs to go through another challenge,
-     *         they return a session with other challenge parameters. This
-     *         session should be passed as it is to the next
-     *         <code>RespondToAuthChallenge</code> API call.
+     *         challenge-response calls to the service. If the caller needs to
+     *         go through another challenge, they return a session with other
+     *         challenge parameters. This session should be passed as it is to
+     *         the next <code>RespondToAuthChallenge</code> API call.
      *         </p>
      */
     public String getSession() {
@@ -199,10 +220,9 @@ public class RespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -210,11 +230,11 @@ public class RespondToAuthChallengeResult implements Serializable {
      *
      * @param session <p>
      *            The session which should be passed both ways in
-     *            challenge-response calls to the service. If the or API call
-     *            determines that the caller needs to go through another
-     *            challenge, they return a session with other challenge
-     *            parameters. This session should be passed as it is to the next
-     *            <code>RespondToAuthChallenge</code> API call.
+     *            challenge-response calls to the service. If the caller needs
+     *            to go through another challenge, they return a session with
+     *            other challenge parameters. This session should be passed as
+     *            it is to the next <code>RespondToAuthChallenge</code> API
+     *            call.
      *            </p>
      */
     public void setSession(String session) {
@@ -224,10 +244,9 @@ public class RespondToAuthChallengeResult implements Serializable {
     /**
      * <p>
      * The session which should be passed both ways in challenge-response calls
-     * to the service. If the or API call determines that the caller needs to go
-     * through another challenge, they return a session with other challenge
-     * parameters. This session should be passed as it is to the next
-     * <code>RespondToAuthChallenge</code> API call.
+     * to the service. If the caller needs to go through another challenge, they
+     * return a session with other challenge parameters. This session should be
+     * passed as it is to the next <code>RespondToAuthChallenge</code> API call.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -238,11 +257,11 @@ public class RespondToAuthChallengeResult implements Serializable {
      *
      * @param session <p>
      *            The session which should be passed both ways in
-     *            challenge-response calls to the service. If the or API call
-     *            determines that the caller needs to go through another
-     *            challenge, they return a session with other challenge
-     *            parameters. This session should be passed as it is to the next
-     *            <code>RespondToAuthChallenge</code> API call.
+     *            challenge-response calls to the service. If the caller needs
+     *            to go through another challenge, they return a session with
+     *            other challenge parameters. This session should be passed as
+     *            it is to the next <code>RespondToAuthChallenge</code> API
+     *            call.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -254,11 +273,15 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      *
      * @return <p>
-     *         The challenge parameters. For more information, see .
+     *         The challenge parameters. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *         >InitiateAuth</a>.
      *         </p>
      */
     public java.util.Map<String, String> getChallengeParameters() {
@@ -267,11 +290,15 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      *
      * @param challengeParameters <p>
-     *            The challenge parameters. For more information, see .
+     *            The challenge parameters. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      */
     public void setChallengeParameters(java.util.Map<String, String> challengeParameters) {
@@ -280,14 +307,18 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
      * together.
      *
      * @param challengeParameters <p>
-     *            The challenge parameters. For more information, see .
+     *            The challenge parameters. For more information, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     *            >InitiateAuth</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -300,7 +331,9 @@ public class RespondToAuthChallengeResult implements Serializable {
 
     /**
      * <p>
-     * The challenge parameters. For more information, see .
+     * The challenge parameters. For more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html"
+     * >InitiateAuth</a>.
      * </p>
      * <p>
      * The method adds a new key-value pair into ChallengeParameters parameter,

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/SchemaAttributeType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/SchemaAttributeType.java
@@ -58,8 +58,9 @@ public class SchemaAttributeType implements Serializable {
      * Specifies whether the attribute type is developer only. This attribute
      * can only be modified by an administrator. Users will not be able to
      * modify this attribute using their access token. For example,
-     * <code>DeveloperOnlyAttribute</code> can be modified using the API but
-     * cannot be updated using the API.
+     * <code>DeveloperOnlyAttribute</code> can be modified using
+     * AdminUpdateUserAttributes but cannot be updated using
+     * UpdateUserAttributes.
      * </p>
      */
     private Boolean developerOnlyAttribute;
@@ -272,8 +273,9 @@ public class SchemaAttributeType implements Serializable {
      * Specifies whether the attribute type is developer only. This attribute
      * can only be modified by an administrator. Users will not be able to
      * modify this attribute using their access token. For example,
-     * <code>DeveloperOnlyAttribute</code> can be modified using the API but
-     * cannot be updated using the API.
+     * <code>DeveloperOnlyAttribute</code> can be modified using
+     * AdminUpdateUserAttributes but cannot be updated using
+     * UpdateUserAttributes.
      * </p>
      *
      * @return <note>
@@ -290,7 +292,8 @@ public class SchemaAttributeType implements Serializable {
      *         attribute can only be modified by an administrator. Users will
      *         not be able to modify this attribute using their access token.
      *         For example, <code>DeveloperOnlyAttribute</code> can be modified
-     *         using the API but cannot be updated using the API.
+     *         using AdminUpdateUserAttributes but cannot be updated using
+     *         UpdateUserAttributes.
      *         </p>
      */
     public Boolean isDeveloperOnlyAttribute() {
@@ -311,8 +314,9 @@ public class SchemaAttributeType implements Serializable {
      * Specifies whether the attribute type is developer only. This attribute
      * can only be modified by an administrator. Users will not be able to
      * modify this attribute using their access token. For example,
-     * <code>DeveloperOnlyAttribute</code> can be modified using the API but
-     * cannot be updated using the API.
+     * <code>DeveloperOnlyAttribute</code> can be modified using
+     * AdminUpdateUserAttributes but cannot be updated using
+     * UpdateUserAttributes.
      * </p>
      *
      * @return <note>
@@ -329,7 +333,8 @@ public class SchemaAttributeType implements Serializable {
      *         attribute can only be modified by an administrator. Users will
      *         not be able to modify this attribute using their access token.
      *         For example, <code>DeveloperOnlyAttribute</code> can be modified
-     *         using the API but cannot be updated using the API.
+     *         using AdminUpdateUserAttributes but cannot be updated using
+     *         UpdateUserAttributes.
      *         </p>
      */
     public Boolean getDeveloperOnlyAttribute() {
@@ -350,8 +355,9 @@ public class SchemaAttributeType implements Serializable {
      * Specifies whether the attribute type is developer only. This attribute
      * can only be modified by an administrator. Users will not be able to
      * modify this attribute using their access token. For example,
-     * <code>DeveloperOnlyAttribute</code> can be modified using the API but
-     * cannot be updated using the API.
+     * <code>DeveloperOnlyAttribute</code> can be modified using
+     * AdminUpdateUserAttributes but cannot be updated using
+     * UpdateUserAttributes.
      * </p>
      *
      * @param developerOnlyAttribute <note>
@@ -368,7 +374,8 @@ public class SchemaAttributeType implements Serializable {
      *            attribute can only be modified by an administrator. Users will
      *            not be able to modify this attribute using their access token.
      *            For example, <code>DeveloperOnlyAttribute</code> can be
-     *            modified using the API but cannot be updated using the API.
+     *            modified using AdminUpdateUserAttributes but cannot be updated
+     *            using UpdateUserAttributes.
      *            </p>
      */
     public void setDeveloperOnlyAttribute(Boolean developerOnlyAttribute) {
@@ -389,8 +396,9 @@ public class SchemaAttributeType implements Serializable {
      * Specifies whether the attribute type is developer only. This attribute
      * can only be modified by an administrator. Users will not be able to
      * modify this attribute using their access token. For example,
-     * <code>DeveloperOnlyAttribute</code> can be modified using the API but
-     * cannot be updated using the API.
+     * <code>DeveloperOnlyAttribute</code> can be modified using
+     * AdminUpdateUserAttributes but cannot be updated using
+     * UpdateUserAttributes.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -410,7 +418,8 @@ public class SchemaAttributeType implements Serializable {
      *            attribute can only be modified by an administrator. Users will
      *            not be able to modify this attribute using their access token.
      *            For example, <code>DeveloperOnlyAttribute</code> can be
-     *            modified using the API but cannot be updated using the API.
+     *            modified using AdminUpdateUserAttributes but cannot be updated
+     *            using UpdateUserAttributes.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/SetRiskConfigurationRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/SetRiskConfigurationRequest.java
@@ -29,9 +29,6 @@ import com.amazonaws.AmazonWebServiceRequest;
  * To enable Amazon Cognito advanced security features, update the user pool to
  * include the <code>UserPoolAddOns</code> key<code>AdvancedSecurityMode</code>.
  * </p>
- * <p>
- * See .
- * </p>
  */
 public class SetRiskConfigurationRequest extends AmazonWebServiceRequest implements Serializable {
     /**

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/SetUserSettingsRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/SetUserSettingsRequest.java
@@ -23,7 +23,9 @@ import com.amazonaws.AmazonWebServiceRequest;
  * <p>
  * <i>This action is no longer supported.</i> You can use it to configure only
  * SMS MFA. You can't use it to configure TOTP software token MFA. To configure
- * either type of MFA, use the <a>SetUserMFAPreference</a> action instead.
+ * either type of MFA, use <a href=
+ * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserMFAPreference.html"
+ * >SetUserMFAPreference</a> instead.
  * </p>
  */
 public class SetUserSettingsRequest extends AmazonWebServiceRequest implements Serializable {

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/TimeUnitsType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/TimeUnitsType.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.cognitoidentityprovider.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Time Units Type
+ */
+public enum TimeUnitsType {
+
+    Seconds("seconds"),
+    Minutes("minutes"),
+    Hours("hours"),
+    Days("days");
+
+    private String value;
+
+    private TimeUnitsType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    private static final Map<String, TimeUnitsType> enumMap;
+    static {
+        enumMap = new HashMap<String, TimeUnitsType>();
+        enumMap.put("seconds", Seconds);
+        enumMap.put("minutes", Minutes);
+        enumMap.put("hours", Hours);
+        enumMap.put("days", Days);
+    }
+
+    /**
+     * Use this in place of valueOf.
+     *
+     * @param value real value
+     * @return TimeUnitsType corresponding to the value
+     */
+    public static TimeUnitsType fromValue(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("Value cannot be null or empty!");
+        } else if (enumMap.containsKey(value)) {
+            return enumMap.get(value);
+        } else {
+            throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+        }
+    }
+}

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/TokenValidityUnitsType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/TokenValidityUnitsType.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.cognitoidentityprovider.model;
+
+import java.io.Serializable;
+
+/**
+ * <p>
+ * The data type for TokenValidityUnits that specifics the time measurements for
+ * token validity.
+ * </p>
+ */
+public class TokenValidityUnitsType implements Serializable {
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * AccessTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     */
+    private String accessToken;
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * IdTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     */
+    private String idToken;
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * RefreshTokenValidity, defaults to days.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     */
+    private String refreshToken;
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * AccessTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @return <p>
+     *         A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *         value in AccessTokenValidity, defaults to hours.
+     *         </p>
+     * @see TimeUnitsType
+     */
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * AccessTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param accessToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in AccessTokenValidity, defaults to hours.
+     *            </p>
+     * @see TimeUnitsType
+     */
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * AccessTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param accessToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in AccessTokenValidity, defaults to hours.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     * @see TimeUnitsType
+     */
+    public TokenValidityUnitsType withAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+        return this;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * AccessTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param accessToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in AccessTokenValidity, defaults to hours.
+     *            </p>
+     * @see TimeUnitsType
+     */
+    public void setAccessToken(TimeUnitsType accessToken) {
+        this.accessToken = accessToken.toString();
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * AccessTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param accessToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in AccessTokenValidity, defaults to hours.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     * @see TimeUnitsType
+     */
+    public TokenValidityUnitsType withAccessToken(TimeUnitsType accessToken) {
+        this.accessToken = accessToken.toString();
+        return this;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * IdTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @return <p>
+     *         A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *         value in IdTokenValidity, defaults to hours.
+     *         </p>
+     * @see TimeUnitsType
+     */
+    public String getIdToken() {
+        return idToken;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * IdTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param idToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in IdTokenValidity, defaults to hours.
+     *            </p>
+     * @see TimeUnitsType
+     */
+    public void setIdToken(String idToken) {
+        this.idToken = idToken;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * IdTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param idToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in IdTokenValidity, defaults to hours.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     * @see TimeUnitsType
+     */
+    public TokenValidityUnitsType withIdToken(String idToken) {
+        this.idToken = idToken;
+        return this;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * IdTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param idToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in IdTokenValidity, defaults to hours.
+     *            </p>
+     * @see TimeUnitsType
+     */
+    public void setIdToken(TimeUnitsType idToken) {
+        this.idToken = idToken.toString();
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * IdTokenValidity, defaults to hours.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param idToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in IdTokenValidity, defaults to hours.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     * @see TimeUnitsType
+     */
+    public TokenValidityUnitsType withIdToken(TimeUnitsType idToken) {
+        this.idToken = idToken.toString();
+        return this;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * RefreshTokenValidity, defaults to days.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @return <p>
+     *         A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *         value in RefreshTokenValidity, defaults to days.
+     *         </p>
+     * @see TimeUnitsType
+     */
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * RefreshTokenValidity, defaults to days.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param refreshToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in RefreshTokenValidity, defaults to days.
+     *            </p>
+     * @see TimeUnitsType
+     */
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * RefreshTokenValidity, defaults to days.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param refreshToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in RefreshTokenValidity, defaults to days.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     * @see TimeUnitsType
+     */
+    public TokenValidityUnitsType withRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+        return this;
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * RefreshTokenValidity, defaults to days.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param refreshToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in RefreshTokenValidity, defaults to days.
+     *            </p>
+     * @see TimeUnitsType
+     */
+    public void setRefreshToken(TimeUnitsType refreshToken) {
+        this.refreshToken = refreshToken.toString();
+    }
+
+    /**
+     * <p>
+     * A time unit in “seconds”, “minutes”, “hours” or “days” for the value in
+     * RefreshTokenValidity, defaults to days.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>seconds, minutes, hours, days
+     *
+     * @param refreshToken <p>
+     *            A time unit in “seconds”, “minutes”, “hours” or “days” for the
+     *            value in RefreshTokenValidity, defaults to days.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     * @see TimeUnitsType
+     */
+    public TokenValidityUnitsType withRefreshToken(TimeUnitsType refreshToken) {
+        this.refreshToken = refreshToken.toString();
+        return this;
+    }
+
+    /**
+     * Returns a string representation of this object; useful for testing and
+     * debugging.
+     *
+     * @return A string representation of this object.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getAccessToken() != null)
+            sb.append("AccessToken: " + getAccessToken() + ",");
+        if (getIdToken() != null)
+            sb.append("IdToken: " + getIdToken() + ",");
+        if (getRefreshToken() != null)
+            sb.append("RefreshToken: " + getRefreshToken());
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode
+                + ((getAccessToken() == null) ? 0 : getAccessToken().hashCode());
+        hashCode = prime * hashCode + ((getIdToken() == null) ? 0 : getIdToken().hashCode());
+        hashCode = prime * hashCode
+                + ((getRefreshToken() == null) ? 0 : getRefreshToken().hashCode());
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof TokenValidityUnitsType == false)
+            return false;
+        TokenValidityUnitsType other = (TokenValidityUnitsType) obj;
+
+        if (other.getAccessToken() == null ^ this.getAccessToken() == null)
+            return false;
+        if (other.getAccessToken() != null
+                && other.getAccessToken().equals(this.getAccessToken()) == false)
+            return false;
+        if (other.getIdToken() == null ^ this.getIdToken() == null)
+            return false;
+        if (other.getIdToken() != null && other.getIdToken().equals(this.getIdToken()) == false)
+            return false;
+        if (other.getRefreshToken() == null ^ this.getRefreshToken() == null)
+            return false;
+        if (other.getRefreshToken() != null
+                && other.getRefreshToken().equals(this.getRefreshToken()) == false)
+            return false;
+        return true;
+    }
+}

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UpdateGroupRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UpdateGroupRequest.java
@@ -84,7 +84,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
     /**
      * <p>
      * The new precedence value for the group. For more information about this
-     * parameter, see .
+     * parameter, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     * >CreateGroup</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -338,7 +340,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
     /**
      * <p>
      * The new precedence value for the group. For more information about this
-     * parameter, see .
+     * parameter, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     * >CreateGroup</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -346,7 +350,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
      *
      * @return <p>
      *         The new precedence value for the group. For more information
-     *         about this parameter, see .
+     *         about this parameter, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     *         >CreateGroup</a>.
      *         </p>
      */
     public Integer getPrecedence() {
@@ -356,7 +362,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
     /**
      * <p>
      * The new precedence value for the group. For more information about this
-     * parameter, see .
+     * parameter, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     * >CreateGroup</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -364,7 +372,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
      *
      * @param precedence <p>
      *            The new precedence value for the group. For more information
-     *            about this parameter, see .
+     *            about this parameter, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     *            >CreateGroup</a>.
      *            </p>
      */
     public void setPrecedence(Integer precedence) {
@@ -374,7 +384,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
     /**
      * <p>
      * The new precedence value for the group. For more information about this
-     * parameter, see .
+     * parameter, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     * >CreateGroup</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -385,7 +397,9 @@ public class UpdateGroupRequest extends AmazonWebServiceRequest implements Seria
      *
      * @param precedence <p>
      *            The new precedence value for the group. For more information
-     *            about this parameter, see .
+     *            about this parameter, see <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html"
+     *            >CreateGroup</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UpdateUserPoolClientRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UpdateUserPoolClientRequest.java
@@ -22,7 +22,9 @@ import com.amazonaws.AmazonWebServiceRequest;
 /**
  * <p>
  * Updates the specified user pool app client with the specified attributes. You
- * can get a list of the current user pool app client settings with .
+ * can get a list of the current user pool app client settings using <a href=
+ * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPoolClient.html"
+ * >DescribeUserPoolClient</a>.
  * </p>
  * <important>
  * <p>
@@ -73,9 +75,39 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      */
     private Integer refreshTokenValidity;
+
+    /**
+     * <p>
+     * The time limit, after which the access token is no longer valid and
+     * cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     */
+    private Integer accessTokenValidity;
+
+    /**
+     * <p>
+     * The time limit, after which the ID token is no longer valid and cannot be
+     * used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     */
+    private Integer idTokenValidity;
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     */
+    private TokenValidityUnitsType tokenValidityUnits;
 
     /**
      * <p>
@@ -282,9 +314,10 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      */
@@ -315,51 +348,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -561,7 +549,7 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @return <p>
      *         The time limit, in days, after which the refresh token is no
@@ -579,7 +567,7 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @param refreshTokenValidity <p>
      *            The time limit, in days, after which the refresh token is no
@@ -600,7 +588,7 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @param refreshTokenValidity <p>
      *            The time limit, in days, after which the refresh token is no
@@ -611,6 +599,181 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      */
     public UpdateUserPoolClientRequest withRefreshTokenValidity(Integer refreshTokenValidity) {
         this.refreshTokenValidity = refreshTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time limit, after which the access token is no longer valid and
+     * cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @return <p>
+     *         The time limit, after which the access token is no longer valid
+     *         and cannot be used.
+     *         </p>
+     */
+    public Integer getAccessTokenValidity() {
+        return accessTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, after which the access token is no longer valid and
+     * cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param accessTokenValidity <p>
+     *            The time limit, after which the access token is no longer
+     *            valid and cannot be used.
+     *            </p>
+     */
+    public void setAccessTokenValidity(Integer accessTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, after which the access token is no longer valid and
+     * cannot be used.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param accessTokenValidity <p>
+     *            The time limit, after which the access token is no longer
+     *            valid and cannot be used.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public UpdateUserPoolClientRequest withAccessTokenValidity(Integer accessTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time limit, after which the ID token is no longer valid and cannot be
+     * used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @return <p>
+     *         The time limit, after which the ID token is no longer valid and
+     *         cannot be used.
+     *         </p>
+     */
+    public Integer getIdTokenValidity() {
+        return idTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, after which the ID token is no longer valid and cannot be
+     * used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param idTokenValidity <p>
+     *            The time limit, after which the ID token is no longer valid
+     *            and cannot be used.
+     *            </p>
+     */
+    public void setIdTokenValidity(Integer idTokenValidity) {
+        this.idTokenValidity = idTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, after which the ID token is no longer valid and cannot be
+     * used.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param idTokenValidity <p>
+     *            The time limit, after which the ID token is no longer valid
+     *            and cannot be used.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public UpdateUserPoolClientRequest withIdTokenValidity(Integer idTokenValidity) {
+        this.idTokenValidity = idTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     *
+     * @return <p>
+     *         The units in which the validity times are represented in. Default
+     *         for RefreshToken is days, and default for ID and access tokens
+     *         are hours.
+     *         </p>
+     */
+    public TokenValidityUnitsType getTokenValidityUnits() {
+        return tokenValidityUnits;
+    }
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     *
+     * @param tokenValidityUnits <p>
+     *            The units in which the validity times are represented in.
+     *            Default for RefreshToken is days, and default for ID and
+     *            access tokens are hours.
+     *            </p>
+     */
+    public void setTokenValidityUnits(TokenValidityUnitsType tokenValidityUnits) {
+        this.tokenValidityUnits = tokenValidityUnits;
+    }
+
+    /**
+     * <p>
+     * The units in which the validity times are represented in. Default for
+     * RefreshToken is days, and default for ID and access tokens are hours.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     *
+     * @param tokenValidityUnits <p>
+     *            The units in which the validity times are represented in.
+     *            Default for RefreshToken is days, and default for ID and
+     *            access tokens are hours.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public UpdateUserPoolClientRequest withTokenValidityUnits(
+            TokenValidityUnitsType tokenValidityUnits) {
+        this.tokenValidityUnits = tokenValidityUnits;
         return this;
     }
 
@@ -2313,9 +2476,10 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      *
@@ -2325,9 +2489,11 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *         </p>
      *         <note>
      *         <p>
-     *         Cognito User Pools only supports sending events to Amazon
-     *         Pinpoint projects in the US East (N. Virginia) us-east-1 Region,
-     *         regardless of the region in which the user pool resides.
+     *         In regions where Pinpoint is not available, Cognito User Pools
+     *         only supports sending events to Amazon Pinpoint projects in
+     *         us-east-1. In regions where Pinpoint is available, Cognito User
+     *         Pools will support sending events to Amazon Pinpoint projects
+     *         within that same region.
      *         </p>
      *         </note>
      */
@@ -2342,9 +2508,10 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      *
@@ -2354,10 +2521,11 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            </p>
      *            <note>
      *            <p>
-     *            Cognito User Pools only supports sending events to Amazon
-     *            Pinpoint projects in the US East (N. Virginia) us-east-1
-     *            Region, regardless of the region in which the user pool
-     *            resides.
+     *            In regions where Pinpoint is not available, Cognito User Pools
+     *            only supports sending events to Amazon Pinpoint projects in
+     *            us-east-1. In regions where Pinpoint is available, Cognito
+     *            User Pools will support sending events to Amazon Pinpoint
+     *            projects within that same region.
      *            </p>
      *            </note>
      */
@@ -2372,9 +2540,10 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * <note>
      * <p>
-     * Cognito User Pools only supports sending events to Amazon Pinpoint
-     * projects in the US East (N. Virginia) us-east-1 Region, regardless of the
-     * region in which the user pool resides.
+     * In regions where Pinpoint is not available, Cognito User Pools only
+     * supports sending events to Amazon Pinpoint projects in us-east-1. In
+     * regions where Pinpoint is available, Cognito User Pools will support
+     * sending events to Amazon Pinpoint projects within that same region.
      * </p>
      * </note>
      * <p>
@@ -2387,10 +2556,11 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            </p>
      *            <note>
      *            <p>
-     *            Cognito User Pools only supports sending events to Amazon
-     *            Pinpoint projects in the US East (N. Virginia) us-east-1
-     *            Region, regardless of the region in which the user pool
-     *            resides.
+     *            In regions where Pinpoint is not available, Cognito User Pools
+     *            only supports sending events to Amazon Pinpoint projects in
+     *            us-east-1. In regions where Pinpoint is available, Cognito
+     *            User Pools will support sending events to Amazon Pinpoint
+     *            projects within that same region.
      *            </p>
      *            </note>
      * @return A reference to this updated object so that method calls can be
@@ -2427,51 +2597,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -2513,51 +2638,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *         <p>
      *         <code>LEGACY</code> - This represents the old behavior of Cognito
      *         where user existence related errors are not prevented.
-     *         </p>
-     *         </li>
-     *         </ul>
-     *         <p>
-     *         This setting affects the behavior of following APIs:
-     *         </p>
-     *         <ul>
-     *         <li>
-     *         <p>
-     *         <a>AdminInitiateAuth</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>AdminRespondToAuthChallenge</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>InitiateAuth</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>RespondToAuthChallenge</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ForgotPassword</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ConfirmForgotPassword</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ConfirmSignUp</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ResendConfirmationCode</a>
      *         </p>
      *         </li>
      *         </ul>
@@ -2603,51 +2683,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -2687,51 +2722,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -2777,51 +2767,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -2864,51 +2809,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -2958,51 +2858,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -3042,51 +2897,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -3130,51 +2940,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -3223,51 +2988,6 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
      *            </p>
      *            </li>
      *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
-     *            </p>
-     *            </li>
-     *            </ul>
      *            <note>
      *            <p>
      *            After February 15th 2020, the value of
@@ -3305,6 +3025,12 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
             sb.append("ClientName: " + getClientName() + ",");
         if (getRefreshTokenValidity() != null)
             sb.append("RefreshTokenValidity: " + getRefreshTokenValidity() + ",");
+        if (getAccessTokenValidity() != null)
+            sb.append("AccessTokenValidity: " + getAccessTokenValidity() + ",");
+        if (getIdTokenValidity() != null)
+            sb.append("IdTokenValidity: " + getIdTokenValidity() + ",");
+        if (getTokenValidityUnits() != null)
+            sb.append("TokenValidityUnits: " + getTokenValidityUnits() + ",");
         if (getReadAttributes() != null)
             sb.append("ReadAttributes: " + getReadAttributes() + ",");
         if (getWriteAttributes() != null)
@@ -3344,6 +3070,12 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
         hashCode = prime * hashCode + ((getClientName() == null) ? 0 : getClientName().hashCode());
         hashCode = prime * hashCode
                 + ((getRefreshTokenValidity() == null) ? 0 : getRefreshTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getAccessTokenValidity() == null) ? 0 : getAccessTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getIdTokenValidity() == null) ? 0 : getIdTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getTokenValidityUnits() == null) ? 0 : getTokenValidityUnits().hashCode());
         hashCode = prime * hashCode
                 + ((getReadAttributes() == null) ? 0 : getReadAttributes().hashCode());
         hashCode = prime * hashCode
@@ -3407,6 +3139,21 @@ public class UpdateUserPoolClientRequest extends AmazonWebServiceRequest impleme
             return false;
         if (other.getRefreshTokenValidity() != null
                 && other.getRefreshTokenValidity().equals(this.getRefreshTokenValidity()) == false)
+            return false;
+        if (other.getAccessTokenValidity() == null ^ this.getAccessTokenValidity() == null)
+            return false;
+        if (other.getAccessTokenValidity() != null
+                && other.getAccessTokenValidity().equals(this.getAccessTokenValidity()) == false)
+            return false;
+        if (other.getIdTokenValidity() == null ^ this.getIdTokenValidity() == null)
+            return false;
+        if (other.getIdTokenValidity() != null
+                && other.getIdTokenValidity().equals(this.getIdTokenValidity()) == false)
+            return false;
+        if (other.getTokenValidityUnits() == null ^ this.getTokenValidityUnits() == null)
+            return false;
+        if (other.getTokenValidityUnits() != null
+                && other.getTokenValidityUnits().equals(this.getTokenValidityUnits()) == false)
             return false;
         if (other.getReadAttributes() == null ^ this.getReadAttributes() == null)
             return false;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UpdateUserPoolRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UpdateUserPoolRequest.java
@@ -22,7 +22,9 @@ import com.amazonaws.AmazonWebServiceRequest;
 /**
  * <p>
  * Updates the specified user pool with the specified attributes. You can get a
- * list of the current user pool settings with .
+ * list of the current user pool settings using <a href=
+ * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPool.html"
+ * >DescribeUserPool</a>.
  * </p>
  * <important>
  * <p>

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UserPoolClientType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UserPoolClientType.java
@@ -88,9 +88,39 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      */
     private Integer refreshTokenValidity;
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the access token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     */
+    private Integer accessTokenValidity;
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the refresh token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     */
+    private Integer idTokenValidity;
+
+    /**
+     * <p>
+     * The time units used to specify the token validity times of their
+     * respective token.
+     * </p>
+     */
+    private TokenValidityUnitsType tokenValidityUnits;
 
     /**
      * <p>
@@ -329,51 +359,6 @@ public class UserPoolClientType implements Serializable {
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -718,7 +703,7 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @return <p>
      *         The time limit, in days, after which the refresh token is no
@@ -736,7 +721,7 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @param refreshTokenValidity <p>
      *            The time limit, in days, after which the refresh token is no
@@ -757,7 +742,7 @@ public class UserPoolClientType implements Serializable {
      * together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Range: </b>0 - 3650<br/>
+     * <b>Range: </b>0 - 315360000<br/>
      *
      * @param refreshTokenValidity <p>
      *            The time limit, in days, after which the refresh token is no
@@ -768,6 +753,183 @@ public class UserPoolClientType implements Serializable {
      */
     public UserPoolClientType withRefreshTokenValidity(Integer refreshTokenValidity) {
         this.refreshTokenValidity = refreshTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the access token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @return <p>
+     *         The time limit, specified by tokenValidityUnits, defaulting to
+     *         hours, after which the access token is no longer valid and cannot
+     *         be used.
+     *         </p>
+     */
+    public Integer getAccessTokenValidity() {
+        return accessTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the access token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param accessTokenValidity <p>
+     *            The time limit, specified by tokenValidityUnits, defaulting to
+     *            hours, after which the access token is no longer valid and
+     *            cannot be used.
+     *            </p>
+     */
+    public void setAccessTokenValidity(Integer accessTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the access token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param accessTokenValidity <p>
+     *            The time limit, specified by tokenValidityUnits, defaulting to
+     *            hours, after which the access token is no longer valid and
+     *            cannot be used.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public UserPoolClientType withAccessTokenValidity(Integer accessTokenValidity) {
+        this.accessTokenValidity = accessTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the refresh token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @return <p>
+     *         The time limit, specified by tokenValidityUnits, defaulting to
+     *         hours, after which the refresh token is no longer valid and
+     *         cannot be used.
+     *         </p>
+     */
+    public Integer getIdTokenValidity() {
+        return idTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the refresh token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param idTokenValidity <p>
+     *            The time limit, specified by tokenValidityUnits, defaulting to
+     *            hours, after which the refresh token is no longer valid and
+     *            cannot be used.
+     *            </p>
+     */
+    public void setIdTokenValidity(Integer idTokenValidity) {
+        this.idTokenValidity = idTokenValidity;
+    }
+
+    /**
+     * <p>
+     * The time limit, specified by tokenValidityUnits, defaulting to hours,
+     * after which the refresh token is no longer valid and cannot be used.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Range: </b>1 - 86400<br/>
+     *
+     * @param idTokenValidity <p>
+     *            The time limit, specified by tokenValidityUnits, defaulting to
+     *            hours, after which the refresh token is no longer valid and
+     *            cannot be used.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public UserPoolClientType withIdTokenValidity(Integer idTokenValidity) {
+        this.idTokenValidity = idTokenValidity;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The time units used to specify the token validity times of their
+     * respective token.
+     * </p>
+     *
+     * @return <p>
+     *         The time units used to specify the token validity times of their
+     *         respective token.
+     *         </p>
+     */
+    public TokenValidityUnitsType getTokenValidityUnits() {
+        return tokenValidityUnits;
+    }
+
+    /**
+     * <p>
+     * The time units used to specify the token validity times of their
+     * respective token.
+     * </p>
+     *
+     * @param tokenValidityUnits <p>
+     *            The time units used to specify the token validity times of
+     *            their respective token.
+     *            </p>
+     */
+    public void setTokenValidityUnits(TokenValidityUnitsType tokenValidityUnits) {
+        this.tokenValidityUnits = tokenValidityUnits;
+    }
+
+    /**
+     * <p>
+     * The time units used to specify the token validity times of their
+     * respective token.
+     * </p>
+     * <p>
+     * Returns a reference to this object so that method calls can be chained
+     * together.
+     *
+     * @param tokenValidityUnits <p>
+     *            The time units used to specify the token validity times of
+     *            their respective token.
+     *            </p>
+     * @return A reference to this updated object so that method calls can be
+     *         chained together.
+     */
+    public UserPoolClientType withTokenValidityUnits(TokenValidityUnitsType tokenValidityUnits) {
+        this.tokenValidityUnits = tokenValidityUnits;
         return this;
     }
 
@@ -2578,51 +2740,6 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -2661,51 +2778,6 @@ public class UserPoolClientType implements Serializable {
      *         <p>
      *         <code>LEGACY</code> - This represents the old behavior of Cognito
      *         where user existence related errors are not prevented.
-     *         </p>
-     *         </li>
-     *         </ul>
-     *         <p>
-     *         This setting affects the behavior of following APIs:
-     *         </p>
-     *         <ul>
-     *         <li>
-     *         <p>
-     *         <a>AdminInitiateAuth</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>AdminRespondToAuthChallenge</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>InitiateAuth</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>RespondToAuthChallenge</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ForgotPassword</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ConfirmForgotPassword</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ConfirmSignUp</a>
-     *         </p>
-     *         </li>
-     *         <li>
-     *         <p>
-     *         <a>ResendConfirmationCode</a>
      *         </p>
      *         </li>
      *         </ul>
@@ -2751,51 +2823,6 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -2835,51 +2862,6 @@ public class UserPoolClientType implements Serializable {
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -2925,51 +2907,6 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -3012,51 +2949,6 @@ public class UserPoolClientType implements Serializable {
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -3105,51 +2997,6 @@ public class UserPoolClientType implements Serializable {
      * </p>
      * </li>
      * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
-     * </p>
-     * </li>
-     * </ul>
      * <note>
      * <p>
      * After February 15th 2020, the value of
@@ -3189,51 +3036,6 @@ public class UserPoolClientType implements Serializable {
      *            <p>
      *            <code>LEGACY</code> - This represents the old behavior of
      *            Cognito where user existence related errors are not prevented.
-     *            </p>
-     *            </li>
-     *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
      *            </p>
      *            </li>
      *            </ul>
@@ -3277,51 +3079,6 @@ public class UserPoolClientType implements Serializable {
      * <p>
      * <code>LEGACY</code> - This represents the old behavior of Cognito where
      * user existence related errors are not prevented.
-     * </p>
-     * </li>
-     * </ul>
-     * <p>
-     * This setting affects the behavior of following APIs:
-     * </p>
-     * <ul>
-     * <li>
-     * <p>
-     * <a>AdminInitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>AdminRespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>InitiateAuth</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>RespondToAuthChallenge</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmForgotPassword</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ConfirmSignUp</a>
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <a>ResendConfirmationCode</a>
      * </p>
      * </li>
      * </ul>
@@ -3370,51 +3127,6 @@ public class UserPoolClientType implements Serializable {
      *            </p>
      *            </li>
      *            </ul>
-     *            <p>
-     *            This setting affects the behavior of following APIs:
-     *            </p>
-     *            <ul>
-     *            <li>
-     *            <p>
-     *            <a>AdminInitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>AdminRespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>InitiateAuth</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>RespondToAuthChallenge</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmForgotPassword</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ConfirmSignUp</a>
-     *            </p>
-     *            </li>
-     *            <li>
-     *            <p>
-     *            <a>ResendConfirmationCode</a>
-     *            </p>
-     *            </li>
-     *            </ul>
      *            <note>
      *            <p>
      *            After February 15th 2020, the value of
@@ -3458,6 +3170,12 @@ public class UserPoolClientType implements Serializable {
             sb.append("CreationDate: " + getCreationDate() + ",");
         if (getRefreshTokenValidity() != null)
             sb.append("RefreshTokenValidity: " + getRefreshTokenValidity() + ",");
+        if (getAccessTokenValidity() != null)
+            sb.append("AccessTokenValidity: " + getAccessTokenValidity() + ",");
+        if (getIdTokenValidity() != null)
+            sb.append("IdTokenValidity: " + getIdTokenValidity() + ",");
+        if (getTokenValidityUnits() != null)
+            sb.append("TokenValidityUnits: " + getTokenValidityUnits() + ",");
         if (getReadAttributes() != null)
             sb.append("ReadAttributes: " + getReadAttributes() + ",");
         if (getWriteAttributes() != null)
@@ -3503,6 +3221,12 @@ public class UserPoolClientType implements Serializable {
                 + ((getCreationDate() == null) ? 0 : getCreationDate().hashCode());
         hashCode = prime * hashCode
                 + ((getRefreshTokenValidity() == null) ? 0 : getRefreshTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getAccessTokenValidity() == null) ? 0 : getAccessTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getIdTokenValidity() == null) ? 0 : getIdTokenValidity().hashCode());
+        hashCode = prime * hashCode
+                + ((getTokenValidityUnits() == null) ? 0 : getTokenValidityUnits().hashCode());
         hashCode = prime * hashCode
                 + ((getReadAttributes() == null) ? 0 : getReadAttributes().hashCode());
         hashCode = prime * hashCode
@@ -3581,6 +3305,21 @@ public class UserPoolClientType implements Serializable {
             return false;
         if (other.getRefreshTokenValidity() != null
                 && other.getRefreshTokenValidity().equals(this.getRefreshTokenValidity()) == false)
+            return false;
+        if (other.getAccessTokenValidity() == null ^ this.getAccessTokenValidity() == null)
+            return false;
+        if (other.getAccessTokenValidity() != null
+                && other.getAccessTokenValidity().equals(this.getAccessTokenValidity()) == false)
+            return false;
+        if (other.getIdTokenValidity() == null ^ this.getIdTokenValidity() == null)
+            return false;
+        if (other.getIdTokenValidity() != null
+                && other.getIdTokenValidity().equals(this.getIdTokenValidity()) == false)
+            return false;
+        if (other.getTokenValidityUnits() == null ^ this.getTokenValidityUnits() == null)
+            return false;
+        if (other.getTokenValidityUnits() != null
+                && other.getTokenValidityUnits().equals(this.getTokenValidityUnits()) == false)
             return false;
         if (other.getReadAttributes() == null ^ this.getReadAttributes() == null)
             return false;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UserPoolType.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/UserPoolType.java
@@ -298,7 +298,9 @@ public class UserPoolType implements Serializable {
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      */
     private UsernameConfigurationType usernameConfiguration;
@@ -2259,7 +2261,9 @@ public class UserPoolType implements Serializable {
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      *
      * @return <p>
@@ -2267,7 +2271,9 @@ public class UserPoolType implements Serializable {
      *         for the selected sign-in option. For example, when this is set to
      *         <code>False</code>, users will be able to sign in using either
      *         "username" or "Username". This configuration is immutable once it
-     *         has been set. For more information, see .
+     *         has been set. For more information, see <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     *         >UsernameConfigurationType</a>.
      *         </p>
      */
     public UsernameConfigurationType getUsernameConfiguration() {
@@ -2280,7 +2286,9 @@ public class UserPoolType implements Serializable {
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      *
      * @param usernameConfiguration <p>
@@ -2288,7 +2296,10 @@ public class UserPoolType implements Serializable {
      *            input for the selected sign-in option. For example, when this
      *            is set to <code>False</code>, users will be able to sign in
      *            using either "username" or "Username". This configuration is
-     *            immutable once it has been set. For more information, see .
+     *            immutable once it has been set. For more information, see <a
+     *            href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     *            >UsernameConfigurationType</a>.
      *            </p>
      */
     public void setUsernameConfiguration(UsernameConfigurationType usernameConfiguration) {
@@ -2301,7 +2312,9 @@ public class UserPoolType implements Serializable {
      * selected sign-in option. For example, when this is set to
      * <code>False</code>, users will be able to sign in using either "username"
      * or "Username". This configuration is immutable once it has been set. For
-     * more information, see .
+     * more information, see <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     * >UsernameConfigurationType</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -2312,7 +2325,10 @@ public class UserPoolType implements Serializable {
      *            input for the selected sign-in option. For example, when this
      *            is set to <code>False</code>, users will be able to sign in
      *            using either "username" or "Username". This configuration is
-     *            immutable once it has been set. For more information, see .
+     *            immutable once it has been set. For more information, see <a
+     *            href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UsernameConfigurationType.html"
+     *            >UsernameConfigurationType</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/VerifySoftwareTokenRequest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/VerifySoftwareTokenRequest.java
@@ -50,7 +50,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
 
     /**
      * <p>
-     * The one time password computed using the secret code returned by
+     * The one time password computed using the secret code returned by <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     * >AssociateSoftwareToken"</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -182,7 +184,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
 
     /**
      * <p>
-     * The one time password computed using the secret code returned by
+     * The one time password computed using the secret code returned by <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     * >AssociateSoftwareToken"</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -191,6 +195,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
      *
      * @return <p>
      *         The one time password computed using the secret code returned by
+     *         <a href=
+     *         "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     *         >AssociateSoftwareToken"</a>.
      *         </p>
      */
     public String getUserCode() {
@@ -199,7 +206,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
 
     /**
      * <p>
-     * The one time password computed using the secret code returned by
+     * The one time password computed using the secret code returned by <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     * >AssociateSoftwareToken"</a>.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -208,7 +217,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
      *
      * @param userCode <p>
      *            The one time password computed using the secret code returned
-     *            by
+     *            by <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     *            >AssociateSoftwareToken"</a>.
      *            </p>
      */
     public void setUserCode(String userCode) {
@@ -217,7 +228,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
 
     /**
      * <p>
-     * The one time password computed using the secret code returned by
+     * The one time password computed using the secret code returned by <a href=
+     * "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     * >AssociateSoftwareToken"</a>.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -229,7 +242,9 @@ public class VerifySoftwareTokenRequest extends AmazonWebServiceRequest implemen
      *
      * @param userCode <p>
      *            The one time password computed using the secret code returned
-     *            by
+     *            by <a href=
+     *            "https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AssociateSoftwareToken.html"
+     *            >AssociateSoftwareToken"</a>.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AddCustomAttributesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AddCustomAttributesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminAddUserToGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminAddUserToGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminConfirmSignUpRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminConfirmSignUpRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminCreateUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminCreateUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDeleteUserAttributesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDeleteUserAttributesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDeleteUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDeleteUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDisableProviderForUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDisableProviderForUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDisableUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminDisableUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminEnableUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminEnableUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminForgetDeviceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminForgetDeviceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminGetDeviceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminGetDeviceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminGetUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminGetUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminInitiateAuthRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminInitiateAuthRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminLinkProviderForUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminLinkProviderForUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminListDevicesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminListDevicesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminListGroupsForUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminListGroupsForUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminListUserAuthEventsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminListUserAuthEventsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminRemoveUserFromGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminRemoveUserFromGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminResetUserPasswordRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminResetUserPasswordRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminRespondToAuthChallengeRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminRespondToAuthChallengeRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminSetUserMFAPreferenceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminSetUserMFAPreferenceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminSetUserPasswordRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminSetUserPasswordRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminSetUserSettingsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminSetUserSettingsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUpdateAuthEventFeedbackRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUpdateAuthEventFeedbackRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUpdateDeviceStatusRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUpdateDeviceStatusRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUpdateUserAttributesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUpdateUserAttributesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUserGlobalSignOutRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AdminUserGlobalSignOutRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AnalyticsConfigurationTypeJsonMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AnalyticsConfigurationTypeJsonMarshaller.java
@@ -31,6 +31,11 @@ class AnalyticsConfigurationTypeJsonMarshaller {
             jsonWriter.name("ApplicationId");
             jsonWriter.value(applicationId);
         }
+        if (analyticsConfigurationType.getApplicationArn() != null) {
+            String applicationArn = analyticsConfigurationType.getApplicationArn();
+            jsonWriter.name("ApplicationArn");
+            jsonWriter.value(applicationArn);
+        }
         if (analyticsConfigurationType.getRoleArn() != null) {
             String roleArn = analyticsConfigurationType.getRoleArn();
             jsonWriter.name("RoleArn");

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AnalyticsConfigurationTypeJsonUnmarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AnalyticsConfigurationTypeJsonUnmarshaller.java
@@ -39,6 +39,9 @@ class AnalyticsConfigurationTypeJsonUnmarshaller implements
             if (name.equals("ApplicationId")) {
                 analyticsConfigurationType.setApplicationId(StringJsonUnmarshaller.getInstance()
                         .unmarshall(context));
+            } else if (name.equals("ApplicationArn")) {
+                analyticsConfigurationType.setApplicationArn(StringJsonUnmarshaller.getInstance()
+                        .unmarshall(context));
             } else if (name.equals("RoleArn")) {
                 analyticsConfigurationType.setRoleArn(StringJsonUnmarshaller.getInstance()
                         .unmarshall(context));

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AssociateSoftwareTokenRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/AssociateSoftwareTokenRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ChangePasswordRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ChangePasswordRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ConfirmDeviceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ConfirmDeviceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ConfirmForgotPasswordRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ConfirmForgotPasswordRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ConfirmSignUpRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ConfirmSignUpRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateIdentityProviderRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateIdentityProviderRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateResourceServerRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateResourceServerRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserImportJobRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserImportJobRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserPoolClientRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserPoolClientRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;
@@ -80,6 +82,23 @@ public class CreateUserPoolClientRequestMarshaller implements
                         .getRefreshTokenValidity();
                 jsonWriter.name("RefreshTokenValidity");
                 jsonWriter.value(refreshTokenValidity);
+            }
+            if (createUserPoolClientRequest.getAccessTokenValidity() != null) {
+                Integer accessTokenValidity = createUserPoolClientRequest.getAccessTokenValidity();
+                jsonWriter.name("AccessTokenValidity");
+                jsonWriter.value(accessTokenValidity);
+            }
+            if (createUserPoolClientRequest.getIdTokenValidity() != null) {
+                Integer idTokenValidity = createUserPoolClientRequest.getIdTokenValidity();
+                jsonWriter.name("IdTokenValidity");
+                jsonWriter.value(idTokenValidity);
+            }
+            if (createUserPoolClientRequest.getTokenValidityUnits() != null) {
+                TokenValidityUnitsType tokenValidityUnits = createUserPoolClientRequest
+                        .getTokenValidityUnits();
+                jsonWriter.name("TokenValidityUnits");
+                TokenValidityUnitsTypeJsonMarshaller.getInstance().marshall(tokenValidityUnits,
+                        jsonWriter);
             }
             if (createUserPoolClientRequest.getReadAttributes() != null) {
                 java.util.List<String> readAttributes = createUserPoolClientRequest

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserPoolDomainRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserPoolDomainRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserPoolRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/CreateUserPoolRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteIdentityProviderRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteIdentityProviderRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteResourceServerRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteResourceServerRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserAttributesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserAttributesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserPoolClientRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserPoolClientRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserPoolDomainRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserPoolDomainRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserPoolRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserPoolRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DeleteUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeIdentityProviderRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeIdentityProviderRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeResourceServerRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeResourceServerRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeRiskConfigurationRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeRiskConfigurationRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserImportJobRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserImportJobRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserPoolClientRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserPoolClientRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserPoolDomainRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserPoolDomainRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserPoolRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/DescribeUserPoolRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ForgetDeviceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ForgetDeviceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ForgotPasswordRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ForgotPasswordRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetCSVHeaderRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetCSVHeaderRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetDeviceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetDeviceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetIdentityProviderByIdentifierRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetIdentityProviderByIdentifierRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetSigningCertificateRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetSigningCertificateRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUICustomizationRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUICustomizationRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUserAttributeVerificationCodeRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUserAttributeVerificationCodeRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUserPoolMfaConfigRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUserPoolMfaConfigRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUserRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GetUserRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GlobalSignOutRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/GlobalSignOutRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/InitiateAuthRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/InitiateAuthRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListDevicesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListDevicesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListGroupsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListGroupsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListIdentityProvidersRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListIdentityProvidersRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListResourceServersRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListResourceServersRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListTagsForResourceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListTagsForResourceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUserImportJobsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUserImportJobsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUserPoolClientsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUserPoolClientsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUserPoolsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUserPoolsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUsersInGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUsersInGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUsersRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ListUsersRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ResendConfirmationCodeRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/ResendConfirmationCodeRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/RespondToAuthChallengeRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/RespondToAuthChallengeRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetRiskConfigurationRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetRiskConfigurationRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUICustomizationRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUICustomizationRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUserMFAPreferenceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUserMFAPreferenceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUserPoolMfaConfigRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUserPoolMfaConfigRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUserSettingsRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SetUserSettingsRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SignUpRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/SignUpRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/StartUserImportJobRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/StartUserImportJobRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/StopUserImportJobRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/StopUserImportJobRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/TagResourceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/TagResourceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/TokenValidityUnitsTypeJsonMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/TokenValidityUnitsTypeJsonMarshaller.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.cognitoidentityprovider.model.transform;
+
+import com.amazonaws.services.cognitoidentityprovider.model.*;
+import com.amazonaws.util.json.AwsJsonWriter;
+
+/**
+ * JSON marshaller for POJO TokenValidityUnitsType
+ */
+class TokenValidityUnitsTypeJsonMarshaller {
+
+    public void marshall(TokenValidityUnitsType tokenValidityUnitsType, AwsJsonWriter jsonWriter)
+            throws Exception {
+        jsonWriter.beginObject();
+        if (tokenValidityUnitsType.getAccessToken() != null) {
+            String accessToken = tokenValidityUnitsType.getAccessToken();
+            jsonWriter.name("AccessToken");
+            jsonWriter.value(accessToken);
+        }
+        if (tokenValidityUnitsType.getIdToken() != null) {
+            String idToken = tokenValidityUnitsType.getIdToken();
+            jsonWriter.name("IdToken");
+            jsonWriter.value(idToken);
+        }
+        if (tokenValidityUnitsType.getRefreshToken() != null) {
+            String refreshToken = tokenValidityUnitsType.getRefreshToken();
+            jsonWriter.name("RefreshToken");
+            jsonWriter.value(refreshToken);
+        }
+        jsonWriter.endObject();
+    }
+
+    private static TokenValidityUnitsTypeJsonMarshaller instance;
+
+    public static TokenValidityUnitsTypeJsonMarshaller getInstance() {
+        if (instance == null)
+            instance = new TokenValidityUnitsTypeJsonMarshaller();
+        return instance;
+    }
+}

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/TokenValidityUnitsTypeJsonUnmarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/TokenValidityUnitsTypeJsonUnmarshaller.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.cognitoidentityprovider.model.transform;
+
+import com.amazonaws.services.cognitoidentityprovider.model.*;
+import com.amazonaws.transform.SimpleTypeJsonUnmarshallers.*;
+import com.amazonaws.transform.*;
+import com.amazonaws.util.json.AwsJsonReader;
+
+/**
+ * JSON unmarshaller for POJO TokenValidityUnitsType
+ */
+class TokenValidityUnitsTypeJsonUnmarshaller implements
+        Unmarshaller<TokenValidityUnitsType, JsonUnmarshallerContext> {
+
+    public TokenValidityUnitsType unmarshall(JsonUnmarshallerContext context) throws Exception {
+        AwsJsonReader reader = context.getReader();
+        if (!reader.isContainer()) {
+            reader.skipValue();
+            return null;
+        }
+        TokenValidityUnitsType tokenValidityUnitsType = new TokenValidityUnitsType();
+        reader.beginObject();
+        while (reader.hasNext()) {
+            String name = reader.nextName();
+            if (name.equals("AccessToken")) {
+                tokenValidityUnitsType.setAccessToken(StringJsonUnmarshaller.getInstance()
+                        .unmarshall(context));
+            } else if (name.equals("IdToken")) {
+                tokenValidityUnitsType.setIdToken(StringJsonUnmarshaller.getInstance()
+                        .unmarshall(context));
+            } else if (name.equals("RefreshToken")) {
+                tokenValidityUnitsType.setRefreshToken(StringJsonUnmarshaller.getInstance()
+                        .unmarshall(context));
+            } else {
+                reader.skipValue();
+            }
+        }
+        reader.endObject();
+        return tokenValidityUnitsType;
+    }
+
+    private static TokenValidityUnitsTypeJsonUnmarshaller instance;
+
+    public static TokenValidityUnitsTypeJsonUnmarshaller getInstance() {
+        if (instance == null)
+            instance = new TokenValidityUnitsTypeJsonUnmarshaller();
+        return instance;
+    }
+}

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UntagResourceRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UntagResourceRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateAuthEventFeedbackRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateAuthEventFeedbackRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateDeviceStatusRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateDeviceStatusRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateGroupRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateGroupRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateIdentityProviderRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateIdentityProviderRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateResourceServerRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateResourceServerRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserAttributesRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserAttributesRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserPoolClientRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserPoolClientRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;
@@ -80,6 +82,23 @@ public class UpdateUserPoolClientRequestMarshaller implements
                         .getRefreshTokenValidity();
                 jsonWriter.name("RefreshTokenValidity");
                 jsonWriter.value(refreshTokenValidity);
+            }
+            if (updateUserPoolClientRequest.getAccessTokenValidity() != null) {
+                Integer accessTokenValidity = updateUserPoolClientRequest.getAccessTokenValidity();
+                jsonWriter.name("AccessTokenValidity");
+                jsonWriter.value(accessTokenValidity);
+            }
+            if (updateUserPoolClientRequest.getIdTokenValidity() != null) {
+                Integer idTokenValidity = updateUserPoolClientRequest.getIdTokenValidity();
+                jsonWriter.name("IdTokenValidity");
+                jsonWriter.value(idTokenValidity);
+            }
+            if (updateUserPoolClientRequest.getTokenValidityUnits() != null) {
+                TokenValidityUnitsType tokenValidityUnits = updateUserPoolClientRequest
+                        .getTokenValidityUnits();
+                jsonWriter.name("TokenValidityUnits");
+                TokenValidityUnitsTypeJsonMarshaller.getInstance().marshall(tokenValidityUnits,
+                        jsonWriter);
             }
             if (updateUserPoolClientRequest.getReadAttributes() != null) {
                 java.util.List<String> readAttributes = updateUserPoolClientRequest

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserPoolDomainRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserPoolDomainRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserPoolRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UpdateUserPoolRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UserPoolClientTypeJsonMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UserPoolClientTypeJsonMarshaller.java
@@ -61,6 +61,22 @@ class UserPoolClientTypeJsonMarshaller {
             jsonWriter.name("RefreshTokenValidity");
             jsonWriter.value(refreshTokenValidity);
         }
+        if (userPoolClientType.getAccessTokenValidity() != null) {
+            Integer accessTokenValidity = userPoolClientType.getAccessTokenValidity();
+            jsonWriter.name("AccessTokenValidity");
+            jsonWriter.value(accessTokenValidity);
+        }
+        if (userPoolClientType.getIdTokenValidity() != null) {
+            Integer idTokenValidity = userPoolClientType.getIdTokenValidity();
+            jsonWriter.name("IdTokenValidity");
+            jsonWriter.value(idTokenValidity);
+        }
+        if (userPoolClientType.getTokenValidityUnits() != null) {
+            TokenValidityUnitsType tokenValidityUnits = userPoolClientType.getTokenValidityUnits();
+            jsonWriter.name("TokenValidityUnits");
+            TokenValidityUnitsTypeJsonMarshaller.getInstance().marshall(tokenValidityUnits,
+                    jsonWriter);
+        }
         if (userPoolClientType.getReadAttributes() != null) {
             java.util.List<String> readAttributes = userPoolClientType.getReadAttributes();
             jsonWriter.name("ReadAttributes");

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UserPoolClientTypeJsonUnmarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/UserPoolClientTypeJsonUnmarshaller.java
@@ -57,6 +57,16 @@ class UserPoolClientTypeJsonUnmarshaller implements
             } else if (name.equals("RefreshTokenValidity")) {
                 userPoolClientType.setRefreshTokenValidity(IntegerJsonUnmarshaller.getInstance()
                         .unmarshall(context));
+            } else if (name.equals("AccessTokenValidity")) {
+                userPoolClientType.setAccessTokenValidity(IntegerJsonUnmarshaller.getInstance()
+                        .unmarshall(context));
+            } else if (name.equals("IdTokenValidity")) {
+                userPoolClientType.setIdTokenValidity(IntegerJsonUnmarshaller.getInstance()
+                        .unmarshall(context));
+            } else if (name.equals("TokenValidityUnits")) {
+                userPoolClientType.setTokenValidityUnits(TokenValidityUnitsTypeJsonUnmarshaller
+                        .getInstance()
+                        .unmarshall(context));
             } else if (name.equals("ReadAttributes")) {
                 userPoolClientType.setReadAttributes(new ListUnmarshaller<String>(
                         StringJsonUnmarshaller.getInstance()

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/VerifySoftwareTokenRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/VerifySoftwareTokenRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/VerifyUserAttributeRequestMarshaller.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/services/cognitoidentityprovider/model/transform/VerifyUserAttributeRequestMarshaller.java
@@ -22,6 +22,8 @@ import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import android.text.TextUtils;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
 import com.amazonaws.DefaultRequest;

--- a/aws-android-sdk-comprehend/src/main/java/com/amazonaws/services/comprehend/model/CreateEntityRecognizerRequest.java
+++ b/aws-android-sdk-comprehend/src/main/java/com/amazonaws/services/comprehend/model/CreateEntityRecognizerRequest.java
@@ -86,8 +86,10 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The language of the input documents. All documents must be in the same
-     * language. Only English ("en") is currently supported.
+     * You can specify any of the following languages supported by Amazon
+     * Comprehend: English ("en"), Spanish ("es"), French ("fr"), Italian
+     * ("it"), German ("de"), or Portuguese ("pt"). All documents must be in the
+     * same language.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
@@ -498,16 +500,20 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The language of the input documents. All documents must be in the same
-     * language. Only English ("en") is currently supported.
+     * You can specify any of the following languages supported by Amazon
+     * Comprehend: English ("en"), Spanish ("es"), French ("fr"), Italian
+     * ("it"), German ("de"), or Portuguese ("pt"). All documents must be in the
+     * same language.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Allowed Values: </b>en, es, fr, de, it, pt, ar, hi, ja, ko, zh, zh-TW
      *
      * @return <p>
-     *         The language of the input documents. All documents must be in the
-     *         same language. Only English ("en") is currently supported.
+     *         You can specify any of the following languages supported by
+     *         Amazon Comprehend: English ("en"), Spanish ("es"), French ("fr"),
+     *         Italian ("it"), German ("de"), or Portuguese ("pt"). All
+     *         documents must be in the same language.
      *         </p>
      * @see LanguageCode
      */
@@ -517,16 +523,20 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The language of the input documents. All documents must be in the same
-     * language. Only English ("en") is currently supported.
+     * You can specify any of the following languages supported by Amazon
+     * Comprehend: English ("en"), Spanish ("es"), French ("fr"), Italian
+     * ("it"), German ("de"), or Portuguese ("pt"). All documents must be in the
+     * same language.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Allowed Values: </b>en, es, fr, de, it, pt, ar, hi, ja, ko, zh, zh-TW
      *
      * @param languageCode <p>
-     *            The language of the input documents. All documents must be in
-     *            the same language. Only English ("en") is currently supported.
+     *            You can specify any of the following languages supported by
+     *            Amazon Comprehend: English ("en"), Spanish ("es"), French
+     *            ("fr"), Italian ("it"), German ("de"), or Portuguese ("pt").
+     *            All documents must be in the same language.
      *            </p>
      * @see LanguageCode
      */
@@ -536,8 +546,10 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The language of the input documents. All documents must be in the same
-     * language. Only English ("en") is currently supported.
+     * You can specify any of the following languages supported by Amazon
+     * Comprehend: English ("en"), Spanish ("es"), French ("fr"), Italian
+     * ("it"), German ("de"), or Portuguese ("pt"). All documents must be in the
+     * same language.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -547,8 +559,10 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
      * <b>Allowed Values: </b>en, es, fr, de, it, pt, ar, hi, ja, ko, zh, zh-TW
      *
      * @param languageCode <p>
-     *            The language of the input documents. All documents must be in
-     *            the same language. Only English ("en") is currently supported.
+     *            You can specify any of the following languages supported by
+     *            Amazon Comprehend: English ("en"), Spanish ("es"), French
+     *            ("fr"), Italian ("it"), German ("de"), or Portuguese ("pt").
+     *            All documents must be in the same language.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.
@@ -561,16 +575,20 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The language of the input documents. All documents must be in the same
-     * language. Only English ("en") is currently supported.
+     * You can specify any of the following languages supported by Amazon
+     * Comprehend: English ("en"), Spanish ("es"), French ("fr"), Italian
+     * ("it"), German ("de"), or Portuguese ("pt"). All documents must be in the
+     * same language.
      * </p>
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Allowed Values: </b>en, es, fr, de, it, pt, ar, hi, ja, ko, zh, zh-TW
      *
      * @param languageCode <p>
-     *            The language of the input documents. All documents must be in
-     *            the same language. Only English ("en") is currently supported.
+     *            You can specify any of the following languages supported by
+     *            Amazon Comprehend: English ("en"), Spanish ("es"), French
+     *            ("fr"), Italian ("it"), German ("de"), or Portuguese ("pt").
+     *            All documents must be in the same language.
      *            </p>
      * @see LanguageCode
      */
@@ -580,8 +598,10 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
 
     /**
      * <p>
-     * The language of the input documents. All documents must be in the same
-     * language. Only English ("en") is currently supported.
+     * You can specify any of the following languages supported by Amazon
+     * Comprehend: English ("en"), Spanish ("es"), French ("fr"), Italian
+     * ("it"), German ("de"), or Portuguese ("pt"). All documents must be in the
+     * same language.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -591,8 +611,10 @@ public class CreateEntityRecognizerRequest extends AmazonWebServiceRequest imple
      * <b>Allowed Values: </b>en, es, fr, de, it, pt, ar, hi, ja, ko, zh, zh-TW
      *
      * @param languageCode <p>
-     *            The language of the input documents. All documents must be in
-     *            the same language. Only English ("en") is currently supported.
+     *            You can specify any of the following languages supported by
+     *            Amazon Comprehend: English ("en"), Spanish ("es"), French
+     *            ("fr"), Italian ("it"), German ("de"), or Portuguese ("pt").
+     *            All documents must be in the same language.
      *            </p>
      * @return A reference to this updated object so that method calls can be
      *         chained together.

--- a/aws-android-sdk-comprehend/src/main/java/com/amazonaws/services/comprehend/model/EntityRecognizerInputDataConfig.java
+++ b/aws-android-sdk-comprehend/src/main/java/com/amazonaws/services/comprehend/model/EntityRecognizerInputDataConfig.java
@@ -26,7 +26,7 @@ public class EntityRecognizerInputDataConfig implements Serializable {
     /**
      * <p>
      * The entity types in the input data for an entity recognizer. A maximum of
-     * 12 entity types can be used at one time to train an entity recognizer.
+     * 25 entity types can be used at one time to train an entity recognizer.
      * </p>
      */
     private java.util.List<EntityTypesListItem> entityTypes;
@@ -55,12 +55,12 @@ public class EntityRecognizerInputDataConfig implements Serializable {
     /**
      * <p>
      * The entity types in the input data for an entity recognizer. A maximum of
-     * 12 entity types can be used at one time to train an entity recognizer.
+     * 25 entity types can be used at one time to train an entity recognizer.
      * </p>
      *
      * @return <p>
      *         The entity types in the input data for an entity recognizer. A
-     *         maximum of 12 entity types can be used at one time to train an
+     *         maximum of 25 entity types can be used at one time to train an
      *         entity recognizer.
      *         </p>
      */
@@ -71,12 +71,12 @@ public class EntityRecognizerInputDataConfig implements Serializable {
     /**
      * <p>
      * The entity types in the input data for an entity recognizer. A maximum of
-     * 12 entity types can be used at one time to train an entity recognizer.
+     * 25 entity types can be used at one time to train an entity recognizer.
      * </p>
      *
      * @param entityTypes <p>
      *            The entity types in the input data for an entity recognizer. A
-     *            maximum of 12 entity types can be used at one time to train an
+     *            maximum of 25 entity types can be used at one time to train an
      *            entity recognizer.
      *            </p>
      */
@@ -92,7 +92,7 @@ public class EntityRecognizerInputDataConfig implements Serializable {
     /**
      * <p>
      * The entity types in the input data for an entity recognizer. A maximum of
-     * 12 entity types can be used at one time to train an entity recognizer.
+     * 25 entity types can be used at one time to train an entity recognizer.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -100,7 +100,7 @@ public class EntityRecognizerInputDataConfig implements Serializable {
      *
      * @param entityTypes <p>
      *            The entity types in the input data for an entity recognizer. A
-     *            maximum of 12 entity types can be used at one time to train an
+     *            maximum of 25 entity types can be used at one time to train an
      *            entity recognizer.
      *            </p>
      * @return A reference to this updated object so that method calls can be
@@ -119,7 +119,7 @@ public class EntityRecognizerInputDataConfig implements Serializable {
     /**
      * <p>
      * The entity types in the input data for an entity recognizer. A maximum of
-     * 12 entity types can be used at one time to train an entity recognizer.
+     * 25 entity types can be used at one time to train an entity recognizer.
      * </p>
      * <p>
      * Returns a reference to this object so that method calls can be chained
@@ -127,7 +127,7 @@ public class EntityRecognizerInputDataConfig implements Serializable {
      *
      * @param entityTypes <p>
      *            The entity types in the input data for an entity recognizer. A
-     *            maximum of 12 entity types can be used at one time to train an
+     *            maximum of 25 entity types can be used at one time to train an
      *            entity recognizer.
      *            </p>
      * @return A reference to this updated object so that method calls can be

--- a/aws-android-sdk-comprehend/src/main/java/com/amazonaws/services/comprehend/model/UnsupportedLanguageException.java
+++ b/aws-android-sdk-comprehend/src/main/java/com/amazonaws/services/comprehend/model/UnsupportedLanguageException.java
@@ -21,9 +21,10 @@ import com.amazonaws.AmazonServiceException;
  * <p>
  * Amazon Comprehend can't process the language of the input text. For all
  * custom entity recognition APIs (such as <code>CreateEntityRecognizer</code>),
- * only English is accepted. For most other APIs, such as those for Custom
- * Classification, Amazon Comprehend accepts text in all supported languages.
- * For a list of supported languages, see <a>supported-languages</a>.
+ * only English, Spanish, French, Italian, German, or Portuguese are accepted.
+ * For most other APIs, such as those for Custom Classification, Amazon
+ * Comprehend accepts text in all supported languages. For a list of supported
+ * languages, see <a>supported-languages</a>.
  * </p>
  */
 public class UnsupportedLanguageException extends AmazonServiceException {

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -26,6 +26,8 @@ import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.os.Build;
+import android.util.Log;
 import androidx.annotation.AnyThread;
 import androidx.annotation.WorkerThread;
 import androidx.browser.customtabs.CustomTabsCallback;
@@ -34,7 +36,6 @@ import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
 import androidx.core.content.ContextCompat;
-import android.util.Log;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
@@ -767,15 +768,12 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
      * @return true if permission to access network state is granted and network is connected.
      */
     protected boolean isNetworkAvailable(final Context context) {
-        try {
-            Class.forName("android.support.v4.content.ContextCompat");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             int hasReadExternalStoragePermission = ContextCompat.checkSelfPermission(context,
                     Manifest.permission.ACCESS_NETWORK_STATE);
             if (hasReadExternalStoragePermission != PackageManager.PERMISSION_GRANTED) {
                 return false;
             }
-        } catch (ClassNotFoundException e) {
-            Log.w(TAG, "Could not check if ACCESS_NETWORK_STATE permission is available.", e);
         }
 
         try {

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1133,13 +1133,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
 
     @AnyThread
     public void signIn(final String username,
-                       final Map<String, String> validationData,
-                       final Callback<SignInResult> callback) {
-        signIn(username, validationData, Collections.<String, String>emptyMap(), callback);
-    }
-
-    @AnyThread
-    public void signIn(final String username,
                        final String password,
                        final Map<String, String> validationData,
                        final Map<String, String> clientMetadata,
@@ -1149,27 +1142,11 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         internalCallback.async(_signIn(username, password, validationData, clientMetadata, internalCallback));
     }
 
-    @AnyThread
-    public void signIn(final String username,
-                       final Map<String, String> validationData,
-                       final Map<String, String> clientMetadata,
-                       final Callback<SignInResult> callback) {
-
-        final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>(callback);
-        internalCallback.async(_signIn(username, validationData, clientMetadata, internalCallback));
-    }
-
     @WorkerThread
     public SignInResult signIn(final String username,
                                final String password,
                                final Map<String, String> validationData) throws Exception {
         return signIn(username, password, validationData, Collections.<String, String>emptyMap());
-    }
-
-    @WorkerThread
-    public SignInResult signIn(final String username,
-                               final Map<String, String> validationData) throws Exception {
-        return signIn(username, validationData, Collections.<String, String>emptyMap());
     }
 
     @WorkerThread
@@ -1182,14 +1159,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         return internalCallback.await(_signIn(username, password, validationData, clientMetadata, internalCallback));
     }
 
-    @WorkerThread
-    public SignInResult signIn(final String username,
-                               final Map<String, String> validationData,
-                               final Map<String, String> clientMetadata) throws Exception {
-
-        final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>();
-        return internalCallback.await(_signIn(username, validationData, clientMetadata, internalCallback));
-    }
     private Runnable _signIn(final String username,
                              final String password,
                              final Map<String, String> validationData,
@@ -1242,7 +1211,11 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                             awsConfiguration.optJsonObject(AUTH_KEY).getString("authenticationFlowType").equals("CUSTOM_AUTH")
                                     ) {
                                         final HashMap<String, String> authParameters = new HashMap<String, String>();
-                                        authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, authParameters, validationData));
+                                        if(password != null){
+                                            authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, authParameters, validationData));
+                                        }else {
+                                            authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, authParameters, validationData));
+                                        }
                                     } else {
                                         authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, password, validationData));
                                     }
@@ -1297,109 +1270,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         };
     }
 
-    private Runnable _signIn(final String username,
-                             final Map<String, String> validationData,
-                             final Map<String, String> clientMetadata,
-                             final Callback<SignInResult> callback) {
-
-        this.signInCallback = callback;
-        signInState = null;
-        mStore.set(SIGN_IN_MODE, SignInMode.SIGN_IN.toString());
-
-        return new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    userpool.getUser(username).getSession(
-                      clientMetadata,
-                      new AuthenticationHandler() {
-                          @Override
-                          public void onSuccess(CognitoUserSession userSession, CognitoDevice newDevice) {
-                              try {
-                                  mCognitoUserSession = userSession;
-                                  signInState = SignInState.DONE;
-                              } catch (Exception e) {
-                                  signInCallback.onError(e);
-                                  signInCallback = null;
-                              }
-
-                              try {
-                                  if (isFederationEnabled()) {
-                                      federatedSignInWithoutAssigningState(userpoolsLoginKey, mCognitoUserSession.getIdToken().getJWTToken());
-                                  }
-
-                                  releaseSignInWait();
-                              } catch (Exception e) {
-                                  Log.w(TAG, "Failed to federate tokens during sign-in", e);
-                              } finally {
-                                  setUserState(new UserStateDetails(UserState.SIGNED_IN, getSignInDetailsMap()));
-                              }
-
-                              signInCallback.onResult(SignInResult.DONE);
-                          }
-
-                          @Override
-                          public void getAuthenticationDetails(AuthenticationContinuation authenticationContinuation, String userId) {
-                              Log.d(TAG, "Sending password.");
-                              try {
-                                  if (
-                                    awsConfiguration.optJsonObject(AUTH_KEY) != null &&
-                                      awsConfiguration.optJsonObject(AUTH_KEY).has("authenticationFlowType") &&
-                                      awsConfiguration.optJsonObject(AUTH_KEY).getString("authenticationFlowType").equals("CUSTOM_AUTH")
-                                  ) {
-                                      final HashMap<String, String> authParameters = new HashMap<String, String>();
-                                      authenticationContinuation.setAuthenticationDetails(new AuthenticationDetails(username, authParameters, validationData));
-                                  }
-                              } catch (JSONException e) {
-                                  e.printStackTrace();
-                              }
-
-                              authenticationContinuation.continueTask();
-                          }
-
-                          @Override
-                          public void getMFACode(MultiFactorAuthenticationContinuation continuation) {
-                              signInMfaContinuation = continuation;
-                              CognitoUserCodeDeliveryDetails parameters = continuation.getParameters();
-                              signInState = SignInState.SMS_MFA;
-                              signInCallback.onResult(
-                                new SignInResult(
-                                  SignInState.SMS_MFA,
-                                  new UserCodeDeliveryDetails(
-                                    parameters.getDestination(),
-                                    parameters.getDeliveryMedium(),
-                                    parameters.getAttributeName()
-                                  )
-                                )
-                              );
-                          }
-
-                          @Override
-                          public void authenticationChallenge(ChallengeContinuation continuation) {
-                              try {
-                                  signInState = SignInState.valueOf(continuation.getChallengeName());
-                                  signInChallengeContinuation = continuation;
-
-                                  signInCallback.onResult(new SignInResult(
-                                    signInState,
-                                    continuation.getParameters()));
-                              } catch (IllegalArgumentException e) {
-                                  signInCallback.onError(e);
-                              }
-                          }
-
-                          @Override
-                          public void onFailure(Exception exception) {
-                              signInCallback.onError(exception);
-                          }
-                      }
-                    );
-                } catch (Exception e) {
-                    callback.onError(e);
-                }
-            }
-        };
-    }
     @AnyThread
     public void confirmSignIn(final String signInChallengeResponse,
                               final Callback<SignInResult> callback) {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferDatabaseHelper.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferDatabaseHelper.java
@@ -27,6 +27,7 @@ class TransferDatabaseHelper extends SQLiteOpenHelper {
     // the database is being upgraded.
     private static final int DATABASE_VERSION = 6;
 
+    private final Context context;
     private int version;
 
     public TransferDatabaseHelper(Context context) {
@@ -35,6 +36,7 @@ class TransferDatabaseHelper extends SQLiteOpenHelper {
 
     public TransferDatabaseHelper(Context context, int version) {
         super(context, DATABASE_NAME, null, version);
+        this.context = context;
         this.version = version;
     }
 
@@ -48,4 +50,9 @@ class TransferDatabaseHelper extends SQLiteOpenHelper {
         TransferTable.onUpgrade(database, oldVersion, newVersion);
     }
 
+    @Override
+    public void onDowngrade(SQLiteDatabase database, int oldVersion, int newVersion) {
+        context.deleteDatabase(DATABASE_NAME);
+        onCreate(database);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

Custom challenge:
Custom authentication request currently assumes to include password always by default. There are no public apis to create a sign in request with out a password. Because of this, when a dummy password(though passwordless) is set to the _signIn() API, it **assumes** an authentication request **with password** downstream and always invokes  AuthenticationDetails() constructor with password as an argument because of which it further includes SRP_A as challenge parameter in the http request and the backend triggers the password trigger in IntiateAuth.

*Description of changes:*
  - Include public APIs to enable passwordless signin and add additional existing _signIn() method without "password" parameter so that it initiates the respective "AuthenticationDetails" constructor that does not set SRP_A.
https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html

In addition, include setting "AUTH_PARAM_USERNAME" (Authentication parameter) that is missing in second AuthenticationDetails constructor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
