### PR TITLE
fix(aws-android-sdk-mobile-client): fix NPE in hosted UI options

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -3203,7 +3203,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                 final Map<String, String> tokensBody = new HashMap<String, String>();
                 try {
                     tokensUriBuilder = Uri.parse(hostedUIJSON.getString("TokenURI")).buildUpon();
-                    if (hostedUIOptions.getSignInQueryParameters() != null) {
+                    if (hostedUIOptions.getTokenQueryParameters() != null) {
                         for (Map.Entry<String, String> e : hostedUIOptions.getTokenQueryParameters().entrySet()) {
                             tokensUriBuilder.appendQueryParameter(e.getKey(), e.getValue());
                         }


### PR DESCRIPTION
*Issue #, if available:*
#2560 
*Description of changes:*
Null-check was being performed on an irrelevant field, causing an NPE in certain situations. Now checks for `null` in correct field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
