### PR TITLE
feat(aws-android-sdk-mobile-client): adds signature with user attributes in confirmSignIn

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1291,7 +1291,17 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                               final Callback<SignInResult> callback) {
 
         final InternalCallback internalCallback = new InternalCallback<SignInResult>(callback);
-        internalCallback.async(_confirmSignIn(signInChallengeResponse, clientMetadata, internalCallback));
+        internalCallback.async(_confirmSignIn(signInChallengeResponse, clientMetadata, Collections.<String, String>emptyMap(), internalCallback));
+    }
+
+    @AnyThread
+    public void confirmSignIn(final String signInChallengeResponse,
+                              final Map<String, String> clientMetadata,
+                              final Map<String, String> userAttributes,
+                              final Callback<SignInResult> callback) {
+
+        final InternalCallback internalCallback = new InternalCallback<SignInResult>(callback);
+        internalCallback.async(_confirmSignIn(signInChallengeResponse, clientMetadata, userAttributes, internalCallback));
     }
 
     @WorkerThread
@@ -1304,11 +1314,21 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                       final Map<String, String> clientMetadata) throws Exception {
 
         final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>();
-        return internalCallback.await(_confirmSignIn(signInChallengeResponse, clientMetadata, internalCallback));
+        return internalCallback.await(_confirmSignIn(signInChallengeResponse, clientMetadata, Collections.<String, String>emptyMap(), internalCallback));
+    }
+
+    @WorkerThread
+    public SignInResult confirmSignIn(final String signInChallengeResponse,
+                                      final Map<String, String> clientMetadata,
+                                      final Map<String, String> userAttributes) throws Exception {
+
+        final InternalCallback<SignInResult> internalCallback = new InternalCallback<SignInResult>();
+        return internalCallback.await(_confirmSignIn(signInChallengeResponse, clientMetadata, userAttributes, internalCallback));
     }
 
     private Runnable _confirmSignIn(final String signInChallengeResponse,
                                     final Map<String, String> clientMetadata,
+                                    final Map<String, String> userAttributes,
                                     final Callback<SignInResult> callback) {
 
         return new Runnable() {
@@ -1333,6 +1353,9 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         ((NewPasswordContinuation) signInChallengeContinuation)
                                 .setPassword(signInChallengeResponse);
                         signInChallengeContinuation.setClientMetaData(clientMetadata);
+                        for (final String key : userAttributes.keySet()) {
+                            signInChallengeContinuation.setChallengeResponse(CHALLENGE_RESPONSE_USER_ATTRIBUTES_PREFIX_KEY + key, userAttributes.get(key));
+                        }
                         detectedContinuation = signInChallengeContinuation;
                         signInCallback = new InternalCallback<SignInResult>(callback);
                         break;
@@ -1340,6 +1363,9 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         signInChallengeContinuation.setChallengeResponse("ANSWER", signInChallengeResponse);
                         detectedContinuation = signInChallengeContinuation;
                         signInCallback = new InternalCallback<SignInResult>(callback);
+                        for (final String key : userAttributes.keySet()) {
+                            signInChallengeContinuation.setChallengeResponse(CHALLENGE_RESPONSE_USER_ATTRIBUTES_PREFIX_KEY + key, userAttributes.get(key));
+                        }
                         if (clientMetadata != null) {
                             signInChallengeContinuation.setClientMetaData(clientMetadata);
                         }

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -1363,9 +1363,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         signInChallengeContinuation.setChallengeResponse("ANSWER", signInChallengeResponse);
                         detectedContinuation = signInChallengeContinuation;
                         signInCallback = new InternalCallback<SignInResult>(callback);
-                        for (final String key : userAttributes.keySet()) {
-                            signInChallengeContinuation.setChallengeResponse(CHALLENGE_RESPONSE_USER_ATTRIBUTES_PREFIX_KEY + key, userAttributes.get(key));
-                        }
                         if (clientMetadata != null) {
                             signInChallengeContinuation.setClientMetaData(clientMetadata);
                         }


### PR DESCRIPTION
*Description of changes:*
Adds ability to pass user attributes in confirm sign in flow. This is meant to match th[e functionality in amplify-ios](https://github.com/aws-amplify/amplify-ios/blob/3f700ac8b16dbfed3d7d40b461d508d6e0f7d1ab/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift). There is a forthcoming PR in amplify-android. This is a draft PR so it is not accidentally merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
