### PR TITLE
fix(s3): transfers are now single-threaded

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferThreadPool.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferThreadPool.java
@@ -41,7 +41,8 @@ class TransferThreadPool {
             executorMainTask = buildExecutor(poolSize);
         }
         if (executorPartTask == null) {
-            executorPartTask = buildExecutor(poolSize);
+            // Upload individual parts serially
+            executorPartTask = buildExecutor(1);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#1947 

*Description of changes:*
Default behavior for transfer utility was to use thread pool size = # available processors. This allowed multipart upload to be executed in parallel for a minor performance boost. However, we found that this was causing certain upload part requests to be prioritized over others, which in turn timed out the requests that were not being prioritized.

To increase the stability of large file uploads, this PR aims to force single-threaded multipart uploads by default (parts will be uploaded serially).

Main task executor to be used for downloads and single-part uploads will still be multi-threaded so that small transfers are not blocked by large file uploads.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
