### PR TITLE
feat(mobile-client): hosted-ui auth response handler is now built into redirect activity

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -21,6 +21,9 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Handler;
 import androidx.browser.customtabs.CustomTabsClient;
@@ -28,9 +31,11 @@ import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.amazonaws.cognito.clientcontext.data.UserContextDataProvider;
 import com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsManagerActivity;
+import com.amazonaws.mobileconnectors.cognitoauth.exceptions.AuthClientException;
 import com.amazonaws.mobileconnectors.cognitoauth.exceptions.AuthInvalidGrantException;
 import com.amazonaws.mobileconnectors.cognitoauth.exceptions.AuthNavigationException;
 import com.amazonaws.mobileconnectors.cognitoauth.exceptions.AuthServiceException;
@@ -44,6 +49,7 @@ import com.amazonaws.mobileconnectors.cognitoauth.util.LocalDataManager;
 import java.net.URL;
 import java.security.InvalidParameterException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -67,14 +73,24 @@ public class AuthClient {
     public static final int CUSTOM_TABS_ACTIVITY_CODE = 49281;
 
     /**
+     * Namespace for logging client activities
+     */
+    private static final String TAG = AuthClient.class.getSimpleName();
+
+    /**
+     * Name of redirect activity in charge of handling auth responses.
+     */
+    private static final String REDIRECT_ACTIVITY_NAME = "HostedUIRedirectActivity";
+
+    /**
+     * Default timeout duration for auth redirects.
+     */
+    private static final long REDIRECT_TIMEOUT_SECONDS = 10;
+
+    /**
      * Specifies what browser package to default to if one isn't specified.
      */
     private static final String DEFAULT_BROWSER_PACKAGE = ClientConstants.CHROME_PACKAGE;
-
-    /**
-     * Default timeout duration to wait for sign-out redirect.
-     */
-    private static final long DEFAULT_REDIRECT_TIMEOUT_SECONDS = 3;
 
     /**
      * Android application context.
@@ -111,6 +127,12 @@ public class AuthClient {
      */
     private AuthHandler userHandler;
 
+    /**
+     * Remembers whether redirect activity was found in manifest or not.
+     */
+    private boolean isRedirectActivityDeclared;
+
+
     // - Chrome Custom Tabs Controls
     private CustomTabsClient mCustomTabsClient;
     private CustomTabsSession mCustomTabsSession;
@@ -138,6 +160,7 @@ public class AuthClient {
         this.context = context;
         this.pool = pool;
         this.userId = username;
+        this.isRedirectActivityDeclared = false;
         preWarmChrome();
     }
 
@@ -280,8 +303,7 @@ public class AuthClient {
      * Signs-out a user.
      * <p>
      *     Launches the sign-out Cognito web end-point to clear all Cognito Auth cookies stored
-     *     by Chrome.
-     *     Cached tokens will be deleted if sign-out redirect is handled properly or timed out.
+     *     by Chrome. Cached tokens will be deleted if sign-out redirect is completed.
      * </p>
      *
      * @param clearLocalTokensOnly true if signs out the user from the client,
@@ -289,7 +311,6 @@ public class AuthClient {
      * @param browserPackage String specifying the browser package to launch the specified url.
      */
     public void signOut(final boolean clearLocalTokensOnly, final String browserPackage) {
-        // Try deleting cookies.
         if (!clearLocalTokensOnly) {
             endSession(browserPackage);
         }
@@ -298,14 +319,25 @@ public class AuthClient {
         LocalDataManager.clearCache(pool.awsKeyValueStore, context, pool.getAppId(), userId);
     }
 
-    private void endSession(final String browserPackage) {
+    /**
+     * Ends current browser session.
+     * @param browserPackage browser package to launch sign-out endpoint from.
+     * @throws AuthClientException if sign-out redirect fails to resolve.
+     */
+    private void endSession(final String browserPackage) throws AuthClientException {
+        boolean redirectReceived;
         try {
             cookiesCleared = new CountDownLatch(1);
             launchSignOut(pool.getSignOutRedirectUri(), browserPackage);
-            cookiesCleared.await(DEFAULT_REDIRECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!isRedirectActivityDeclared()) {
+                cookiesCleared.countDown();
+            }
+            redirectReceived = cookiesCleared.await(REDIRECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            // Do nothing. It's possible that sign-out redirect URI was successfully
-            // launched but success callback wasn't called.
+            throw new AuthNavigationException("User cancelled sign-out.");
+        }
+        if (!redirectReceived) {
+            throw new AuthServiceException("Timed out while waiting for sign-out redirect response.");
         }
     }
 
@@ -440,6 +472,7 @@ public class AuthClient {
                 } else {
                     if (cookiesCleared != null) {
                         cookiesCleared.countDown();
+                        Log.d(TAG, "Sign-out was successful.");
                     }
 
                     // User sign-out.
@@ -599,7 +632,7 @@ public class AuthClient {
         if (userContextData != null) {
             httpBodyParams.put(ClientConstants.DOMAIN_QUERY_PARAM_USERCONTEXTDATA, userContextData);
         }
-        return  httpBodyParams;
+        return httpBodyParams;
     }
 
     /**
@@ -698,9 +731,9 @@ public class AuthClient {
                     CUSTOM_TABS_ACTIVITY_CODE
                 );
             } else {
-                context.startActivity(
-                    CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent)
-                );
+                Intent startIntent = CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent);
+                startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(startIntent);
             }
     	} catch (final Exception e) {
     		userHandler.onFailure(e);
@@ -734,5 +767,37 @@ public class AuthClient {
                 mCustomTabsClient = null;
             }
         };
+    }
+
+    // Inspects context to determine whether HostedUIRedirectActivity is declared in
+    // customer's AndroidManifest.xml.
+    private boolean isRedirectActivityDeclared() {
+        // If the activity was found at least once, then don't bother searching again.
+        if (isRedirectActivityDeclared) {
+            return true;
+        }
+        if (context == null) {
+            Log.w(TAG, "Context is null. Failed to inspect packages.");
+            return false;
+        }
+        try {
+            List<PackageInfo> packages = context.getPackageManager()
+                    .getInstalledPackages(PackageManager.GET_ACTIVITIES);
+            for (PackageInfo packageInfo : packages) {
+                if (packageInfo.activities == null) {
+                    continue;
+                }
+                for (ActivityInfo activityInfo : packageInfo.activities) {
+                    if (activityInfo.name.contains(REDIRECT_ACTIVITY_NAME)) {
+                        isRedirectActivityDeclared = true;
+                        return true;
+                    }
+                }
+            }
+            Log.w(TAG, REDIRECT_ACTIVITY_NAME + " is not declared in AndroidManifest.");
+        } catch (Exception error) {
+            Log.w(TAG, "Failed to inspect packages.");
+        }
+        return false;
     }
 }

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -732,7 +732,7 @@ public class AuthClient {
                 );
             } else {
                 Intent startIntent = CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent);
-                startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_NO_HISTORY);
                 context.startActivity(startIntent);
             }
     	} catch (final Exception e) {

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/activities/CustomTabsRedirectActivity.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/activities/CustomTabsRedirectActivity.java
@@ -3,6 +3,12 @@ package com.amazonaws.mobileconnectors.cognitoauth.activities;
 import android.app.Activity;
 import android.os.Bundle;
 
+/**
+ * Handles auth redirect for sign-in and sign-out.
+ *
+ * If cognitoauth module is being used in conjunction with mobile client, then use
+ * com.amazonaws.mobile.client.activities.CustomTabsRedirectActivity instead of this.
+ */
 public final class CustomTabsRedirectActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceBundle) {

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/activities/CustomTabsRedirectActivity.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/activities/CustomTabsRedirectActivity.java
@@ -6,8 +6,8 @@ import android.os.Bundle;
 /**
  * Handles auth redirect for sign-in and sign-out.
  *
- * If cognitoauth module is being used in conjunction with mobile client, then use
- * com.amazonaws.mobile.client.activities.CustomTabsRedirectActivity instead of this.
+ * If cognitoauth module is being used in conjunction with AWSMobileClient, then use
+ * com.amazonaws.mobile.client.activities.HostedUIRedirectActivity instead of this.
  */
 public final class CustomTabsRedirectActivity extends Activity {
     @Override

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/activities/CustomTabsRedirectActivity.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/activities/CustomTabsRedirectActivity.java
@@ -6,6 +6,9 @@ import android.os.Bundle;
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsManagerActivity;
 
+/**
+ * Handles auth redirect for sign-in and sign-out.
+ */
 public final class CustomTabsRedirectActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceBundle) {

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/activities/CustomTabsRedirectActivity.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/activities/CustomTabsRedirectActivity.java
@@ -1,0 +1,23 @@
+package com.amazonaws.mobile.client.activities;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import com.amazonaws.mobile.client.AWSMobileClient;
+import com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsManagerActivity;
+
+public final class CustomTabsRedirectActivity extends Activity {
+    @Override
+    public void onCreate(Bundle savedInstanceBundle) {
+        super.onCreate(savedInstanceBundle);
+        startActivity(CustomTabsManagerActivity.createResponseHandlingIntent(
+                this, getIntent().getData()));
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        AWSMobileClient.getInstance().handleAuthResponse(getIntent());
+        finish();
+    }
+}

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/activities/HostedUIRedirectActivity.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/activities/HostedUIRedirectActivity.java
@@ -2,6 +2,7 @@ package com.amazonaws.mobile.client.activities;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsManagerActivity;
@@ -9,7 +10,7 @@ import com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsManagerAc
 /**
  * Handles auth redirect for sign-in and sign-out.
  */
-public final class CustomTabsRedirectActivity extends Activity {
+public final class HostedUIRedirectActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
@@ -20,6 +21,7 @@ public final class CustomTabsRedirectActivity extends Activity {
     @Override
     public void onResume() {
         super.onResume();
+        Log.d("AuthClient", "Handling auth redirect response");
         AWSMobileClient.getInstance().handleAuthResponse(getIntent());
         finish();
     }


### PR DESCRIPTION
*Issue #, if available:*
#2291 

*Description of changes:*
Fixes `signOut` after `showSignIn()` from failing to clear browser cookies.

## Issue
Previously, `AuthClient#signOut()` would do the following:
1. clear cache (marks current state as "signed out")
2. launch sign out redirect URL for clearing browser cookies

Step 2 was non-blocking, which meant that it could be cancelled by switching activity, resulting in a state where cookies are _not_ cleared, but the client mistakenly believes that it is currently signed out. This results in the next sign-in attempt not prompting for the credentials.

## Fix
Auth redirect handler is now added to `HostedUIRedirectActivity#onResume()` (called upon finishing the flow regardless of whether it was successful or canceled), which will then trigger the callbacks to let `AWSMobileClient` know that auth flow was finished. This will let `AWSMobileClient` know that sign-in or sign-out was either successful or canceled midway and handle the result appropriately.


There is an added bonus with this PR that now the customer no longer needs to call the `AWSMobileClient#handleAuthResponse(Intent)` method in their own app for handling auth results.

## TLDR
Hosted UI sign-out will now work _**without any breaking change**_, but the fix will only be applied if, `AndroidManifest.xml` file is updated to use the new `HostedUIRedirectActivity`.

## TODO
- ~~Add official documentation for v2 SDK~~ https://github.com/aws-amplify/docs/pull/3214
- Add official documentation for Amplify

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
