### PR TITLE
Read the `authenticationFlowType` value of the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [Release 2.25.0](https://github.com/aws-amplify/aws-sdk-android/releases/tag/release_v2.25.0)
+
+### Features
+- **aws-android-sdk-cognitoidentityprovider:** update models to latest (#2510)
+
+### Bug Fixes
+- **aws-android-sdk-lex:** prioritize custom lex signer for all regions (#2506)
+- **mobileclient:** Honor auth flow setting from config (#2499)
+- **aws-android-sdk-polly:** use correct SignerConfig in all regions (#2505)
+
+[See all changes between 2.24.0 and 2.25.0](https://github.com/aws-amplify/aws-sdk-android/compare/release_v2.24.0...release_v2.25.0)
+
 ## [Release 2.24.0](https://github.com/aws-amplify/aws-sdk-android/releases/tag/release_v2.24.0)
 
 ### Features

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -318,6 +318,13 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
     boolean mIsPersistenceEnabled = true;
 
     /**
+     * Flag that indicates if the SRP password verification is used in
+     * a custom authentication Flow. By default, this is set to false.
+     * If set to true custom authentication would be enabled.
+     */
+    boolean mCustomAuthEnabled = true;
+
+    /**
      * Constructor invoked by getInstance.
      *
      * @throws AssertionError when this is called with context more than once.
@@ -492,7 +499,9 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                     }
 
                     mIsPersistenceEnabled = true; // Default value
-                    // Read Persistence key from the awsconfiguration.json and set the flag
+                    mCustomAuthEnabled = false; // Default value
+
+                    // Read Persistence key from the awsconfiguration.json and set the flags
                     // appropriately.
                     try {
                         if (awsConfiguration.optJsonObject(AUTH_KEY) != null &&
@@ -500,6 +509,14 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                             mIsPersistenceEnabled = awsConfiguration
                                     .optJsonObject(AUTH_KEY)
                                     .getBoolean("Persistence");
+                        }
+
+                        if (
+                                awsConfiguration.optJsonObject(AUTH_KEY) != null &&
+                                awsConfiguration.optJsonObject(AUTH_KEY).has("authenticationFlowType") &&
+                                awsConfiguration.optJsonObject(AUTH_KEY).getString("authenticationFlowType").equals("CUSTOM_AUTH")
+                        ) {
+                            mCustomAuthEnabled = true;
                         }
                     } catch (final Exception ex) {
                         // If reading from awsconfiguration.json fails, invoke callback.
@@ -788,6 +805,12 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                 }
             }
         }
+    }
+
+    public boolean isCustomAuthEnabled() { return mCustomAuthEnabled; }
+
+    public void setCustomAuthEnabled(boolean customAuthEnabled) {
+        mCustomAuthEnabled = customAuthEnabled;
     }
 
     /**
@@ -1246,7 +1269,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                                     String authFlowType = authFlowTypeInConfig ?
                                         awsConfiguration.optJsonObject(AUTH_KEY).getString("authenticationFlowType") :
                                         null;
-                                    if (authFlowTypeInConfig && AUTH_TYPE_INIT_CUSTOM_AUTH.equals(authFlowType)) {
+                                    if (mCustomAuthEnabled) {
                                         // If there's a value in the config and it's CUSTOM_AUTH, we'll
                                         // use one of the below constructors depending on what's passed in.
                                         if (password != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ android.enableJetifier=true
 
 GROUP=com.amazonaws
 
-VERSION_NAME=2.24.0
+VERSION_NAME=2.25.0
 
 POM_URL=https://github.com/aws/aws-sdk-android
 POM_SCM_URL=https://github.com/aws/aws-sdk-android


### PR DESCRIPTION
Attempt to fix #1488. Related to but doesn't fix https://github.com/aws-amplify/aws-sdk-android/issues/684. A small step to show the need for customizing programmatically after the SDK has been initialized. 

The change is inspired from the workaround described in https://github.com/aws-amplify/aws-sdk-ios/issues/1204 and the original PR that looks slightly different when it's initially introduced on iOS https://github.com/aws-amplify/aws-sdk-ios/pull/1860.

The idea with the change is to allow us to programmatically change to custom auth before attempting login, calling the custom challenge, then revert the change after the sign in, if we fail the user could change/try a different method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
