### PR TITLE
VersionInfoUtils null check for string replace

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/util/VersionInfoUtils.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/util/VersionInfoUtils.java
@@ -131,6 +131,9 @@ public class VersionInfoUtils {
      * @return the input with spaces replaced by underscores
      */
     private static String replaceSpaces(final String input) {
-        return input.replace(' ', '_');
+        if (input != null){
+            return input.replace(' ', '_');
+        }
+        return input;
     }
 }


### PR DESCRIPTION
Adding a null check for string replace in VersionInfoUtils. This is causing crashes in production for kinesis.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
