### PR TITLE
Issue1003: registerConfigSignInProviders in _initialize resolves signInProviders missing for DropInUI

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -457,6 +457,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     protected Runnable _initialize(final Context context, final AWSConfiguration awsConfiguration, final Callback<UserStateDetails> callback) {
         return new Runnable() {
             public void run() {
+
                 synchronized (initLockObject) {
                     if (AWSMobileClient.this.awsConfiguration != null) {
                         callback.onResult(getUserStateDetails(true));
@@ -483,11 +484,14 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                     mContext = context.getApplicationContext();
                     mStore = new AWSMobileClientStore(AWSMobileClient.this);
 
+                    AWSMobileClient.this.awsConfiguration = awsConfiguration;
+
                     final IdentityManager identityManager = new IdentityManager(mContext);
                     identityManager.enableFederation(false);
                     identityManager.setConfiguration(awsConfiguration);
                     identityManager.setPersistenceEnabled(mIsPersistenceEnabled);
                     IdentityManager.setDefaultIdentityManager(identityManager);
+                    registerConfigSignInProviders();
                     identityManager.addSignInStateChangeListener(new SignInStateChangeListener() {
                         @Override
                         public void onUserSignedIn() {
@@ -603,8 +607,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                 " At least one must be present to use AWSMobileClient."));
                         return;
                     }
-
-                    AWSMobileClient.this.awsConfiguration = awsConfiguration;
 
                     final UserStateDetails userStateDetails = getUserStateDetails(true);
                     callback.onResult(userStateDetails);
@@ -3352,8 +3354,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         callback.onError(new RuntimeException("Called showSignIn while user is already signed-in"));
                         return;
                     }
-
-                    registerConfigSignInProviders();
 
                     final AuthUIConfiguration.Builder authUIConfigBuilder = new AuthUIConfiguration.Builder()
                             .canCancel(signInUIOptions.canCancel())


### PR DESCRIPTION
To resolve, AWSMobileClient.getInstance().showSignIn() buttons do not work after sign-out or invalid token, issue #1003. The problem was created by changes made in 2.13.4. 

*Issue #* 1003

*Description of changes:* By moving the call to `registerConfigSignInProviders()` up to _initialize in AWSMobleClient.java resoles the problem when MobileClient "Failed to federate the tokens. Token expired:". MobileClient return SIGN_IN state then immediately returns SIGNED_OUT_FEDERATED_TOKENS_INVALID to the user state listener. 

`registerConfigSignInProviders()` sets the sign in providers, but unless set prior to `_showSignInDropInUI(callingActivity`, the providers are not found when needed by the Drop in UI, in some use cases such as when federated tokens are invalid. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
