### PR TITLE
chore(docs): releases not pushed to S3 anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,6 @@ dependencies {
 
 Above, SERVICE might be `s3`, `ddb`, `pinpoint`, etc. A full list is provided below.
 
-### Downloading SDK libraries
-
-You can also download a `.zip` file containg `.aar` files for each of the SDK modules, [here](https://sdk-for-android.amazonwebservices.com/latest/aws-android-sdk.zip).
-
-Add the aar files to a folder in your project called `libs` (create one if it doesn't already exist).
-
-Ensure that the `libs` directory is included in your module-level `build.gradle`, under the `dependencies` block:
-```groovy
-dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.aar'])
-}
-```
-
 ## Available Modules
  
  * apigateway-core


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The updated release process does not push to S3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
