### PR TITLE
chore(release): remove VERSION_CODE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ subprojects { project ->
 private void configureAndroidLibrary(Project project) {
     project.android {
         defaultConfig {
-            versionCode rootProject.findProperty('VERSION_CODE').toInteger()
             versionName rootProject.findProperty('VERSION_NAME')
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,6 @@ android.enableJetifier=true
 
 GROUP=com.amazonaws
 VERSION_NAME=2.22.2
-VERSION_CODE=022202
 
 POM_URL=https://github.com/aws/aws-sdk-android
 POM_SCM_URL=https://github.com/aws/aws-sdk-android


### PR DESCRIPTION
Per the [documentation for `versionCode`](https://developer.android.com/studio/publish/versioning), it's only use is to prevent users from downgrading to an APK with a lower `versionCode` than the version currently installed.  Since `aws-sdk-android` is a library, and not an app, this doesn't apply.

We removed this from the [amplify-android library](https://github.com/aws-amplify/amplify-android/pull/1223) yesterday, and so far have had no issues reported from it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
