### PR TITLE
fix(mobile-client): missing optional dependency warning removed

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -3544,8 +3544,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                 identityManager.addSignInProvider(GoogleSignInProvider.class);
             }
         } catch (NoClassDefFoundError exception) {
-            Log.w(TAG, "Sign in provider was not registered due to missing optional dependency. " +
-                    "showSignIn() API may not work as expected.", exception);
+            // This is not 90% use-case. Do not log anything.
         }
     }
 

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -3544,7 +3544,9 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                 identityManager.addSignInProvider(GoogleSignInProvider.class);
             }
         } catch (NoClassDefFoundError exception) {
-            // This is not 90% use-case. Do not log anything.
+            // The above sign in providers are optional dependencies that are required for
+            // drop-in UI to work correctly. Not registering them will still allow users to
+            // sign in via other methods.
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
removed warning from being logged when missing optional dependency. Those using `showSignIn()` are already expected to have these optional dependencies anyways and all it was doing was unnecessarily cluttering log messages for majority of users that do not need it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
