### PR TITLE
chore: update instructions for testing local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,12 @@ allprojects {
     }
 }
 ```
-Then, specify `local` instead of a version number to point to mavenLocal inside `build.gradle(Module)` file:
+Then, find the `VERSION_NAME` of the *library* inside `gradle.properties` file.
+
+Use the above version to specify dependencies in your *app*'s `build.gradle (:app)` file:
 ```
 dependencies {
-    implementation 'com.amazonaws:aws-android-sdk-SERVICE:local'
+    implementation 'com.amazonaws:aws-android-sdk-SERVICE:VERSION_NAME'
 }
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that the `gradle.properties` version name points to the live version, previous instructions for using local builds no longer applies. Updates README.md accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
