### PR TITLE
fix(aws-android-sdk-lex): prioritize custom lex signer for all regions

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/internal/config/InternalConfig.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/internal/config/InternalConfig.java
@@ -150,6 +150,8 @@ public class InternalConfig {
         ret.put("s3/ap-south-1", new SignerConfig("AWSS3V4SignerType"));
         ret.put("s3/ap-northeast-2", new SignerConfig("AWSS3V4SignerType"));
         ret.put("s3/eu-west-2", new SignerConfig("AWSS3V4SignerType"));
+        ret.put("lex/eu-central-1", new SignerConfig("AmazonLexV4Signer"));
+        ret.put("lex/cn-north-1", new SignerConfig("AmazonLexV4Signer"));
         return ret;
     }
 

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/internal/config/InternalConfigTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/internal/config/InternalConfigTest.java
@@ -43,6 +43,24 @@ public class InternalConfigTest {
     }
 
     @Test
+    public void lex() throws Exception {
+        InternalConfig config = new InternalConfig();
+        lexAssertions(config);
+    }
+
+    private void lexAssertions(InternalConfig config) {
+        // lex
+        SignerConfig signer = config.getSignerConfig("lex");
+        assertEquals("AmazonLexV4Signer", signer.getSignerType());
+        // lex EU
+        signer = config.getSignerConfig("lex", "eu-central-1");
+        assertEquals("AmazonLexV4Signer", signer.getSignerType());
+        // lex us-east-1
+        signer = config.getSignerConfig("lex", Regions.US_EAST_1.name());
+        assertEquals("AmazonLexV4Signer", signer.getSignerType());
+    }
+
+    @Test
     public void cloudfront() throws Exception {
         InternalConfig config = new InternalConfig();
         cloudfrontAssertions(config);


### PR DESCRIPTION
*Issue #, if available:*
#2385 
#2485

*Description of changes:*
Default sigv4 signer was being used for lex service in `eu-central-1` and `cn-north-1` regions. Now Lex custom signer is used for both regions too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
