### PR TITLE
fix(location) Wire up trackerName

### DIFF
--- a/aws-android-sdk-location/src/main/java/com/amazonaws/mobileconnectors/geo/tracker/AWSLocationTracker.java
+++ b/aws-android-sdk-location/src/main/java/com/amazonaws/mobileconnectors/geo/tracker/AWSLocationTracker.java
@@ -144,6 +144,7 @@ public class AWSLocationTracker {
         this.trackingPublisher = new TrackingPublisher(
                 locationClient,
                 deviceId,
+                trackerName,
                 5,
                 options.getEmitLocationFrequency() == null ?
                         DEFAULT_EMIT_LOCATION_FREQUENCY :

--- a/aws-android-sdk-location/src/main/java/com/amazonaws/mobileconnectors/geo/tracker/TrackingPublisher.java
+++ b/aws-android-sdk-location/src/main/java/com/amazonaws/mobileconnectors/geo/tracker/TrackingPublisher.java
@@ -44,6 +44,7 @@ public class TrackingPublisher {
     private static final long TERMINATION_TIMEOUT_MS = 10;
 
     private final String deviceId;
+    private final String trackerName;
     private final LinkedBlockingQueue<DevicePositionUpdate> positionUpdateQueue;
     private final LinkedBlockingQueue<BatchUpdateDevicePositionRequest> batchRequestQueue;
     private final ScheduledFuture<?> scheduledFuture;
@@ -51,9 +52,11 @@ public class TrackingPublisher {
     private final BatchPublisher batchPublisher;
 
     public TrackingPublisher(AmazonLocationClient locationClient,
-                             String deviceId) {
+                             String deviceId,
+                             String trackerName) {
         this(locationClient,
              deviceId,
+             trackerName,
              DEFAULT_WORKER_POOL_SIZE,
              DEFAULT_PUBLISH_INTERVAL_MS,
              DEFAULT_BATCH_SIZE,
@@ -62,12 +65,14 @@ public class TrackingPublisher {
 
     public TrackingPublisher(AmazonLocationClient locationClient,
                              String deviceId,
+                             String trackerName,
                              int workerPoolSize,
                              long publishIntervalMillis,
                              int batchSize,
                              TrackingListener listener) {
         this(locationClient,
              deviceId,
+             trackerName,
              Executors.newScheduledThreadPool(workerPoolSize),
              publishIntervalMillis,
              batchSize,
@@ -76,11 +81,13 @@ public class TrackingPublisher {
 
     public TrackingPublisher(AmazonLocationClient locationClient,
                              String deviceId,
+                             String trackerName,
                              ScheduledExecutorService scheduledExecutorService,
                              long publishIntervalMillis,
                              int batchSize,
                              TrackingListener listener) {
         this.deviceId = deviceId;
+        this.trackerName = trackerName;
         positionUpdateQueue = new LinkedBlockingQueue<>(batchSize);
         batchRequestQueue = new LinkedBlockingQueue<>();
         batchPublisher = new BatchPublisher(locationClient, batchRequestQueue, listener);
@@ -185,7 +192,7 @@ public class TrackingPublisher {
      */
     private BatchUpdateDevicePositionRequest createNewBatch() {
         BatchUpdateDevicePositionRequest batch = new BatchUpdateDevicePositionRequest();
-        batch.setTrackerName(deviceId);
+        batch.setTrackerName(trackerName);
         batch.setUpdates(new ArrayList<DevicePositionUpdate>());
         return batch;
     }


### PR DESCRIPTION
Currently the `trackerName` is set to the `deviceId` on the `BatchUpdateDevicePositionRequest`.  This PR fixes it, so that we correctly set the `trackerName` instead, provided in the `AWSLocationTracker` constructor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
