### PR TITLE
Reduce Cognito token refresh window

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/util/CognitoIdentityProviderClientConfig.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/util/CognitoIdentityProviderClientConfig.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2013-2019 Amazon.com,
+ *  Copyright 2013-2020 Amazon.com,
  *  Inc. or its affiliates. All Rights Reserved.
  *
  *  Licensed under the Amazon Software License (the "License").
@@ -37,7 +37,7 @@ public final class CognitoIdentityProviderClientConfig {
     /**
      * Default threshold for refresh tokens, in milliseconds.
      */
-    private static final long REFRESH_THRESHOLD_DEFAULT = 300 * 1000;
+    private static final long REFRESH_THRESHOLD_DEFAULT = 120 * 1000;
 
     /**
      * Threshold for refresh tokens, in milliseconds.


### PR DESCRIPTION
*Issue #, if available:*
[Issue #2232 ](https://github.com/aws-amplify/aws-sdk-android/issues/2232)

*Description of changes:*
Address the feature request to reduce token refresh window from 5 minutes to 1-3 minutes from Cognito team. As iOS has released this feature with token refresh window set to 2 minutes, I set it to 2 minutes as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
