### PR TITLE
change the time offset precision from int to long

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/AmazonWebServiceClient.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/AmazonWebServiceClient.java
@@ -95,7 +95,7 @@ public abstract class AmazonWebServiceClient {
 
     /** Optional offset (in seconds) to use when signing requests. */
     @SuppressWarnings("checkstyle:visibilitymodifier")
-    protected int timeOffset;
+    protected long timeOffset;
 
     /** AWS signer for authenticating requests. */
     private volatile Signer signer;
@@ -660,7 +660,7 @@ public abstract class AmazonWebServiceClient {
      *
      * @return The optional value for time offset (in seconds) for this client.
      */
-    public int getTimeOffset() {
+    public long getTimeOffset() {
         return timeOffset;
     }
 

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/DefaultRequest.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/DefaultRequest.java
@@ -68,7 +68,7 @@ public class DefaultRequest<T> implements Request<T> {
     private InputStream content;
 
     /** An optional time offset to account for clock skew */
-    private int timeOffset;
+    private long timeOffset;
 
     /** All AWS Request metrics are collected into this object. */
     private AWSRequestMetrics metrics;
@@ -264,15 +264,24 @@ public class DefaultRequest<T> implements Request<T> {
      * {@inheritDoc}
      */
     @Override
-    public int getTimeOffset() {
+    public long getTimeOffset() {
         return timeOffset;
     }
 
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     @Override
     public void setTimeOffset(int timeOffset) {
+        this.setTimeOffset((long) timeOffset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTimeOffset(long timeOffset) {
         this.timeOffset = timeOffset;
     }
 
@@ -280,8 +289,18 @@ public class DefaultRequest<T> implements Request<T> {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     @SuppressWarnings("checkstyle:hiddenfield")
     public Request<T> withTimeOffset(int timeOffset) {
+        return withTimeOffset((long) timeOffset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public Request<T> withTimeOffset(long timeOffset) {
         setTimeOffset(timeOffset);
         return this;
     }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/Request.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/Request.java
@@ -193,7 +193,16 @@ public interface Request<T> {
      *
      * @return The optional value for time offset (in seconds) for this request.
      */
-    public int getTimeOffset();
+    public long getTimeOffset();
+
+    /**
+     * This is deprecated, use {@link #setTimeOffset(long)} instead.
+     *
+     * @param timeOffset The optional value for time offset (in seconds) for
+     *                   this request.
+     */
+    @Deprecated
+    public void setTimeOffset(int timeOffset);
 
     /**
      * Sets the optional value for time offset for this request. This will be
@@ -204,7 +213,16 @@ public interface Request<T> {
      * @param timeOffset The optional value for time offset (in seconds) for
      *            this request.
      */
-    public void setTimeOffset(int timeOffset);
+    public void setTimeOffset(long timeOffset);
+
+    /**
+     * This is deprecated, use {@link #withTimeOffset(long)} instead.
+     * @param timeOffset the time offset for the request.
+     *
+     * @return The updated request object.
+     */
+    @Deprecated
+    public Request<T> withTimeOffset(int timeOffset);
 
     /**
      * Sets the optional value for time offset for this request. This will be
@@ -215,7 +233,7 @@ public interface Request<T> {
      *
      * @return The updated request object.
      */
-    public Request<T> withTimeOffset(int timeOffset);
+    public Request<T> withTimeOffset(long timeOffset);
 
     /**
      * @return the request metrics.

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
@@ -15,7 +15,7 @@
 
 package com.amazonaws;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * SDKGlobalConfiguration is to configure any global settings
@@ -131,27 +131,38 @@ public class SDKGlobalConfiguration {
      * this variable will adjust clock skew globally. Java SDK detects clock
      * skew errors and adjusts global clock skew automatically.
      */
-    private static final AtomicInteger GLOBAL_TIME_OFFSET = new AtomicInteger(0);
+    private static final AtomicLong GLOBAL_TIME_OFFSET = new AtomicLong(0);
 
     /**
      * Sets the global time offset. If this value is set then all the subsequent
      * requests will use this value to generate timestamps. To adjust clock skew
-     * per request use {@link Request#setTimeOffset(int)}
+     * per request use {@link Request#setTimeOffset(long)}
      *
      * @param timeOffset the time difference between local client and server
      */
-    public static void setGlobalTimeOffset(int timeOffset) {
+    public static void setGlobalTimeOffset(long timeOffset) {
         GLOBAL_TIME_OFFSET.set(timeOffset);
+    }
+
+    /**
+     * This method is deprecated, use {@link #setGlobalTimeOffset(long)} instead.
+     *
+     * @param timeOffset the time difference between local client and server
+     */
+    @Deprecated
+    public static void setGlobalTimeOffset(int timeOffset) {
+        setGlobalTimeOffset((long) timeOffset);
     }
 
     /**
      * Gets the global time offset. See {@link Request#getTimeOffset()} if
      * global time offset is not set.
      *
-     * @return GLOBAL_TIME_OFFSET an AtomicInteger that holds the value of time
+     * @return GLOBAL_TIME_OFFSET an AtomicLong that holds the value of time
      *         offset
      */
-    public static int getGlobalTimeOffset() {
+    public static long getGlobalTimeOffset() {
         return GLOBAL_TIME_OFFSET.get();
     }
+
 }

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/AWS3Signer.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/AWS3Signer.java
@@ -74,7 +74,7 @@ public class AWS3Signer extends AbstractAWSSigner {
         SigningAlgorithm algorithm = SigningAlgorithm.HmacSHA256;
         String nonce = UUID.randomUUID().toString();
 
-        int timeOffset = getTimeOffset(request);
+        long timeOffset = getTimeOffset(request);
         Date dateValue = getSignatureDate(timeOffset);
         String date = DateUtils.formatRFC822Date(dateValue);
         boolean isHttps = false;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
@@ -317,7 +317,7 @@ public class AWS4Signer extends AbstractAWSSigner
     }
 
     protected final long getDateFromRequest(Request<?> request) {
-        final int timeOffset = getTimeOffset(request);
+        final long timeOffset = getTimeOffset(request);
         Date date = getSignatureDate(timeOffset);
         if (overriddenDate != null) {
             date = overriddenDate;

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
@@ -432,7 +432,7 @@ public abstract class AbstractAWSSigner implements Signer {
         return new String(bytes, UTF8);
     }
 
-    protected Date getSignatureDate(int timeOffset) {
+    protected Date getSignatureDate(long timeOffset) {
         Date dateValue = new Date();
         if (timeOffset != 0) {
             long epochMillis = dateValue.getTime();
@@ -442,8 +442,8 @@ public abstract class AbstractAWSSigner implements Signer {
         return dateValue;
     }
 
-    protected int getTimeOffset(Request<?> request) {
-        int timeOffset = request.getTimeOffset();
+    protected long getTimeOffset(Request<?> request) {
+        long timeOffset = request.getTimeOffset();
         if (SDKGlobalConfiguration.getGlobalTimeOffset() != 0) {
             // if global time offset is set then use that (For clock skew
             // issues)

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/auth/QueryStringSigner.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/auth/QueryStringSigner.java
@@ -67,7 +67,7 @@ public class QueryStringSigner extends AbstractAWSSigner implements Signer {
         request.addParameter("AWSAccessKeyId", sanitizedCredentials.getAWSAccessKeyId());
         request.addParameter("SignatureVersion", version.toString());
 
-        int timeOffset = getTimeOffset(request);
+        long timeOffset = getTimeOffset(request);
         request.addParameter("Timestamp", getFormattedTimestamp(timeOffset));
 
         if (sanitizedCredentials instanceof AWSSessionCredentials) {
@@ -161,7 +161,7 @@ public class QueryStringSigner extends AbstractAWSSigner implements Signer {
     /**
      * Formats date as ISO 8601 timestamp
      */
-    private String getFormattedTimestamp(int offset) {
+    private String getFormattedTimestamp(long offset) {
         SimpleDateFormat df = new SimpleDateFormat(
                 "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         df.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -72,7 +72,7 @@ public class AmazonHttpClient {
     private static final int HTTP_STATUS_REQ_TOO_LONG = 413;
     private static final int HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
 
-    private static final int TIME_MILLISEC = 1000;
+    private static final long TIME_MILLISEC = 1000L;
 
     /**
      * Logger providing detailed information on requests/responses. Users can
@@ -439,7 +439,7 @@ public class AmazonHttpClient {
                      * exception.
                      */
                     if (RetryUtils.isClockSkewError(ase)) {
-                        final int timeOffset = parseClockSkewOffset(httpResponse, ase);
+                        final long timeOffset = parseClockSkewOffset(httpResponse, ase);
                         SDKGlobalConfiguration.setGlobalTimeOffset(timeOffset);
                     }
                     resetRequestAfterError(request, ase);
@@ -803,7 +803,7 @@ public class AmazonHttpClient {
         return msg;
     }
 
-    int parseClockSkewOffset(HttpResponse response, AmazonServiceException exception) {
+    long parseClockSkewOffset(HttpResponse response, AmazonServiceException exception) {
         final Date deviceDate = new Date();
         Date serverDate = null;
         String serverDateStr = null;
@@ -827,7 +827,7 @@ public class AmazonHttpClient {
         }
 
         final long diff = deviceDate.getTime() - serverDate.getTime();
-        return (int) (diff / TIME_MILLISEC);
+        return diff / TIME_MILLISEC;
     }
 
     @Override

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/keyvaluestore/AWSKeyValueStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/DefaultRequestTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/DefaultRequestTest.java
@@ -31,8 +31,8 @@ public class DefaultRequestTest {
     @Test
     public void testWithTimeOffset() {
         DefaultRequest r = new DefaultRequest("test");
-        r.withTimeOffset(1000);
-        assertEquals(r.getTimeOffset(), 1000);
+        r.withTimeOffset(1000L);
+        assertEquals(r.getTimeOffset(), 1000L);
     }
 
 }

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/http/AmazonHttpClientTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/http/AmazonHttpClientTest.java
@@ -494,8 +494,8 @@ public class AmazonHttpClientTest {
         AmazonServiceException ase = new AmazonServiceException("ClockSkew");
 
         // assert date is > 10 years
-        int offset = client.parseClockSkewOffset(httpResponse, ase);
-        assertTrue(offset > 315400000);
+        long offset = client.parseClockSkewOffset(httpResponse, ase);
+        assertTrue(offset > 315400000L);
     }
 
     @Test
@@ -505,8 +505,8 @@ public class AmazonHttpClientTest {
         AmazonServiceException ase = new AmazonServiceException("(20041106T084937Z - 15)");
 
         // assert date is > 10 years
-        int offset = client.parseClockSkewOffset(httpResponse, ase);
-        assertTrue(offset > 315400000);
+        long offset = client.parseClockSkewOffset(httpResponse, ase);
+        assertTrue(offset > 315400000L);
     }
 
     @Test
@@ -517,8 +517,8 @@ public class AmazonHttpClientTest {
 
         AmazonServiceException ase = new AmazonServiceException("ClockSkew");
         // assert date is > 10 years
-        int offset = client.parseClockSkewOffset(httpResponse, ase);
-        assertEquals(offset, 0);
+        final long offset = client.parseClockSkewOffset(httpResponse, ase);
+        assertEquals(offset, 0L);
     }
 
     @Test

--- a/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/ClockSkewIntegrationTest.java
+++ b/aws-android-sdk-s3-test/src/androidTest/java/com/amazonaws/services/s3/ClockSkewIntegrationTest.java
@@ -33,7 +33,7 @@ public class ClockSkewIntegrationTest extends S3IntegrationTestBase {
      */
     @Test
     public void testClockSkewS3() {
-        SDKGlobalConfiguration.setGlobalTimeOffset(3600);
+        SDKGlobalConfiguration.setGlobalTimeOffset(3600L);
         s3.listBuckets();
         assertTrue(SDKGlobalConfiguration.getGlobalTimeOffset() < 60);
     }

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/S3Signer.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/S3Signer.java
@@ -158,7 +158,7 @@ public class S3Signer extends AbstractAWSSigner {
         final String encodedResourcePath = HttpUtils.appendUri(request.getEndpoint().getPath(),
                 resourcePath, true);
 
-        final int timeOffset = getTimeOffset(request);
+        final long timeOffset = getTimeOffset(request);
         Date date = getSignatureDate(timeOffset);
 
         if (overrideDate != null) {


### PR DESCRIPTION
**Notes:**

The clock skew auto-correct logic in the SDK relies on the `int` primitive type when calculating the offset. When the offset is converted from milliseconds to days, the ms represented as an `int` have the boundaries as -24 and +24 days. Changing it to long (64-bit precision) fixes the limit.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
