### PR TITLE
Fix | Use cert chain to connect to IoT Core

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotKeystoreHelper.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotKeystoreHelper.java
@@ -411,7 +411,7 @@ public final class AWSIotKeystoreHelper {
             newTokens.add(tokens[i].split(endDelimiter)[0]);
         }
 
-        byte[][] ders = new byte[2][];
+        byte[][] ders = new byte[newTokens.size()][];
         for (int i = 0; i < newTokens.size(); i++) {
             ders[i] = Base64.decode(newTokens.get(i));
         }

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotKeystoreHelper.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotKeystoreHelper.java
@@ -295,11 +295,17 @@ public final class AWSIotKeystoreHelper {
             KeyStore tempKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
             tempKeystore.load(null);
 
-            X509Certificate[] certs = (X509Certificate[]) customerKeystore.getCertificateChain(certId);
-            tempKeystore.setCertificateEntry("cert-alias", certs[0]);
+            Certificate[] certs = customerKeystore.getCertificateChain(certId);
+            X509Certificate[] xcerts = new X509Certificate[certs.length];
+
+            for (int i = 0; i < certs.length; i++) {
+                xcerts[i] = (X509Certificate) certs[i];
+            }
+
+            tempKeystore.setCertificateEntry("cert-alias", xcerts[0]);
             Key key = customerKeystore.getKey(certId, customerKeystorePassword.toCharArray());
             tempKeystore.setKeyEntry("key-alias", key,
-                    AWS_IOT_INTERNAL_KEYSTORE_PASSWORD.toCharArray(), certs);
+                    AWS_IOT_INTERNAL_KEYSTORE_PASSWORD.toCharArray(), xcerts);
 
             return tempKeystore;
 

--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotKeystoreHelper.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotKeystoreHelper.java
@@ -38,6 +38,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility class for working with keystores, private and public keys, and
@@ -116,12 +118,16 @@ public final class AWSIotKeystoreHelper {
             throw new IllegalArgumentException("keystorePassword cannot be null");
         }
 
-        byte[] certBytes = parseDERFromPEM(certPem, AWS_IOT_PEM_BEGIN_CERT_TAG,
+        byte[][] certBytes = parseDERFromPEM(certPem, AWS_IOT_PEM_BEGIN_CERT_TAG,
                 AWS_IOT_PEM_END_CERT_TAG);
 
         try {
 
-            X509Certificate cert = generateCertificateFromDER(certBytes);
+            X509Certificate[] xCerts = new X509Certificate[certBytes.length];
+
+            for (int i = 0; i < certBytes.length; i++) {
+                xCerts[i] = generateCertificateFromDER(certBytes[i]);
+            }
 
             KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
             File keystoreFile = new File(keystorePath, keystoreName);
@@ -134,11 +140,9 @@ public final class AWSIotKeystoreHelper {
             keystore.load(fis, keystorePassword.toCharArray());
             fis.close();
 
-            keystore.setCertificateEntry(certId, cert);
+            keystore.setCertificateEntry(certId, xCerts[0]);
             keystore.setKeyEntry(certId, privKey, keystorePassword.toCharArray(),
-                    new Certificate[] {
-                        cert
-                    });
+                    xCerts); // we store the chain
 
             String keystoreFileAndPath;
 
@@ -291,13 +295,11 @@ public final class AWSIotKeystoreHelper {
             KeyStore tempKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
             tempKeystore.load(null);
 
-            X509Certificate cert = (X509Certificate) customerKeystore.getCertificate(certId);
-            tempKeystore.setCertificateEntry("cert-alias", cert);
+            X509Certificate[] certs = (X509Certificate[]) customerKeystore.getCertificateChain(certId);
+            tempKeystore.setCertificateEntry("cert-alias", certs[0]);
             Key key = customerKeystore.getKey(certId, customerKeystorePassword.toCharArray());
             tempKeystore.setKeyEntry("key-alias", key,
-                    AWS_IOT_INTERNAL_KEYSTORE_PASSWORD.toCharArray(), new Certificate[] {
-                        cert
-                    });
+                    AWS_IOT_INTERNAL_KEYSTORE_PASSWORD.toCharArray(), certs);
 
             return tempKeystore;
 
@@ -402,10 +404,18 @@ public final class AWSIotKeystoreHelper {
      * @param endDelimiter beginning delimiter of PEM (ala ----END ...).
      * @return byte array containing certificate data parsed from PEM.
      */
-    static byte[] parseDERFromPEM(String data, String beginDelimiter, String endDelimiter) {
+    static byte[][] parseDERFromPEM(String data, String beginDelimiter, String endDelimiter) {
         String[] tokens = data.split(beginDelimiter);
-        tokens = tokens[1].split(endDelimiter);
-        return Base64.decode(tokens[0]);
+        List<String> newTokens = new ArrayList<>();
+        for (int i = 1; i < tokens.length; i++) {
+            newTokens.add(tokens[i].split(endDelimiter)[0]);
+        }
+
+        byte[][] ders = new byte[2][];
+        for (int i = 0; i < newTokens.size(); i++) {
+            ders[i] = Base64.decode(newTokens.get(i));
+        }
+        return ders;
     }
 
     /**


### PR DESCRIPTION
This fix enables the connection for android devices using a cert chain (without this JITP can't work)

Instead of reading just the first part of a certificate, we read the entire cert chain and use it to connect to IoT Core.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
