### PR TITLE
fix: add key condition expression field to DynamoDBQueryExpression

### DIFF
--- a/aws-android-sdk-ddb-mapper/src/main/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBMapper.java
+++ b/aws-android-sdk-ddb-mapper/src/main/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBMapper.java
@@ -2681,6 +2681,7 @@ public class DynamoDBMapper {
                 .getExpressionAttributeNames());
         queryRequest.setExpressionAttributeValues(queryExpression
                 .getExpressionAttributeValues());
+        queryRequest.setKeyConditionExpression(queryExpression.getKeyConditionExpression());
 
         return applyUserAgent(queryRequest);
     }

--- a/aws-android-sdk-ddb-mapper/src/main/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBQueryExpression.java
+++ b/aws-android-sdk-ddb-mapper/src/main/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBQueryExpression.java
@@ -364,6 +364,9 @@ public class DynamoDBQueryExpression<T> {
 
     /**
      * Sets the key condition expression to be used by this query.
+     * See <a href="Key Condition Expressions">
+     *     https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.KeyConditionExpressions
+     *     </a>
      *
      * @param keyConditionExpression the key condition expression to use for the query.
      */
@@ -373,6 +376,9 @@ public class DynamoDBQueryExpression<T> {
 
     /**
      * Sets the key condition expression to be used by this query.
+     * See <a href="Key Condition Expressions">
+     *     https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.KeyConditionExpressions
+     *     </a>
      * <p>
      * Returns a pointer to this object for method-chaining.
      *

--- a/aws-android-sdk-ddb-mapper/src/main/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBQueryExpression.java
+++ b/aws-android-sdk-ddb-mapper/src/main/java/com/amazonaws/mobileconnectors/dynamodbv2/dynamodbmapper/DynamoDBQueryExpression.java
@@ -37,6 +37,7 @@ public class DynamoDBQueryExpression<T> {
     private Map<String, AttributeValue> exclusiveStartKey;
     private Integer limit;
     private String indexName;
+    private String keyConditionExpression;
     private Map<String, Condition> queryFilter;
     private String conditionalOperator;
     /**
@@ -349,6 +350,37 @@ public class DynamoDBQueryExpression<T> {
     @SuppressWarnings("checkstyle:hiddenfield")
     public DynamoDBQueryExpression<T> withIndexName(String indexName) {
         setIndexName(indexName);
+        return this;
+    }
+
+    /**
+     * Returns the key condition expression to be used by this query.
+     *
+     * @return the key condition expression used for the query.
+     */
+    public String getKeyConditionExpression() {
+        return keyConditionExpression;
+    }
+
+    /**
+     * Sets the key condition expression to be used by this query.
+     *
+     * @param keyConditionExpression the key condition expression to use for the query.
+     */
+    public void setKeyConditionExpression(String keyConditionExpression) {
+        this.keyConditionExpression = keyConditionExpression;
+    }
+
+    /**
+     * Sets the key condition expression to be used by this query.
+     * <p>
+     * Returns a pointer to this object for method-chaining.
+     *
+     * @param keyConditionExpression the key condition expression to use for the query.
+     * @return updated {@link DynamoDBQueryExpression} for chaining
+     */
+    public DynamoDBQueryExpression<T> withKeyConditionExpression(String keyConditionExpression) {
+        setKeyConditionExpression(keyConditionExpression);
         return this;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The customer would like to assign `keyConditionExpression` in `DynamoDBQueryExpression` and have it be mapped appropriately to the low-level request object `QueryRequest`. [iOS SDK allows this already](https://github.com/aws-amplify/aws-sdk-ios/blob/0f985322625566a566726e8ca2c24d5a5bc678b8/AWSDynamoDB/AWSDynamoDBObjectMapper.h#L558-L567) via AWSDynamoDBObjectMapper.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
