### PR TITLE
Set token expiration time when credentials provider is AWSMobileClient

### DIFF
--- a/aws-android-sdk-kinesisvideo/build.gradle
+++ b/aws-android-sdk-kinesisvideo/build.gradle
@@ -20,6 +20,7 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
     implementation 'androidx.annotation:annotation:1.1.0'
+    implementation project(path: ':aws-android-sdk-mobile-client')
     //noinspection DuplicatePlatformClasses
     compileOnly 'org.apache.httpcomponents:httpclient:4.5.12'
     testImplementation 'junit:junit:4.13.1'

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/mobileconnectors/kinesisvideo/auth/KinesisVideoCredentialsProviderImpl.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/mobileconnectors/kinesisvideo/auth/KinesisVideoCredentialsProviderImpl.java
@@ -28,8 +28,10 @@ import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentials;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.common.logging.Log;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
+import com.amazonaws.mobile.client.AWSMobileClient;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Implementation of the AWS Credentials Provider wrapper for Android
@@ -67,6 +69,15 @@ public class KinesisVideoCredentialsProviderImpl extends AbstractKinesisVideoCre
 
             expiration = cognitoCredentialsProvider.getSessionCredentialsExpiration();
             log.debug("Refreshed token expiration is %s", expiration);
+        } else if (credentialsProvider instanceof AWSMobileClient) {
+            AWSMobileClient awsMobileClient = (AWSMobileClient) credentialsProvider;
+            try {
+                expiration = awsMobileClient.getTokens().getAccessToken().getExpiration();
+                log.debug("Refreshed token expiration is %s", expiration);
+            } catch (Exception e) {
+                log.debug("Failed to set the next token refresh time. Defaulting to 40 minutes. %s", e.getMessage());
+                expiration.setTime(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(40L));
+            }
         }
 
         log.debug("Returning %scredentials with expiration %s",

--- a/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/mobileconnectors/kinesisvideo/auth/KinesisVideoCredentialsProviderImpl.java
+++ b/aws-android-sdk-kinesisvideo/src/main/java/com/amazonaws/mobileconnectors/kinesisvideo/auth/KinesisVideoCredentialsProviderImpl.java
@@ -75,8 +75,7 @@ public class KinesisVideoCredentialsProviderImpl extends AbstractKinesisVideoCre
                 expiration = awsMobileClient.getTokens().getAccessToken().getExpiration();
                 log.debug("Refreshed token expiration is %s", expiration);
             } catch (Exception e) {
-                log.debug("Failed to set the next token refresh time. Defaulting to 40 minutes. %s", e.getMessage());
-                expiration.setTime(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(40L));
+                throw new KinesisVideoException("Failed to refresh! " + e.getMessage());
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the updateCredentials() method to take AWSMobileClient credentialsProvider into account. When the credentialsProvider is an instanceof AWSMobileClient, the returned expiration time is indefinite, meaning that this method does not get called in the future when the credentials expire and needs refreshing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
