### PR TITLE
fix(aws-android-sdk-io): AWSlotMqttManager offlinePublishQueueBound n…

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1665,7 +1665,7 @@ public class AWSIotMqttManager {
      * if the client is unable to publish (offline).
      * Behavior on a full queue is defined by fullQueueKeepsOldest.  If this is true
      * we keep the oldest values so we skip adding on a full queue.  If this is false
-     * we want the queue to always have the latest values so pop the first element out
+     * we want the queue to always have the latest values so poll the first element out
      * and append.
      *
      * @param data  byte array of message payload.
@@ -1685,7 +1685,7 @@ public class AWSIotMqttManager {
                         new AmazonClientException("Failed to publish the message. Queue is full and set to hold onto the oldest messages."));
                 return;
             } else {
-                mqttMessageQueue.remove(0);
+                mqttMessageQueue.poll();
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*
#2558 

*Description of changes:*
Calling the ConcurrentLinkedQueue.remove(0) would result into removing
Integer initialized to 0 from an Integer queue, however in this case it
always fails to remove first AWSIotMqttQueueMessage Object.

Switch the unsupported ConcurrentLinkedQueue.remove(0) call to
the supported poll.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
