### PR TITLE
Reduce Cognito token refresh window from 5 minutes to 2 minutes

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/util/CognitoIdentityProviderClientConfig.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/util/CognitoIdentityProviderClientConfig.java
@@ -37,7 +37,7 @@ public final class CognitoIdentityProviderClientConfig {
     /**
      * Default threshold for refresh tokens, in milliseconds.
      */
-    private static final long REFRESH_THRESHOLD_DEFAULT = 300 * 1000;
+    private static final long REFRESH_THRESHOLD_DEFAULT = 120 * 1000;
 
     /**
      * Threshold for refresh tokens, in milliseconds.

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -160,8 +160,9 @@ public class AWSIotMqttManager {
     /** Do we need to resubscribe upon reconnecting? */
     private boolean needResubscribe;
 
-    /** The session present flag tells the client whether the broker already has a
-     *  persistent session available from previous interactions with the client.
+    /**
+     * The session present flag tells the client whether the broker already has a
+     * persistent session available from previous interactions with the client.
      */
     private boolean sessionPresent;
 
@@ -1182,10 +1183,12 @@ public class AWSIotMqttManager {
 
                     if (!userDisconnect && autoReconnect) {
                         connectionState = MqttManagerConnectionState.Reconnecting;
+                        sessionPresent = asyncActionToken.getSessionPresent();
                         userConnectionCallback(e);
                         scheduleReconnect();
                     } else {
                         connectionState = MqttManagerConnectionState.Disconnected;
+                        sessionPresent = asyncActionToken.getSessionPresent();
                         userConnectionCallback(e);
                     }
                     sessionPresent = asyncActionToken.getSessionPresent();

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1978,8 +1978,7 @@ public class AWSIotMqttManager {
     }
 
     /**
-     *
-     * @return sessionPresent
+     * @return the session present flag from a connack
      */
     public boolean getSessionPresent() {
         return sessionPresent;

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.ibm.icu.impl.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -3050,6 +3051,8 @@ public class AWSIotMqttManagerTest {
         if (countDownLatch.await(2, TimeUnit.SECONDS)) {
             // Compare sessionPresent flag from AWSIotMqttManager with the actual one
             assertEquals(testSessionPresentFlag.getSessionPresent(), actualSessionPresent);
+        } else {
+            fail("CountDownLatch timed out.");
         }
     }
 

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
@@ -1,10 +1,6 @@
 
 package com.amazonaws.mobileconnectors.iot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -36,6 +32,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 16)
@@ -3019,6 +3019,67 @@ public class AWSIotMqttManagerTest {
         assertTrue(testClient.isMetricsEnabled());
         testClient.setMetricsIsEnabled(false);
         assertFalse(testClient.isMetricsEnabled());
+    }
+
+    @Test
+    public void testMqttSessionPresentWithCleanSession() throws MqttException {
+        MockMqttClient mockClient = new MockMqttClient();
+//        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        final AWSIotMqttManager testClient = new AWSIotMqttManager("test-client",
+                Region.getRegion(Regions.US_EAST_1), TEST_ENDPOINT_PREFIX);
+        testClient.setMqttClient(mockClient);
+
+        KeyStore testKeystore = AWSIotKeystoreHelper.getIotKeystore(CERT_ID, KEYSTORE_PATH,
+                KEYSTORE_NAME, KEYSTORE_PASSWORD);
+
+        testClient.setCleanSession(true);
+
+        testClient.connect(testKeystore, new AWSIotMqttClientStatusCallback() {
+            @Override
+            public void onStatusChanged(AWSIotMqttClientStatus status, Throwable throwable) {
+                if (status == AWSIotMqttClientStatus.Connecting) {
+                    System.out.println("Client persistent-client-id connecton status: " + status);
+                    System.out.println("getSessionPresent: " + testClient.getSessionPresent());
+                    assertFalse(testClient.getSessionPresent());
+                } else if (status == AWSIotMqttClientStatus.Connected) {
+                    System.out.println("Client persistent-client-id connecton status: " + status);
+                    System.out.println("getSessionPresent: " + testClient.getSessionPresent());
+                    assertFalse(testClient.getSessionPresent());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testMqttSessionPresentWithoutCleanSession() throws MqttException {
+        MockMqttClient mockClient = new MockMqttClient();
+//        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        final AWSIotMqttManager testClient = new AWSIotMqttManager("test-client",
+                Region.getRegion(Regions.US_EAST_1), TEST_ENDPOINT_PREFIX);
+        testClient.setMqttClient(mockClient);
+
+        KeyStore testKeystore = AWSIotKeystoreHelper.getIotKeystore(CERT_ID, KEYSTORE_PATH,
+                KEYSTORE_NAME, KEYSTORE_PASSWORD);
+
+        testClient.setCleanSession(false);
+
+        testClient.connect(testKeystore, new AWSIotMqttClientStatusCallback() {
+            @Override
+            public void onStatusChanged(AWSIotMqttClientStatus status, Throwable throwable) {
+                if (status == AWSIotMqttClientStatus.Connecting) {
+                    System.out.println("Client persistent-client-id connecton status: " + status);
+                    System.out.println("getSessionPresent: " + testClient.getSessionPresent());
+                    assertFalse(testClient.getSessionPresent());
+                } else if (status == AWSIotMqttClientStatus.Connected) {
+                    System.out.println("Client persistent-client-id connecton status: " + status);
+                    System.out.println("getSessionPresent: " + testClient.getSessionPresent());
+                    assertFalse(testClient.getSessionPresent());
+                }
+            }
+        });
+
     }
 
     /**

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
@@ -11,8 +11,6 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.util.StringUtils;
 import com.amazonaws.util.VersionInfoUtils;
 
-import org.eclipse.paho.client.mqttv3.IMqttActionListener;
-import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.junit.After;
@@ -3026,21 +3024,9 @@ public class AWSIotMqttManagerTest {
     @Test
     public void testMqttSessionPresent() throws MqttException {
         // Test if sessionPresent flag from AWSIotMqttManager is correctly passed from the MqttClient
-        final boolean[] actualSessionPresent = new boolean[1];
         MockMqttClient mockClient = new MockMqttClient();
-        IMqttActionListener listener = new IMqttActionListener() {
-            @Override
-            public void onSuccess(IMqttToken asyncActionToken) {
-                // Extract the actual sessionPresent flag from MqttClient and store it
-                actualSessionPresent[0] = asyncActionToken.getSessionPresent();
-            }
-
-            @Override
-            public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
-                System.out.println("An error occurs within MqttClient" + exception);
-            }
-        };
-        mockClient.testToken.setActionCallback(listener);
+        final boolean actualSessionPresent;
+        actualSessionPresent = mockClient.testToken.getSessionPresent();
 
         final AWSIotMqttManager testSessionPresentFlag = new AWSIotMqttManager("test-sessionPresent-flag",
                 Region.getRegion(Regions.US_EAST_1), TEST_ENDPOINT_PREFIX);
@@ -3056,11 +3042,11 @@ public class AWSIotMqttManagerTest {
                     System.out.println("Client persistent-client-id connecton status: " + status);
                     System.out.println("getSessionPresent: " + testSessionPresentFlag.getSessionPresent());
                     // Compare sessionPresent flag from AWSIotMqttManager with the actual one
-                    assertEquals(testSessionPresentFlag.getSessionPresent(), actualSessionPresent[0]);
+                    assertEquals(testSessionPresentFlag.getSessionPresent(), actualSessionPresent);
                 } else if (status == AWSIotMqttClientStatus.Connected) {
                     System.out.println("Client persistent-client-id connecton status: " + status);
                     System.out.println("getSessionPresent: " + testSessionPresentFlag.getSessionPresent());
-                    assertEquals(testSessionPresentFlag.getSessionPresent(), actualSessionPresent[0]);
+                    assertEquals(testSessionPresentFlag.getSessionPresent(), actualSessionPresent);
                 }
             }
         });

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.ibm.icu.impl.Assert.fail;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
*Issue #, if available:*
[Issue #2232 ](https://github.com/aws-amplify/aws-sdk-android/issues/2232)

*Description of changes:*
Address the feature request to reduce token refresh window from 5 minutes to 1-3 minutes from Cognito team. As iOS has released this feature with token refresh window set to 2 minutes, I set it to 2 minutes as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
