### PR TITLE
chore: remove apache commons logging dependency

### DIFF
--- a/Proguard.html
+++ b/Proguard.html
@@ -90,7 +90,6 @@ the following lines to the end of your <i>proguard-project.txt</i> file:
 -keep class com.amazonaws.services.**.*Handler
 # The following are referenced but aren't required to run
 -dontwarn com.fasterxml.jackson.**
--dontwarn org.apache.commons.logging.**
 # Android 6.0 release removes support for the Apache HTTP client
 -dontwarn org.apache.http.**
 # The SDK has several references of Apache HTTP client

--- a/aws-android-sdk-core/build.gradle
+++ b/aws-android-sdk-core/build.gradle
@@ -14,7 +14,6 @@ android {
 
 dependencies {
     api 'com.google.code.gson:gson:2.8.6'
-    compileOnly 'commons-logging:commons-logging:1.2'
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'joda-time:joda-time:2.8.1'
@@ -23,6 +22,5 @@ dependencies {
     testImplementation 'org.easymock:easymock:3.1'
     testImplementation 'org.robolectric:robolectric:4.4'
     testImplementation 'xerces:xercesImpl:2.12.0'
-    testRuntimeOnly 'commons-logging:commons-logging:1.2'
 }
 

--- a/aws-android-sdk-core/consumer-proguard-rules.pro
+++ b/aws-android-sdk-core/consumer-proguard-rules.pro
@@ -10,7 +10,6 @@
 
 # The following are referenced but aren't required to run
 -dontwarn com.fasterxml.jackson.**
--dontwarn org.apache.commons.logging.**
 
 # Android 6.0 release removes support for the Apache HTTP client
 -dontwarn org.apache.http.**

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/logging/ApacheCommonsLogging.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/logging/ApacheCommonsLogging.java
@@ -15,14 +15,14 @@
 
 package com.amazonaws.logging;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import com.amazonaws.logging.LogFactory.Level;
 
 /**
  * This is a wrapper over the Apache Commons
  * Logging framework.
+ * @deprecated Use {@link AndroidLog} instead.
  */
+@Deprecated
 public class ApacheCommonsLogging implements com.amazonaws.logging.Log {
 
     private Class logClass;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/logging/LogFactory.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/logging/LogFactory.java
@@ -29,7 +29,6 @@ public class LogFactory {
      * Log tag longer than 23 will cause it to break on Android API level <= 23.
      */
     private static final String TAG = LogFactory.class.getSimpleName();
-    private static final String APACHE_COMMONS_LOGGING_LOGFACTORY = "org.apache.commons.logging.LogFactory";
     private static final Map<String, Log> logMap = new HashMap<>();
 
     private static Level globalLogLevel = null;
@@ -60,8 +59,6 @@ public class LogFactory {
 
         if (Environment.isJUnitTest()) {
             log = new ConsoleLog(logTag);
-        } else if (checkApacheCommonsLoggingExists()) {
-            log = new ApacheCommonsLogging(logTag);
         } else {
             log = new AndroidLog(logTag);
         }
@@ -75,18 +72,6 @@ public class LogFactory {
 
     public static Level getLevel() {
         return globalLogLevel;
-    }
-
-    private static boolean checkApacheCommonsLoggingExists() {
-        try {
-            Class.forName(APACHE_COMMONS_LOGGING_LOGFACTORY);
-            return true;
-        } catch (ClassNotFoundException cnfe) {
-            return false;
-        } catch (RuntimeException ex) {
-            android.util.Log.e(TAG, ex.getMessage());
-            return false;
-        }
     }
 
     /**

--- a/aws-android-sdk-s3-test/build.gradle
+++ b/aws-android-sdk-s3-test/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'commons-logging:commons-logging:1.2'
     androidTestImplementation 'org.apache.commons:commons-io:1.3.2'
     androidTestImplementation project(':aws-android-sdk-testutils')
 }

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/internal/crypto/CryptoTestUtils.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/internal/crypto/CryptoTestUtils.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
  
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.PropertiesCredentials;
+import com.amazonaws.logging.LogFactory;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.internal.MD5DigestCalculatingInputStream;
 import com.amazonaws.services.s3.model.ObjectListing;
@@ -30,7 +31,6 @@ import com.amazonaws.util.Base64;
 import com.amazonaws.util.StringUtils;
  
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.LogFactory;
  
 import java.io.File;
 import java.io.FileInputStream;

--- a/aws-android-sdk-s3/build.gradle
+++ b/aws-android-sdk-s3/build.gradle
@@ -16,7 +16,6 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    testImplementation 'commons-logging:commons-logging:1.2'
     testImplementation 'joda-time:joda-time:2.8.1'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.apache.commons:commons-io:1.3.2'


### PR DESCRIPTION
*Description of changes:*
Currently, Android Studio complains that:

> `commons-logging` defines classes that conflict with classes now provided by Android. Solutions include finding newer versions or alternative libraries that don't have the same problem (for example, for `httpclient` use `HttpUrlConnection` or `okhttp` instead), or repackaging the library using something like `jarjar`.

This PR removes gradle dependency on `'commons-logging:commons-logging:1.2'` and deprecates `ApacheCommonsLogging` class in favor of always using `AndroidLog` class.

Some unit tests had to be modified to run with `RobolectricTestRunner` due to this change, because JVM cannot run Android code (`android.util.Log`) by itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
