### PR TITLE
[IoT] AWSIotMqttManager.scheduleReconnect() prevent reconnect loop and HandlerThread not quit on exception

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1407,6 +1407,7 @@ public class AWSIotMqttManager {
                             reconnectToSession();
                         }
                     } finally {
+                        LOGGER.debug("TID: " + ht.getThreadId() + " quit");
                         ht.quit();
                     }
                 }

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1383,7 +1383,7 @@ public class AWSIotMqttManager {
             + " in " + currentReconnectRetryTime + " seconds.");
 
         // schedule a reconnect only if previously scheduled reconnect is finished.
-        if (System.currentTimeMillis() < autoReconnectsScheduledTimestamp) {
+        if (getSystemTimeMs() < autoReconnectsScheduledTimestamp) {
             LOGGER.info("schedule Reconnect attempt canceled. There is already a reconnect scheduled at " + new Date(autoReconnectsScheduledTimestamp) + ".");
             return true;
         }
@@ -1411,7 +1411,7 @@ public class AWSIotMqttManager {
                     }
                 }
             }, reconnectScheduleDelay);
-            autoReconnectsScheduledTimestamp = System.currentTimeMillis() + reconnectScheduleDelay;
+            autoReconnectsScheduledTimestamp = getSystemTimeMs() + reconnectScheduleDelay;
             currentReconnectRetryTime = Math.min(currentReconnectRetryTime * 2, maxReconnectRetryTime);
             return true;
         } else {

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1402,10 +1402,13 @@ public class AWSIotMqttManager {
                 @Override
                 public void run() {
                     LOGGER.debug("TID: " + ht.getThreadId() + " trying to reconnect to session");
-                    if (mqttClient != null && !mqttClient.isConnected()) {
-                        reconnectToSession();
+                    try {
+                        if (mqttClient != null && !mqttClient.isConnected()) {
+                            reconnectToSession();
+                        }
+                    } finally {
+                        ht.quit();
                     }
-                    ht.quit();
                 }
             }, reconnectScheduleDelay);
             autoReconnectsScheduledTimestamp = System.currentTimeMillis() + reconnectScheduleDelay;


### PR DESCRIPTION
*Issue #, if available:*
#2273 AWSIotMqttManager: an Exception in reconnectToSession causes reconnect loop without backoff

*Description of changes:*

When an exception occurs in `AWSIotMqttManager.scheduleReconnect()`:

* The HandlerThread for the reconnect is quit in a finally block
* Scheduling another reconnect is prevented when a reconnect is already scheduled. For this we don't keep track of a reference to the thread, but in stead store a timestamp with the expiration date of the reconnect that was scheduled. Includes a Unit Test for this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.