### PR TITLE
Configure Apache HttpClient to perform hostname verification

### DIFF
--- a/aws-android-sdk-kinesisvideo/build.gradle
+++ b/aws-android-sdk-kinesisvideo/build.gradle
@@ -6,7 +6,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 21 // android.hardware.camera2
+        minSdkVersion 24 // https://developer.android.com/reference/javax/net/ssl/X509ExtendedTrustManager
         targetSdkVersion 29
         versionCode 21800
         versionName '2.18.0'
@@ -24,5 +24,6 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     //noinspection DuplicatePlatformClasses
     compileOnly 'org.apache.httpcomponents:httpclient:4.5.12'
+    testImplementation 'junit:junit:4.13'
 }
 

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/DistinguishedNameParser.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/DistinguishedNameParser.java
@@ -1,0 +1,392 @@
+package com.amazonaws.kinesisvideo.http;
+
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * A distinguished name (DN) parser. This parser only supports extracting a string value from a DN.
+ * It doesn't support values in the hex-string style.
+ *
+ * Adapted from https://github.com/square/okhttp/blob/okhttp_3.9.x/okhttp/src/main/java/okhttp3/internal/tls/DistinguishedNameParser.java
+ */
+final class DistinguishedNameParser {
+    private final String dn;
+    private final int length;
+    private int pos;
+    private int beg;
+    private int end;
+
+    /** Temporary variable to store positions of the currently parsed item. */
+    private int cur;
+
+    /** Distinguished name characters. */
+    private char[] chars;
+
+    DistinguishedNameParser(X500Principal principal) {
+        // RFC2253 is used to ensure we get attributes in the reverse
+        // order of the underlying ASN.1 encoding, so that the most
+        // significant values of repeated attributes occur first.
+        this.dn = principal.getName(X500Principal.RFC2253);
+        this.length = this.dn.length();
+    }
+
+    // gets next attribute type: (ALPHA 1*keychar) / oid
+    private String nextAT() {
+        // skip preceding space chars, they can present after
+        // comma or semicolon (compatibility with RFC 1779)
+        for (; pos < length && chars[pos] == ' '; pos++) {
+        }
+        if (pos == length) {
+            return null; // reached the end of DN
+        }
+
+        // mark the beginning of attribute type
+        beg = pos;
+
+        // attribute type chars
+        pos++;
+        for (; pos < length && chars[pos] != '=' && chars[pos] != ' '; pos++) {
+            // we don't follow exact BNF syntax here:
+            // accept any char except space and '='
+        }
+        if (pos >= length) {
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        // mark the end of attribute type
+        end = pos;
+
+        // skip trailing space chars between attribute type and '='
+        // (compatibility with RFC 1779)
+        if (chars[pos] == ' ') {
+            for (; pos < length && chars[pos] != '=' && chars[pos] == ' '; pos++) {
+            }
+
+            if (chars[pos] != '=' || pos == length) {
+                throw new IllegalStateException("Unexpected end of DN: " + dn);
+            }
+        }
+
+        pos++; //skip '=' char
+
+        // skip space chars between '=' and attribute value
+        // (compatibility with RFC 1779)
+        for (; pos < length && chars[pos] == ' '; pos++) {
+        }
+
+        // in case of oid attribute type skip its prefix: "oid." or "OID."
+        // (compatibility with RFC 1779)
+        if ((end - beg > 4) && (chars[beg + 3] == '.')
+                && (chars[beg] == 'O' || chars[beg] == 'o')
+                && (chars[beg + 1] == 'I' || chars[beg + 1] == 'i')
+                && (chars[beg + 2] == 'D' || chars[beg + 2] == 'd')) {
+            beg += 4;
+        }
+
+        return new String(chars, beg, end - beg);
+    }
+
+    // gets quoted attribute value: QUOTATION *( quotechar / pair ) QUOTATION
+    private String quotedAV() {
+        pos++;
+        beg = pos;
+        end = beg;
+        while (true) {
+
+            if (pos == length) {
+                throw new IllegalStateException("Unexpected end of DN: " + dn);
+            }
+
+            if (chars[pos] == '"') {
+                // enclosing quotation was found
+                pos++;
+                break;
+            } else if (chars[pos] == '\\') {
+                chars[end] = getEscaped();
+            } else {
+                // shift char: required for string with escaped chars
+                chars[end] = chars[pos];
+            }
+            pos++;
+            end++;
+        }
+
+        // skip trailing space chars before comma or semicolon.
+        // (compatibility with RFC 1779)
+        for (; pos < length && chars[pos] == ' '; pos++) {
+        }
+
+        return new String(chars, beg, end - beg);
+    }
+
+    // gets hex string attribute value: "#" hexstring
+    private String hexAV() {
+        if (pos + 4 >= length) {
+            // encoded byte array  must be not less then 4 c
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        beg = pos; // store '#' position
+        pos++;
+        while (true) {
+
+            // check for end of attribute value
+            // looks for space and component separators
+            if (pos == length || chars[pos] == '+' || chars[pos] == ','
+                    || chars[pos] == ';') {
+                end = pos;
+                break;
+            }
+
+            if (chars[pos] == ' ') {
+                end = pos;
+                pos++;
+                // skip trailing space chars before comma or semicolon.
+                // (compatibility with RFC 1779)
+                for (; pos < length && chars[pos] == ' '; pos++) {
+                }
+                break;
+            } else if (chars[pos] >= 'A' && chars[pos] <= 'F') {
+                chars[pos] += 32; //to low case
+            }
+
+            pos++;
+        }
+
+        // verify length of hex string
+        // encoded byte array  must be not less then 4 and must be even number
+        int hexLen = end - beg; // skip first '#' char
+        if (hexLen < 5 || (hexLen & 1) == 0) {
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        // get byte encoding from string representation
+        byte[] encoded = new byte[hexLen / 2];
+        for (int i = 0, p = beg + 1; i < encoded.length; p += 2, i++) {
+            encoded[i] = (byte) getByte(p);
+        }
+
+        return new String(chars, beg, hexLen);
+    }
+
+    // gets string attribute value: *( stringchar / pair )
+    private String escapedAV() {
+        beg = pos;
+        end = pos;
+        while (true) {
+            if (pos >= length) {
+                // the end of DN has been found
+                return new String(chars, beg, end - beg);
+            }
+
+            switch (chars[pos]) {
+                case '+':
+                case ',':
+                case ';':
+                    // separator char has been found
+                    return new String(chars, beg, end - beg);
+                case '\\':
+                    // escaped char
+                    chars[end++] = getEscaped();
+                    pos++;
+                    break;
+                case ' ':
+                    // need to figure out whether space defines
+                    // the end of attribute value or not
+                    cur = end;
+
+                    pos++;
+                    chars[end++] = ' ';
+
+                    for (; pos < length && chars[pos] == ' '; pos++) {
+                        chars[end++] = ' ';
+                    }
+                    if (pos == length || chars[pos] == ',' || chars[pos] == '+'
+                            || chars[pos] == ';') {
+                        // separator char or the end of DN has been found
+                        return new String(chars, beg, cur - beg);
+                    }
+                    break;
+                default:
+                    chars[end++] = chars[pos];
+                    pos++;
+            }
+        }
+    }
+
+    // returns escaped char
+    private char getEscaped() {
+        pos++;
+        if (pos == length) {
+            throw new IllegalStateException("Unexpected end of DN: " + dn);
+        }
+
+        switch (chars[pos]) {
+            case '"':
+            case '\\':
+            case ',':
+            case '=':
+            case '+':
+            case '<':
+            case '>':
+            case '#':
+            case ';':
+            case ' ':
+            case '*':
+            case '%':
+            case '_':
+                //FIXME: escaping is allowed only for leading or trailing space char
+                return chars[pos];
+            default:
+                // RFC doesn't explicitly say that escaped hex pair is
+                // interpreted as UTF-8 char. It only contains an example of such DN.
+                return getUTF8();
+        }
+    }
+
+    // decodes UTF-8 char
+    // see http://www.unicode.org for UTF-8 bit distribution table
+    private char getUTF8() {
+        int res = getByte(pos);
+        pos++; //FIXME tmp
+
+        if (res < 128) { // one byte: 0-7F
+            return (char) res;
+        } else if (res >= 192 && res <= 247) {
+
+            int count;
+            if (res <= 223) { // two bytes: C0-DF
+                count = 1;
+                res = res & 0x1F;
+            } else if (res <= 239) { // three bytes: E0-EF
+                count = 2;
+                res = res & 0x0F;
+            } else { // four bytes: F0-F7
+                count = 3;
+                res = res & 0x07;
+            }
+
+            int b;
+            for (int i = 0; i < count; i++) {
+                pos++;
+                if (pos == length || chars[pos] != '\\') {
+                    return 0x3F; //FIXME failed to decode UTF-8 char - return '?'
+                }
+                pos++;
+
+                b = getByte(pos);
+                pos++; //FIXME tmp
+                if ((b & 0xC0) != 0x80) {
+                    return 0x3F; //FIXME failed to decode UTF-8 char - return '?'
+                }
+
+                res = (res << 6) + (b & 0x3F);
+            }
+            return (char) res;
+        } else {
+            return 0x3F; //FIXME failed to decode UTF-8 char - return '?'
+        }
+    }
+
+    // Returns byte representation of a char pair
+    // The char pair is composed of DN char in
+    // specified 'position' and the next char
+    // According to BNF syntax:
+    // hexchar    = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+    //                    / "a" / "b" / "c" / "d" / "e" / "f"
+    private int getByte(int position) {
+        if (position + 1 >= length) {
+            throw new IllegalStateException("Malformed DN: " + dn);
+        }
+
+        int b1, b2;
+
+        b1 = chars[position];
+        if (b1 >= '0' && b1 <= '9') {
+            b1 = b1 - '0';
+        } else if (b1 >= 'a' && b1 <= 'f') {
+            b1 = b1 - 87; // 87 = 'a' - 10
+        } else if (b1 >= 'A' && b1 <= 'F') {
+            b1 = b1 - 55; // 55 = 'A' - 10
+        } else {
+            throw new IllegalStateException("Malformed DN: " + dn);
+        }
+
+        b2 = chars[position + 1];
+        if (b2 >= '0' && b2 <= '9') {
+            b2 = b2 - '0';
+        } else if (b2 >= 'a' && b2 <= 'f') {
+            b2 = b2 - 87; // 87 = 'a' - 10
+        } else if (b2 >= 'A' && b2 <= 'F') {
+            b2 = b2 - 55; // 55 = 'A' - 10
+        } else {
+            throw new IllegalStateException("Malformed DN: " + dn);
+        }
+
+        return (b1 << 4) + b2;
+    }
+
+    /**
+     * Parses the DN and returns the most significant attribute value for an attribute type, or null
+     * if none found.
+     *
+     * @param attributeType attribute type to look for (e.g. "ca")
+     */
+    public String findMostSpecific(String attributeType) {
+        // Initialize internal state.
+        pos = 0;
+        beg = 0;
+        end = 0;
+        cur = 0;
+        chars = dn.toCharArray();
+
+        String attType = nextAT();
+        if (attType == null) {
+            return null;
+        }
+        while (true) {
+            String attValue = "";
+
+            if (pos == length) {
+                return null;
+            }
+
+            switch (chars[pos]) {
+                case '"':
+                    attValue = quotedAV();
+                    break;
+                case '#':
+                    attValue = hexAV();
+                    break;
+                case '+':
+                case ',':
+                case ';': // compatibility with RFC 1779: semicolon can separate RDNs
+                    //empty attribute value
+                    break;
+                default:
+                    attValue = escapedAV();
+            }
+
+            // Values are ordered from most specific to least specific
+            // due to the RFC2253 formatting. So take the first match
+            // we see.
+            if (attributeType.equalsIgnoreCase(attType)) {
+                return attValue;
+            }
+
+            if (pos >= length) {
+                return null;
+            }
+
+            if (chars[pos] == ',' || chars[pos] == ';') {
+            } else if (chars[pos] != '+') {
+                throw new IllegalStateException("Malformed DN: " + dn);
+            }
+
+            pos++;
+            attType = nextAT();
+            if (attType == null) {
+                throw new IllegalStateException("Malformed DN: " + dn);
+            }
+        }
+    }
+}

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifier.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifier.java
@@ -1,0 +1,225 @@
+package com.amazonaws.kinesisvideo.http;
+
+import java.security.cert.Certificate;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * A HostnameVerifier consistent with <a href="http://www.ietf.org/rfc/rfc2818.txt">RFC 2818</a>.
+ * Adapted from https://github.com/square/okhttp/blob/okhttp_3.9.x/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
+ */
+public final class HostnameVerifier implements javax.net.ssl.HostnameVerifier {
+    public static final HostnameVerifier INSTANCE = new HostnameVerifier();
+
+    private static final int ALT_DNS_NAME = 2;
+    private static final int ALT_IPA_NAME = 7;
+
+    /**
+     * Quick and dirty pattern to differentiate IP addresses from hostnames. This is an approximation
+     * of Android's private InetAddress#isNumeric API.
+     *
+     * <p>This matches IPv6 addresses as a hex string containing at least one colon, and possibly
+     * including dots after the first colon. It matches IPv4 addresses as strings containing only
+     * decimal digits and dots. This pattern matches strings like "a:.23" and "54" that are neither IP
+     * addresses nor hostnames; they will be verified as IP addresses (which is a more strict
+     * verification).
+     */
+    private static final Pattern VERIFY_AS_IP_ADDRESS = Pattern.compile(
+            "([0-9a-fA-F]*:[0-9a-fA-F:.]*)|([\\d.]+)");
+
+    private HostnameVerifier() {
+    }
+
+    @Override
+    public boolean verify(String host, SSLSession session) {
+        try {
+            Certificate[] certificates = session.getPeerCertificates();
+            return verify(host, (X509Certificate) certificates[0]);
+        } catch (SSLException e) {
+            return false;
+        }
+    }
+
+    public boolean verify(String host, X509Certificate certificate) {
+        return VERIFY_AS_IP_ADDRESS.matcher(host).matches()
+                ? verifyIpAddress(host, certificate)
+                : verifyHostname(host, certificate);
+    }
+
+    /** Returns true if {@code certificate} matches {@code ipAddress}. */
+    private boolean verifyIpAddress(String ipAddress, X509Certificate certificate) {
+        List<String> altNames = getSubjectAltNames(certificate, ALT_IPA_NAME);
+        for (int i = 0, size = altNames.size(); i < size; i++) {
+            if (ipAddress.equalsIgnoreCase(altNames.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Returns true if {@code certificate} matches {@code hostname}. */
+    private boolean verifyHostname(String hostname, X509Certificate certificate) {
+        hostname = hostname.toLowerCase(Locale.US);
+        boolean hasDns = false;
+        List<String> altNames = getSubjectAltNames(certificate, ALT_DNS_NAME);
+        for (int i = 0, size = altNames.size(); i < size; i++) {
+            hasDns = true;
+            if (verifyHostname(hostname, altNames.get(i))) {
+                return true;
+            }
+        }
+
+        if (!hasDns) {
+            X500Principal principal = certificate.getSubjectX500Principal();
+            // RFC 2818 advises using the most specific name for matching.
+            String cn = new DistinguishedNameParser(principal).findMostSpecific("cn");
+            if (cn != null) {
+                return verifyHostname(hostname, cn);
+            }
+        }
+
+        return false;
+    }
+
+    public static List<String> allSubjectAltNames(X509Certificate certificate) {
+        List<String> altIpaNames = getSubjectAltNames(certificate, ALT_IPA_NAME);
+        List<String> altDnsNames = getSubjectAltNames(certificate, ALT_DNS_NAME);
+        List<String> result = new ArrayList<>(altIpaNames.size() + altDnsNames.size());
+        result.addAll(altIpaNames);
+        result.addAll(altDnsNames);
+        return result;
+    }
+
+    private static List<String> getSubjectAltNames(X509Certificate certificate, int type) {
+        List<String> result = new ArrayList<>();
+        try {
+            Collection<?> subjectAltNames = certificate.getSubjectAlternativeNames();
+            if (subjectAltNames == null) {
+                return Collections.emptyList();
+            }
+            for (Object subjectAltName : subjectAltNames) {
+                List<?> entry = (List<?>) subjectAltName;
+                if (entry == null || entry.size() < 2) {
+                    continue;
+                }
+                Integer altNameType = (Integer) entry.get(0);
+                if (altNameType == null) {
+                    continue;
+                }
+                if (altNameType == type) {
+                    String altName = (String) entry.get(1);
+                    if (altName != null) {
+                        result.add(altName);
+                    }
+                }
+            }
+            return result;
+        } catch (CertificateParsingException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Returns {@code true} iff {@code hostname} matches the domain name {@code pattern}.
+     *
+     * @param hostname lower-case host name.
+     * @param pattern domain name pattern from certificate. May be a wildcard pattern such as {@code
+     * *.android.com}.
+     */
+    public boolean verifyHostname(String hostname, String pattern) {
+        // Basic sanity checks
+        // Check length == 0 instead of .isEmpty() to support Java 5.
+        if ((hostname == null) || (hostname.length() == 0) || (hostname.startsWith("."))
+                || (hostname.endsWith(".."))) {
+            // Invalid domain name
+            return false;
+        }
+        if ((pattern == null) || (pattern.length() == 0) || (pattern.startsWith("."))
+                || (pattern.endsWith(".."))) {
+            // Invalid pattern/domain name
+            return false;
+        }
+
+        // Normalize hostname and pattern by turning them into absolute domain names if they are not
+        // yet absolute. This is needed because server certificates do not normally contain absolute
+        // names or patterns, but they should be treated as absolute. At the same time, any hostname
+        // presented to this method should also be treated as absolute for the purposes of matching
+        // to the server certificate.
+        //   www.android.com  matches www.android.com
+        //   www.android.com  matches www.android.com.
+        //   www.android.com. matches www.android.com.
+        //   www.android.com. matches www.android.com
+        if (!hostname.endsWith(".")) {
+            hostname += '.';
+        }
+        if (!pattern.endsWith(".")) {
+            pattern += '.';
+        }
+        // hostname and pattern are now absolute domain names.
+
+        pattern = pattern.toLowerCase(Locale.US);
+        // hostname and pattern are now in lower case -- domain names are case-insensitive.
+
+        if (!pattern.contains("*")) {
+            // Not a wildcard pattern -- hostname and pattern must match exactly.
+            return hostname.equals(pattern);
+        }
+        // Wildcard pattern
+
+        // WILDCARD PATTERN RULES:
+        // 1. Asterisk (*) is only permitted in the left-most domain name label and must be the
+        //    only character in that label (i.e., must match the whole left-most label).
+        //    For example, *.example.com is permitted, while *a.example.com, a*.example.com,
+        //    a*b.example.com, a.*.example.com are not permitted.
+        // 2. Asterisk (*) cannot match across domain name labels.
+        //    For example, *.example.com matches test.example.com but does not match
+        //    sub.test.example.com.
+        // 3. Wildcard patterns for single-label domain names are not permitted.
+
+        if ((!pattern.startsWith("*.")) || (pattern.indexOf('*', 1) != -1)) {
+            // Asterisk (*) is only permitted in the left-most domain name label and must be the only
+            // character in that label
+            return false;
+        }
+
+        // Optimization: check whether hostname is too short to match the pattern. hostName must be at
+        // least as long as the pattern because asterisk must match the whole left-most label and
+        // hostname starts with a non-empty label. Thus, asterisk has to match one or more characters.
+        if (hostname.length() < pattern.length()) {
+            // hostname too short to match the pattern.
+            return false;
+        }
+
+        if ("*.".equals(pattern)) {
+            // Wildcard pattern for single-label domain name -- not permitted.
+            return false;
+        }
+
+        // hostname must end with the region of pattern following the asterisk.
+        String suffix = pattern.substring(1);
+        if (!hostname.endsWith(suffix)) {
+            // hostname does not end with the suffix
+            return false;
+        }
+
+        // Check that asterisk did not match across domain name labels.
+        int suffixStartIndexInHostname = hostname.length() - suffix.length();
+        if ((suffixStartIndexInHostname > 0)
+                && (hostname.lastIndexOf('.', suffixStartIndexInHostname - 1) != -1)) {
+            // Asterisk is matching across domain name labels -- not permitted.
+            return false;
+        }
+
+        // hostname matches pattern
+        return true;
+    }
+}

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManager.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManager.java
@@ -1,0 +1,234 @@
+package com.amazonaws.kinesisvideo.http;
+
+import com.amazonaws.kinesisvideo.common.logging.Log;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/*
+     Adapted from (Apache 2.0 License):
+
+     https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/common/
+     ZKTrustManager.java
+
+     A custom TrustManager that supports hostname verification via org.apache.http.conn.ssl.DefaultHostnameVerifier.
+     *
+     * We attempt to perform verification using just the IP address first and if that fails will attempt to perform a
+     * reverse DNS lookup and verify using the hostname.
+*/
+
+public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrustManager {
+
+    private static final HostnameVerifier DEFAULT_HOSTNAME_VERIFIER = HostnameVerifier.INSTANCE;
+    private Log log = new Log(Log.SYSTEM_OUT);
+    private final boolean clientSideHostnameVerificationEnabled;
+
+    private final X509ExtendedTrustManager x509ExtendedTrustManager;
+
+    public HostnameVerifyingX509ExtendedTrustManager(final boolean clientSideHostnameVerificationEnabled) {
+        this.x509ExtendedTrustManager = getX509ExtendedTrustManager();
+        this.clientSideHostnameVerificationEnabled = clientSideHostnameVerificationEnabled;
+    }
+
+    private X509ExtendedTrustManager getX509ExtendedTrustManager() {
+        TrustManagerFactory factory;
+        try {
+            factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            factory.init((KeyStore) null);
+        } catch (NoSuchAlgorithmException nsae) {
+            log.error("Unable to initialize default TrustManagerFactory, using no-op X509ExtendedTrustManager", nsae);
+            return getNoOpInstance();
+        } catch (KeyStoreException nse) {
+            log.error("Unable to initialize default TrustManagerFactory, using no-op X509ExtendedTrustManager", nse);
+            return getNoOpInstance();
+        }
+
+        for (TrustManager tm: factory.getTrustManagers()) {
+            if (tm instanceof X509ExtendedTrustManager) {
+                return (X509ExtendedTrustManager) tm;
+            }
+        }
+
+        log.debug("No default X509TrustManager found, using no-op");
+        return getNoOpInstance();
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return x509ExtendedTrustManager.getAcceptedIssuers();
+    }
+
+    @Override
+    public void checkClientTrusted(
+            final X509Certificate[] chain,
+            final String authType,
+            final Socket socket) throws CertificateException {
+        x509ExtendedTrustManager.checkClientTrusted(chain, authType, socket);
+        if (clientSideHostnameVerificationEnabled) {
+            performHostVerification(socket.getInetAddress(), chain[0]);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(
+            final X509Certificate[] chain,
+            final String authType,
+            final Socket socket) throws CertificateException {
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType, socket);
+        performHostVerification(socket.getInetAddress(), chain[0]);
+    }
+
+    @Override
+    public void checkClientTrusted(
+            final X509Certificate[] chain,
+            final String authType,
+            final SSLEngine engine) throws CertificateException {
+        x509ExtendedTrustManager.checkClientTrusted(chain, authType, engine);
+        if (clientSideHostnameVerificationEnabled) {
+            try {
+                performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
+            } catch (UnknownHostException e) {
+                throw new CertificateException("Failed to verify host", e);
+            }
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(
+            final X509Certificate[] chain,
+            final String authType,
+            final SSLEngine engine) throws CertificateException {
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType, engine);
+        try {
+            performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
+        } catch (UnknownHostException e) {
+            throw new CertificateException("Failed to verify host", e);
+        }
+    }
+
+    @Override
+    public void checkClientTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
+        x509ExtendedTrustManager.checkClientTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
+        x509ExtendedTrustManager.checkServerTrusted(chain, authType);
+    }
+
+    /**
+     * Compares peer's hostname with the one stored in the provided client certificate. Performs verification
+     * with the help of provided HostnameVerifier.
+     *
+     * @param inetAddress Peer's inet address.
+     * @param certificate Peer's certificate
+     * @throws CertificateException Thrown if the provided certificate doesn't match the peer hostname.
+     */
+    public void performHostVerification(
+            final InetAddress inetAddress,
+            final X509Certificate certificate
+    ) throws CertificateException {
+        performHostVerification(inetAddress.getHostAddress(), inetAddress.getHostName(), certificate);
+    }
+
+    /**
+     * Compares peer's hostname with the one stored in the provided client certificate. Performs verification
+     * with the help of provided HostnameVerifier.
+     *
+     * @param hostAddress Peer's host address.
+     * @param hostName Peer's host name.
+     * @param certificate Peer's certificate
+     * @throws CertificateException Thrown if the provided certificate doesn't match the peer hostname.
+     */
+    public void performHostVerification(
+            final String hostAddress,
+            final String hostName,
+            final X509Certificate certificate
+    ) throws CertificateException {
+        if (DEFAULT_HOSTNAME_VERIFIER.verify(hostAddress, certificate)) {
+            return;
+        }
+
+        log.debug(
+                "Failed to verify host address: {} attempting to verify host name with reverse dns lookup",
+                hostAddress);
+
+        if (DEFAULT_HOSTNAME_VERIFIER.verify(hostName, certificate)) {
+            return;
+        }
+
+        log.error("Failed to verify host address: %s", hostAddress);
+        log.error("Failed to verify hostname: %s", hostName);
+        throw new CertificateException("Failed to verify both host address and host name");
+    }
+
+
+    private X509ExtendedTrustManager getNoOpInstance() {
+        return new X509ExtendedTrustManager() {
+            @Override
+            public void checkClientTrusted(
+                    final X509Certificate[] x509Certificates,
+                    final String s,
+                    final Socket socket)
+                    throws CertificateException {
+
+            }
+
+            @Override
+            public void checkServerTrusted(
+                    final X509Certificate[] x509Certificates,
+                    final String s,
+                    final Socket socket)
+                    throws CertificateException {
+
+            }
+
+            @Override
+            public void checkClientTrusted(
+                    final X509Certificate[] x509Certificates,
+                    final String s,
+                    final SSLEngine sslEngine)
+                    throws CertificateException {
+
+            }
+
+            @Override
+            public void checkServerTrusted(
+                    final X509Certificate[] x509Certificates,
+                    final String s,
+                    final SSLEngine sslEngine)
+                    throws CertificateException {
+
+            }
+
+            @Override
+            public void checkClientTrusted(
+                    final X509Certificate[] x509Certificates,
+                    final String s) throws CertificateException {
+
+            }
+
+            @Override
+            public void checkServerTrusted(
+                    final X509Certificate[] x509Certificates,
+                    final String s) throws CertificateException {
+
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+    }
+
+}

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManager.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManager.java
@@ -45,11 +45,9 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
             factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             factory.init((KeyStore) null);
         } catch (NoSuchAlgorithmException nsae) {
-            log.error("Unable to initialize default TrustManagerFactory, using no-op X509ExtendedTrustManager", nsae);
-            return getNoOpInstance();
+            throw new RuntimeException("Unable to initialize default TrustManagerFactory", nsae);
         } catch (KeyStoreException nse) {
-            log.error("Unable to initialize default TrustManagerFactory, using no-op X509ExtendedTrustManager", nse);
-            return getNoOpInstance();
+            throw new RuntimeException("Unable to initialize default TrustManagerFactory", nse);
         }
 
         for (TrustManager tm: factory.getTrustManagers()) {
@@ -58,8 +56,7 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
             }
         }
 
-        log.debug("No default X509TrustManager found, using no-op");
-        return getNoOpInstance();
+        throw new RuntimeException("No default X509TrustManager found");
     }
 
     @Override
@@ -170,65 +167,4 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
         log.error("Failed to verify hostname: %s", hostName);
         throw new CertificateException("Failed to verify both host address and host name");
     }
-
-
-    private X509ExtendedTrustManager getNoOpInstance() {
-        return new X509ExtendedTrustManager() {
-            @Override
-            public void checkClientTrusted(
-                    final X509Certificate[] x509Certificates,
-                    final String s,
-                    final Socket socket)
-                    throws CertificateException {
-
-            }
-
-            @Override
-            public void checkServerTrusted(
-                    final X509Certificate[] x509Certificates,
-                    final String s,
-                    final Socket socket)
-                    throws CertificateException {
-
-            }
-
-            @Override
-            public void checkClientTrusted(
-                    final X509Certificate[] x509Certificates,
-                    final String s,
-                    final SSLEngine sslEngine)
-                    throws CertificateException {
-
-            }
-
-            @Override
-            public void checkServerTrusted(
-                    final X509Certificate[] x509Certificates,
-                    final String s,
-                    final SSLEngine sslEngine)
-                    throws CertificateException {
-
-            }
-
-            @Override
-            public void checkClientTrusted(
-                    final X509Certificate[] x509Certificates,
-                    final String s) throws CertificateException {
-
-            }
-
-            @Override
-            public void checkServerTrusted(
-                    final X509Certificate[] x509Certificates,
-                    final String s) throws CertificateException {
-
-            }
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return new X509Certificate[0];
-            }
-        };
-    }
-
 }

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/socket/SocketFactory.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/kinesisvideo/socket/SocketFactory.java
@@ -17,16 +17,16 @@
 
 package com.amazonaws.kinesisvideo.socket;
 
+import com.amazonaws.kinesisvideo.http.HostnameVerifyingX509ExtendedTrustManager;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 
 public class SocketFactory {
     private static final int DEFAULT_HTTP_PORT = 80;
@@ -52,27 +52,10 @@ public class SocketFactory {
 
     private Socket createSslSocket(final InetAddress address, final int port) throws Exception {
         final SSLContext context = SSLContext.getInstance("TLSv1.2");
-        context.init(NO_KEY_MANAGERS, trustAllCertificates(), new SecureRandom());
+        context.init(NO_KEY_MANAGERS, new X509ExtendedTrustManager[] {
+                                new HostnameVerifyingX509ExtendedTrustManager(true)}, new SecureRandom());
         return context.getSocketFactory().createSocket(address, port);
 
-    }
-
-    public TrustManager[] trustAllCertificates() {
-        return new TrustManager[]{
-                new X509TrustManager() {
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return new X509Certificate[0];
-                    }
-
-                    public void checkClientTrusted(final X509Certificate[] certs, final String authType) {
-
-                    }
-
-                    public void checkServerTrusted(final X509Certificate[] certs, final String authType) {
-
-                    }
-                }
-        };
     }
 
     private boolean isHttps(final URI uri) {

--- a/aws-android-sdk-kinesisvideo/src/test/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManagerTest.java
+++ b/aws-android-sdk-kinesisvideo/src/test/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManagerTest.java
@@ -1,0 +1,253 @@
+package com.amazonaws.kinesisvideo.http;
+
+import org.junit.Before;
+import org.junit.Test;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+/**
+ * Adapted from (Apache 2.0 License):
+ * https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/test/java/org/apache/zookeeper/common/ZKHostnameVerifierTest.java
+ */
+public class HostnameVerifyingX509ExtendedTrustManagerTest {
+    /**
+     * CN=foo.com
+     */
+    public final static byte[] X509_FOO = (
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIERjCCAy6gAwIBAgIJAIz+EYMBU6aQMA0GCSqGSIb3DQEBBQUAMIGiMQswCQYD\n" +
+                    "VQQGEwJDQTELMAkGA1UECBMCQkMxEjAQBgNVBAcTCVZhbmNvdXZlcjEWMBQGA1UE\n" +
+                    "ChMNd3d3LmN1Y2JjLmNvbTEUMBIGA1UECxQLY29tbW9uc19zc2wxHTAbBgNVBAMU\n" +
+                    "FGRlbW9faW50ZXJtZWRpYXRlX2NhMSUwIwYJKoZIhvcNAQkBFhZqdWxpdXNkYXZp\n" +
+                    "ZXNAZ21haWwuY29tMB4XDTA2MTIxMTE1MzE0MVoXDTI4MTEwNTE1MzE0MVowgaQx\n" +
+                    "CzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDEUMBIGA1UEBxMLRm9yZXN0\n" +
+                    "IEhpbGwxFzAVBgNVBAoTDmh0dHBjb21wb25lbnRzMRowGAYDVQQLExF0ZXN0IGNl\n" +
+                    "cnRpZmljYXRlczEQMA4GA1UEAxMHZm9vLmNvbTElMCMGCSqGSIb3DQEJARYWanVs\n" +
+                    "aXVzZGF2aWVzQGdtYWlsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\n" +
+                    "ggEBAMhjr5aCPoyp0R1iroWAfnEyBMGYWoCidH96yGPFjYLowez5aYKY1IOKTY2B\n" +
+                    "lYho4O84X244QrZTRl8kQbYtxnGh4gSCD+Z8gjZ/gMvLUlhqOb+WXPAUHMB39GRy\n" +
+                    "zerA/ZtrlUqf+lKo0uWcocxeRc771KN8cPH3nHZ0rV0Hx4ZAZy6U4xxObe4rtSVY\n" +
+                    "07hNKXAb2odnVqgzcYiDkLV8ilvEmoNWMWrp8UBqkTcpEhYhCYp3cTkgJwMSuqv8\n" +
+                    "BqnGd87xQU3FVZI4tbtkB+KzjD9zz8QCDJAfDjZHR03KNQ5mxOgXwxwKw6lGMaiV\n" +
+                    "JTxpTKqym93whYk93l3ocEe55c0CAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgB\n" +
+                    "hvhCAQ0EHxYdT3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYE\n" +
+                    "FJ8Ud78/OrbKOIJCSBYs2tDLXofYMB8GA1UdIwQYMBaAFHua2o+QmU5S0qzbswNS\n" +
+                    "yoemDT4NMA0GCSqGSIb3DQEBBQUAA4IBAQC3jRmEya6sQCkmieULcvx8zz1euCk9\n" +
+                    "fSez7BEtki8+dmfMXe3K7sH0lI8f4jJR0rbSCjpmCQLYmzC3NxBKeJOW0RcjNBpO\n" +
+                    "c2JlGO9auXv2GDP4IYiXElLJ6VSqc8WvDikv0JmCCWm0Zga+bZbR/EWN5DeEtFdF\n" +
+                    "815CLpJZNcYwiYwGy/CVQ7w2TnXlG+mraZOz+owr+cL6J/ZesbdEWfjoS1+cUEhE\n" +
+                    "HwlNrAu8jlZ2UqSgskSWlhYdMTAP9CPHiUv9N7FcT58Itv/I4fKREINQYjDpvQcx\n" +
+                    "SaTYb9dr5sB4WLNglk7zxDtM80H518VvihTcP7FHL+Gn6g4j5fkI98+S\n" +
+                    "-----END CERTIFICATE-----\n").getBytes();
+
+    /**
+     * CN=foo.com, subjectAlt=bar.com
+     */
+    public final static byte[] X509_FOO_BAR = (
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIEXDCCA0SgAwIBAgIJAIz+EYMBU6aRMA0GCSqGSIb3DQEBBQUAMIGiMQswCQYD\n" +
+                    "VQQGEwJDQTELMAkGA1UECBMCQkMxEjAQBgNVBAcTCVZhbmNvdXZlcjEWMBQGA1UE\n" +
+                    "ChMNd3d3LmN1Y2JjLmNvbTEUMBIGA1UECxQLY29tbW9uc19zc2wxHTAbBgNVBAMU\n" +
+                    "FGRlbW9faW50ZXJtZWRpYXRlX2NhMSUwIwYJKoZIhvcNAQkBFhZqdWxpdXNkYXZp\n" +
+                    "ZXNAZ21haWwuY29tMB4XDTA2MTIxMTE1MzYyOVoXDTI4MTEwNTE1MzYyOVowgaQx\n" +
+                    "CzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDEUMBIGA1UEBxMLRm9yZXN0\n" +
+                    "IEhpbGwxFzAVBgNVBAoTDmh0dHBjb21wb25lbnRzMRowGAYDVQQLExF0ZXN0IGNl\n" +
+                    "cnRpZmljYXRlczEQMA4GA1UEAxMHZm9vLmNvbTElMCMGCSqGSIb3DQEJARYWanVs\n" +
+                    "aXVzZGF2aWVzQGdtYWlsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\n" +
+                    "ggEBAMhjr5aCPoyp0R1iroWAfnEyBMGYWoCidH96yGPFjYLowez5aYKY1IOKTY2B\n" +
+                    "lYho4O84X244QrZTRl8kQbYtxnGh4gSCD+Z8gjZ/gMvLUlhqOb+WXPAUHMB39GRy\n" +
+                    "zerA/ZtrlUqf+lKo0uWcocxeRc771KN8cPH3nHZ0rV0Hx4ZAZy6U4xxObe4rtSVY\n" +
+                    "07hNKXAb2odnVqgzcYiDkLV8ilvEmoNWMWrp8UBqkTcpEhYhCYp3cTkgJwMSuqv8\n" +
+                    "BqnGd87xQU3FVZI4tbtkB+KzjD9zz8QCDJAfDjZHR03KNQ5mxOgXwxwKw6lGMaiV\n" +
+                    "JTxpTKqym93whYk93l3ocEe55c0CAwEAAaOBkDCBjTAJBgNVHRMEAjAAMCwGCWCG\n" +
+                    "SAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4E\n" +
+                    "FgQUnxR3vz86tso4gkJIFiza0Mteh9gwHwYDVR0jBBgwFoAUe5raj5CZTlLSrNuz\n" +
+                    "A1LKh6YNPg0wEgYDVR0RBAswCYIHYmFyLmNvbTANBgkqhkiG9w0BAQUFAAOCAQEA\n" +
+                    "dQyprNZBmVnvuVWjV42sey/PTfkYShJwy1j0/jcFZR/ypZUovpiHGDO1DgL3Y3IP\n" +
+                    "zVQ26uhUsSw6G0gGRiaBDe/0LUclXZoJzXX1qpS55OadxW73brziS0sxRgGrZE/d\n" +
+                    "3g5kkio6IED47OP6wYnlmZ7EKP9cqjWwlnvHnnUcZ2SscoLNYs9rN9ccp8tuq2by\n" +
+                    "88OyhKwGjJfhOudqfTNZcDzRHx4Fzm7UsVaycVw4uDmhEHJrAsmMPpj/+XRK9/42\n" +
+                    "2xq+8bc6HojdtbCyug/fvBZvZqQXSmU8m8IVcMmWMz0ZQO8ee3QkBHMZfCy7P/kr\n" +
+                    "VbWx/uETImUu+NZg22ewEw==\n" +
+                    "-----END CERTIFICATE-----\n").getBytes();
+
+
+    /**
+     * CN=*.foo.com
+     */
+    public final static byte[] X509_WILD_FOO = (
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIESDCCAzCgAwIBAgIJAIz+EYMBU6aUMA0GCSqGSIb3DQEBBQUAMIGiMQswCQYD\n" +
+                    "VQQGEwJDQTELMAkGA1UECBMCQkMxEjAQBgNVBAcTCVZhbmNvdXZlcjEWMBQGA1UE\n" +
+                    "ChMNd3d3LmN1Y2JjLmNvbTEUMBIGA1UECxQLY29tbW9uc19zc2wxHTAbBgNVBAMU\n" +
+                    "FGRlbW9faW50ZXJtZWRpYXRlX2NhMSUwIwYJKoZIhvcNAQkBFhZqdWxpdXNkYXZp\n" +
+                    "ZXNAZ21haWwuY29tMB4XDTA2MTIxMTE2MTU1NVoXDTI4MTEwNTE2MTU1NVowgaYx\n" +
+                    "CzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDEUMBIGA1UEBxMLRm9yZXN0\n" +
+                    "IEhpbGwxFzAVBgNVBAoTDmh0dHBjb21wb25lbnRzMRowGAYDVQQLExF0ZXN0IGNl\n" +
+                    "cnRpZmljYXRlczESMBAGA1UEAxQJKi5mb28uY29tMSUwIwYJKoZIhvcNAQkBFhZq\n" +
+                    "dWxpdXNkYXZpZXNAZ21haWwuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\n" +
+                    "CgKCAQEAyGOvloI+jKnRHWKuhYB+cTIEwZhagKJ0f3rIY8WNgujB7PlpgpjUg4pN\n" +
+                    "jYGViGjg7zhfbjhCtlNGXyRBti3GcaHiBIIP5nyCNn+Ay8tSWGo5v5Zc8BQcwHf0\n" +
+                    "ZHLN6sD9m2uVSp/6UqjS5ZyhzF5FzvvUo3xw8fecdnStXQfHhkBnLpTjHE5t7iu1\n" +
+                    "JVjTuE0pcBvah2dWqDNxiIOQtXyKW8Sag1YxaunxQGqRNykSFiEJindxOSAnAxK6\n" +
+                    "q/wGqcZ3zvFBTcVVkji1u2QH4rOMP3PPxAIMkB8ONkdHTco1DmbE6BfDHArDqUYx\n" +
+                    "qJUlPGlMqrKb3fCFiT3eXehwR7nlzQIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCG\n" +
+                    "SAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4E\n" +
+                    "FgQUnxR3vz86tso4gkJIFiza0Mteh9gwHwYDVR0jBBgwFoAUe5raj5CZTlLSrNuz\n" +
+                    "A1LKh6YNPg0wDQYJKoZIhvcNAQEFBQADggEBAH0ipG6J561UKUfgkeW7GvYwW98B\n" +
+                    "N1ZooWX+JEEZK7+Pf/96d3Ij0rw9ACfN4bpfnCq0VUNZVSYB+GthQ2zYuz7tf/UY\n" +
+                    "A6nxVgR/IjG69BmsBl92uFO7JTNtHztuiPqBn59pt+vNx4yPvno7zmxsfI7jv0ww\n" +
+                    "yfs+0FNm7FwdsC1k47GBSOaGw38kuIVWqXSAbL4EX9GkryGGOKGNh0qvAENCdRSB\n" +
+                    "G9Z6tyMbmfRY+dLSh3a9JwoEcBUso6EWYBakLbq4nG/nvYdYvG9ehrnLVwZFL82e\n" +
+                    "l3Q/RK95bnA6cuRClGusLad0e6bjkBzx/VQ3VarDEpAkTLUGVAa0CLXtnyc=\n" +
+                    "-----END CERTIFICATE-----\n").getBytes();
+
+    /**
+     * subjectAlt=foo.com
+     */
+    public final static byte[] X509_NO_CNS_FOO = (
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIIESjCCAzKgAwIBAgIJAIz+EYMBU6aYMA0GCSqGSIb3DQEBBQUAMIGiMQswCQYD\n" +
+                    "VQQGEwJDQTELMAkGA1UECBMCQkMxEjAQBgNVBAcTCVZhbmNvdXZlcjEWMBQGA1UE\n" +
+                    "ChMNd3d3LmN1Y2JjLmNvbTEUMBIGA1UECxQLY29tbW9uc19zc2wxHTAbBgNVBAMU\n" +
+                    "FGRlbW9faW50ZXJtZWRpYXRlX2NhMSUwIwYJKoZIhvcNAQkBFhZqdWxpdXNkYXZp\n" +
+                    "ZXNAZ21haWwuY29tMB4XDTA2MTIxMTE2MjYxMFoXDTI4MTEwNTE2MjYxMFowgZIx\n" +
+                    "CzAJBgNVBAYTAlVTMREwDwYDVQQIDAhNYXJ5bGFuZDEUMBIGA1UEBwwLRm9yZXN0\n" +
+                    "IEhpbGwxFzAVBgNVBAoMDmh0dHBjb21wb25lbnRzMRowGAYDVQQLDBF0ZXN0IGNl\n" +
+                    "cnRpZmljYXRlczElMCMGCSqGSIb3DQEJARYWanVsaXVzZGF2aWVzQGdtYWlsLmNv\n" +
+                    "bTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhjr5aCPoyp0R1iroWA\n" +
+                    "fnEyBMGYWoCidH96yGPFjYLowez5aYKY1IOKTY2BlYho4O84X244QrZTRl8kQbYt\n" +
+                    "xnGh4gSCD+Z8gjZ/gMvLUlhqOb+WXPAUHMB39GRyzerA/ZtrlUqf+lKo0uWcocxe\n" +
+                    "Rc771KN8cPH3nHZ0rV0Hx4ZAZy6U4xxObe4rtSVY07hNKXAb2odnVqgzcYiDkLV8\n" +
+                    "ilvEmoNWMWrp8UBqkTcpEhYhCYp3cTkgJwMSuqv8BqnGd87xQU3FVZI4tbtkB+Kz\n" +
+                    "jD9zz8QCDJAfDjZHR03KNQ5mxOgXwxwKw6lGMaiVJTxpTKqym93whYk93l3ocEe5\n" +
+                    "5c0CAwEAAaOBkDCBjTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NM\n" +
+                    "IEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUnxR3vz86tso4gkJIFiza\n" +
+                    "0Mteh9gwHwYDVR0jBBgwFoAUe5raj5CZTlLSrNuzA1LKh6YNPg0wEgYDVR0RBAsw\n" +
+                    "CYIHZm9vLmNvbTANBgkqhkiG9w0BAQUFAAOCAQEAjl78oMjzFdsMy6F1sGg/IkO8\n" +
+                    "tF5yUgPgFYrs41yzAca7IQu6G9qtFDJz/7ehh/9HoG+oqCCIHPuIOmS7Sd0wnkyJ\n" +
+                    "Y7Y04jVXIb3a6f6AgBkEFP1nOT0z6kjT7vkA5LJ2y3MiDcXuRNMSta5PYVnrX8aZ\n" +
+                    "yiqVUNi40peuZ2R8mAUSBvWgD7z2qWhF8YgDb7wWaFjg53I36vWKn90ZEti3wNCw\n" +
+                    "qAVqixM+J0qJmQStgAc53i2aTMvAQu3A3snvH/PHTBo+5UL72n9S1kZyNCsVf1Qo\n" +
+                    "n8jKTiRriEM+fMFlcgQP284EBFzYHyCXFb9O/hMjK2+6mY9euMB1U1aFFzM/Bg==\n" +
+                    "-----END CERTIFICATE-----\n").getBytes();
+
+    public final static byte[] IP_1_1_1_1 = (
+            "-----BEGIN CERTIFICATE-----\n" +
+                    "MIICwjCCAaqgAwIBAgIBATANBgkqhkiG9w0BAQUFADAaMRgwFgYDVQQDEw9kdW1t\n" +
+                    "eS12YWx1ZS5jb20wHhcNMTcwMTEzMjI1MTQ2WhcNMTgwMTEzMjI1MTQ2WjAaMRgw\n" +
+                    "FgYDVQQDEw9kdW1teS12YWx1ZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\n" +
+                    "ggEKAoIBAQDfrapp3jHLp1RlElzpR/4sF9AcTYwMF1N+adkHRoVtmTlJV2lTIAjn\n" +
+                    "QLauy0Kkzv8uxmbID3uROgrFNDQ5RxTTCe+kW/vE6Pyzr5Z5ayjSTKeycTE7mAC4\n" +
+                    "6ntoCeEWiD593zlfqVo5PuRSp9Kusd+kexNVjC/BETDPa3yXctcH1ouW9GyGItgQ\n" +
+                    "u4GhCE8cipKMuTltgfK+Gh/5e9lFG9/F2fD+wHUVBULLR3JOQoqwgk2zAwKDwLuS\n" +
+                    "sEd1CBi35+W3apCKN0SEdTKIAxc/R+O/1j2hpOl9yXCCYyveGwJdFXVZtDcx+9/H\n" +
+                    "7NXhOdmw/mTXC5fOQGKciEo2SXt8Wp89AgMBAAGjEzARMA8GA1UdEQQIMAaHBAEB\n" +
+                    "AQEwDQYJKoZIhvcNAQEFBQADggEBAEAO6CE8twpcfdjk9oMjI5nX9GdC5Wt6+ujd\n" +
+                    "tLj0SbXvMKzCLLkveT0xTEzXfyEo8KW2qYYvPP1h83BIxsbR/J3Swt35UQVofv+4\n" +
+                    "JgO0FIdgB+iLEcjUh5+60xslylqWE+9bSWm4f06OXuv78tq5NYPZKku/3i4tqLRp\n" +
+                    "gH2rTtjX7Q4olSS7GdAgfiA2AnDZAbMtxtsnTt/QFpYQqhlkqHVDwgkGP7C8aMBD\n" +
+                    "RH0UIQCPxUkhwhtNmVyHO42r6oHXselZoVU6XRHuhogrGxPf/pzDUvrKBiJhsZQQ\n" +
+                    "oEu+pZCwkFLiNwUoq1G2oDpkkdBWB0JcBXB2Txa536ezFFWZYc0=\n" +
+                    "-----END CERTIFICATE-----"
+    ).getBytes();
+
+    private HostnameVerifyingX509ExtendedTrustManager trustManager;
+    private CertificateFactory certificateFactory;
+
+    @Before
+    public void initialize() throws Exception {
+        trustManager = new HostnameVerifyingX509ExtendedTrustManager(true);
+        certificateFactory = CertificateFactory.getInstance("X.509");
+    }
+
+    @Test
+    public void valid_CNOnly() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+        trustManager.performHostVerification("", "foo.com", x509);
+    }
+
+    @Test
+    public void valid_CNWithSAN() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_FOO_BAR);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+        trustManager.performHostVerification("", "bar.com", x509);
+    }
+
+    @Test
+    public void valid_Wildcard() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_WILD_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "www.foo.com", x509);
+        trustManager.performHostVerification("", "\u82b1\u5b50.foo.com", x509);
+    }
+
+    @Test
+    public void valid_SANOnly() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_NO_CNS_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "foo.com", x509);
+    }
+
+    @Test
+    public void valid_IP() throws Exception {
+        final InputStream in = new ByteArrayInputStream(IP_1_1_1_1);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("1.1.1.1", "", x509);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void invalid_CNOnlyNotMatched() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "bar.com", x509);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void invalid_CNWithSANNotMatched() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_FOO_BAR);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "foo.com", x509);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void invalid_WildcardNotMatched() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_WILD_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "foo.com", x509);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void invalid_WildcardNestedWildcard() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_WILD_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "a.b.foo.com", x509);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void invalid_SANOnlyNotMatched() throws Exception {
+        final InputStream in = new ByteArrayInputStream(X509_NO_CNS_FOO);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("", "a.foo.com", x509);
+    }
+
+    @Test(expected = CertificateException.class)
+    public void invalid_IPNotMatched() throws Exception {
+        final InputStream in = new ByteArrayInputStream(IP_1_1_1_1);
+        final X509Certificate x509 = (X509Certificate) certificateFactory.generateCertificate(in);
+
+        trustManager.performHostVerification("1.1.1.2", "", x509);
+    }
+}


### PR DESCRIPTION
Since HostnameVerifier is deprecated on android 23+, I had to adapt the OkHTTPClient hostname verifier to the codebase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
