### PR TITLE
chore(build): use in-memory key in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ private void configureAndroidLibrary(Project project) {
     project.android {
         defaultConfig {
             versionName rootProject.findProperty('VERSION_NAME')
+            if (project.hasProperty('signingKeyId')) {
+                System.out.println("Getting signing info from protected source.")
+                project.ext.'signing.keyId' = findProperty('signingKeyId') 
+                project.ext.'signing.password' = findProperty('signingPassword')
+                project.ext.'signing.inMemoryKey' = findProperty('signingInMemoryKey')
+            }
         }
     }
 }

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -105,6 +105,12 @@ afterEvaluate { project ->
 
     signing {
         required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        if (project.hasProperty('signing.inMemoryKey')) {
+            def signingKey = findProperty("signing.inMemoryKey").replace("\\n","\n")
+            def signingPassword = findProperty("signing.password")
+            def keyId = findProperty("signing.keyId")
+            useInMemoryPgpKeys(keyId, signingKey, signingPassword)
+        }
         sign configurations.archives
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Identical to what was done in `amplify-android` to enable signing with an in memory key instead of file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
