### PR TITLE
adds custom challenge for first method overload of confirmSignIn

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1325,6 +1325,14 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         detectedContinuation = signInChallengeContinuation;
                         signInCallback = new InternalCallback<SignInResult>(callback);
                         break;
+                    case CUSTOM_CHALLENGE:
+                        signInChallengeContinuation.setChallengeResponse("ANSWER", signInChallengeResponse);
+                        detectedContinuation = signInChallengeContinuation;
+                        signInCallback = new InternalCallback<SignInResult>(callback);
+                        if (clientMetadata != null) {
+                            signInChallengeContinuation.setClientMetaData(clientMetadata);
+                        }
+                        break;
                     case DONE:
                         callback.onError(new IllegalStateException("confirmSignIn called after signIn has succeeded"));
                         return;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-flutter/issues/271
https://github.com/aws-amplify/amplify-android/issues/805
https://github.com/aws-amplify/aws-sdk-android/issues/1761

*Description of changes:*
If confirmSignIn is called without a map for custom challenge, we simply assume that the signInChallengeResponse variable as the attribute for the "ANSWER" key in the .setChallengeResponse's map parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
