### PR TITLE
fix(pinpoint): add campaign attributes to push events

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -889,10 +889,10 @@ abstract class NotificationClientBase {
         }
 
         final AnalyticsEvent pushEvent;
+        this.pinpointContext.getAnalyticsClient().updateEventSourceGlobally(eventSourceAttributes);
         if (isAppInForeground) {
             pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventSourceType.getEventTypeReceivedForeground());
         } else {
-            this.pinpointContext.getAnalyticsClient().updateEventSourceGlobally(eventSourceAttributes);
             pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventSourceType.getEventTypeReceivedBackground());
         }
         pushEvent.addAttribute("isAppInForeground", Boolean.toString(isAppInForeground));

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClientTest.java
@@ -201,11 +201,11 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(1));
+        assertThat(receivedEvent.getAllAttributes().size(), is(4));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertNull(receivedEvent.getAttribute("campaign_id"));
-        assertNull(receivedEvent.getAttribute("treatment_id"));
-        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
@@ -241,9 +241,12 @@ public class ADMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(2));
+        assertThat(receivedEvent.getAllAttributes().size(), is(5));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClientTest.java
@@ -201,11 +201,11 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(1));
+        assertThat(receivedEvent.getAllAttributes().size(), is(4));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertNull(receivedEvent.getAttribute("campaign_id"));
-        assertNull(receivedEvent.getAttribute("treatment_id"));
-        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
@@ -241,9 +241,12 @@ public class BaiduNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(2));
+        assertThat(receivedEvent.getAllAttributes().size(), is(5));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/FCMNotificationClientTest.java
@@ -195,11 +195,11 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(1));
+        assertThat(receivedEvent.getAllAttributes().size(), is(4));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertNull(receivedEvent.getAttribute("campaign_id"));
-        assertNull(receivedEvent.getAttribute("treatment_id"));
-        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
@@ -235,9 +235,12 @@ public class FCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(2));
+        assertThat(receivedEvent.getAllAttributes().size(), is(5));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClientTest.java
@@ -243,11 +243,11 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(1));
+        assertThat(receivedEvent.getAllAttributes().size(), is(4));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
-        assertNull(receivedEvent.getAttribute("campaign_id"));
-        assertNull(receivedEvent.getAttribute("treatment_id"));
-        assertNull(receivedEvent.getAttribute("campaign_activity_id"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 
@@ -283,9 +283,12 @@ public class GCMNotificationClientTest extends MobileAnalyticsTestBase {
         for (Map.Entry<String, String> entry : receivedEvent.getAllAttributes().entrySet()) {
             System.out.println(entry.getKey() + ":" + entry.getValue());
         }
-        assertThat(receivedEvent.getAllAttributes().size(), is(2));
+        assertThat(receivedEvent.getAllAttributes().size(), is(5));
         assertThat(receivedEvent.getAttribute("isOptedOut"), is("true"));
         assertThat(receivedEvent.getAttribute("isAppInForeground"), is("true"));
+        assertThat(receivedEvent.getAttribute("campaign_id"), is("Customers rule"));
+        assertThat(receivedEvent.getAttribute("treatment_id"), is("Treat Me well please"));
+        assertThat(receivedEvent.getAttribute("campaign_activity_id"), is("the brink of dawn"));
         // optOut is true because this test can't get the app icon resource id.
         assertThat(receivedEvent.getAllMetrics().size(), is(0));
 


### PR DESCRIPTION
*Description of changes:*
Journey implementation assumed that journey and campaign events were mutually exclusive and incorrectly removed campaign attributes even when they were expected in the payload. This PR reverses that change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
