### PR TITLE
fix: launch hosted-ui sign-out using custom tabs manager

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -646,7 +646,7 @@ public class AuthClient {
                 .appendQueryParameter(ClientConstants.DOMAIN_QUERY_PARAM_CLIENT_ID, pool.getAppId())
                 .appendQueryParameter(ClientConstants.DOMAIN_QUERY_PARAM_LOGOUT_URI, redirectUri);
         final Uri fqdn = builder.build();
-        launchCustomTabsWithoutCallback(fqdn, browserPackage);
+        launchCustomTabs(fqdn, null, browserPackage);
     }
 
     /**
@@ -665,35 +665,19 @@ public class AuthClient {
 	        mCustomTabsIntent.intent.setPackage(
 	                browserPackage != null ? browserPackage : DEFAULT_BROWSER_PACKAGE);
             mCustomTabsIntent.intent.setData(uri);
-            activity.startActivityForResult(
-                CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent),
-                CUSTOM_TABS_ACTIVITY_CODE
-            );
+            if (activity != null) {
+                activity.startActivityForResult(
+                    CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent),
+                    CUSTOM_TABS_ACTIVITY_CODE
+                );
+            } else {
+                context.startActivity(
+                    CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent)
+                );
+            }
     	} catch (final Exception e) {
     		userHandler.onFailure(e);
     	}
-    }
-
-    /**
-     * Launches the HostedUI page on Custom Tab without paying attention to callbacks.
-     * @param uri Required: {@link Uri}.
-     * @param browserPackage Optional string specifying the browser package to launch the specified url.
-     *                       Defaults to Chrome if null.
-     */
-    private void launchCustomTabsWithoutCallback(final Uri uri, final String browserPackage) {
-        try {
-            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(mCustomTabsSession);
-            mCustomTabsIntent = builder.build();
-            if(pool.getCustomTabExtras() != null)
-                mCustomTabsIntent.intent.putExtras(pool.getCustomTabExtras());
-            mCustomTabsIntent.intent.setPackage(
-                    browserPackage != null ? browserPackage : DEFAULT_BROWSER_PACKAGE);
-            mCustomTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-            mCustomTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            mCustomTabsIntent.launchUrl(context, uri);
-        } catch (final Exception e) {
-            userHandler.onFailure(e);
-        }
     }
 
     private String getUserContextData() {

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/activities/CustomTabsManagerActivity.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/activities/CustomTabsManagerActivity.java
@@ -7,7 +7,10 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 
+import java.util.logging.Logger;
+
 public final class CustomTabsManagerActivity extends Activity {
+    private static final String TAG = "AuthClient"; // This activity is used for HostedUI auth flow
     static final String CUSTOM_TABS_LAUNCHED_KEY = "customTabsLaunched";
     static final String CUSTOM_TABS_INTENT_KEY = "customTabsIntent";
 
@@ -100,18 +103,18 @@ public final class CustomTabsManagerActivity extends Activity {
     }
 
     private void handleAuthorizationComplete() {
+        Log.d(TAG, "Authorization flow completed successfully");
         setResult(RESULT_OK, getIntent());
     }
 
     private void handleAuthorizationCanceled() {
+        Log.d(TAG, "Authorization flow canceled by user");
         setResult(RESULT_CANCELED);
     }
 
     private void extractState(Bundle state) {
         if (state == null) {
-            Log.i("AuthClient",
-                    "CustomTabsManagerActivity was created with a null state. This should never happen. " +
-                            "Please file an issue with us on GitHub.");
+            Log.d(TAG, "CustomTabsManagerActivity was created with a null state.");
             finish();
             return;
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/1090
https://github.com/aws-amplify/amplify-android/issues/1101

*Description of changes:*
Sign out flow was being launched without using `CustomTabsManagerActivity` which would cause `CustomTabsRedirectActivity` to be involved at an incorrect state. This would launch `CustomTabsManagerActivity` from the middle of the flow instead from the beginning.

This PR starts the flow correctly so that the entire auth flow can be carried out as intended.

Note: this PR does not address the fact that sign-out callback is not working as intended, which is a different issue.
