### PR TITLE
prevent class def not found error

### DIFF
--- a/aws-android-sdk-auth-core/src/main/java/com/amazonaws/mobile/auth/core/IdentityManager.java
+++ b/aws-android-sdk-auth-core/src/main/java/com/amazonaws/mobile/auth/core/IdentityManager.java
@@ -46,9 +46,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -122,8 +121,7 @@ public class IdentityManager {
     private final CountDownLatch startupAuthTimeoutLatch = new CountDownLatch(1);
 
     /** Keep track of the registered sign-in providers. */
-    private final List<Class<? extends SignInProvider>> signInProviderClasses
-        = new LinkedList<Class<? extends SignInProvider>>();
+    private final Set<Class<? extends SignInProvider>> signInProviderClasses = new HashSet<>();
 
     /** Current provider beingIdentityProviderType used to obtain a Cognito access token. */
     private volatile IdentityProvider currentIdentityProvider = null;

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -3544,19 +3544,21 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
         Log.d(TAG, "Using the SignInProviderConfig from `awsconfiguration.json`.");
         final IdentityManager identityManager = IdentityManager.getDefaultIdentityManager();
 
-        if (isConfigurationKeyPresent(USER_POOLS, awsConfiguration)
-                && !identityManager.getSignInProviderClasses().contains(CognitoUserPoolsSignInProvider.class)) {
-            identityManager.addSignInProvider(CognitoUserPoolsSignInProvider.class);
-        }
+        try {
+            if (isConfigurationKeyPresent(USER_POOLS, awsConfiguration)) {
+                identityManager.addSignInProvider(CognitoUserPoolsSignInProvider.class);
+            }
 
-        if (isConfigurationKeyPresent(FACEBOOK, awsConfiguration)
-                && !identityManager.getSignInProviderClasses().contains(FacebookSignInProvider.class)) {
-            identityManager.addSignInProvider(FacebookSignInProvider.class);
-        }
+            if (isConfigurationKeyPresent(FACEBOOK, awsConfiguration)) {
+                identityManager.addSignInProvider(FacebookSignInProvider.class);
+            }
 
-        if (isConfigurationKeyPresent(GOOGLE, awsConfiguration)
-                && !identityManager.getSignInProviderClasses().contains(GoogleSignInProvider.class)) {
-            identityManager.addSignInProvider(GoogleSignInProvider.class);
+            if (isConfigurationKeyPresent(GOOGLE, awsConfiguration)) {
+                identityManager.addSignInProvider(GoogleSignInProvider.class);
+            }
+        } catch (NoClassDefFoundError exception) {
+            Log.w(TAG, "Sign in provider was not registered due to missing optional dependency. " +
+                    "showSignIn() API may not work as expected.", exception);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Readdresses patch from #2386 

*Description of changes:*
Now that `registerConfigSignInProviders()` method is called (which has references to class paths in optional dependencies) in `_initialize()` step, `NoClassDefFoundError` would crash mobile client initialization even for those not using `showSignIn()`. 

This PR makes sure that initialization step will not crash for those using mobile client without optional dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
