### PR TITLE
fix(cognitoidentityprovider): Fix UserPoolId validation ReDoS

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
@@ -274,10 +274,10 @@ public class CognitoUserPool {
         initialize(context);
         this.context = context;
         if (userPoolId.isEmpty() || clientId.isEmpty()) {
-            throw new IllegalArgumentException("Both UserPoolId and ClientId are required. ");
+            throw new IllegalArgumentException("Both UserPoolId and ClientId are required.");
         }
         if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches(USER_POOL_ID_PATTERN, userPoolId)) {
-            throw new IllegalArgumentException("Invalid userPoolId format. ");
+            throw new IllegalArgumentException("Invalid userPoolId format.");
         }
         this.userPoolId = userPoolId;
         this.clientId = clientId;
@@ -334,10 +334,10 @@ public class CognitoUserPool {
         initialize(context);
         this.context = context;
         if (userPoolId.isEmpty() || clientId.isEmpty()) {
-            throw new IllegalArgumentException("Both UserPoolId and ClientId are required. ");
+            throw new IllegalArgumentException("Both UserPoolId and ClientId are required.");
         }
         if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches(USER_POOL_ID_PATTERN, userPoolId)) {
-            throw new IllegalArgumentException("Invalid userPoolId format. ");
+            throw new IllegalArgumentException("Invalid userPoolId format.");
         }
         this.userPoolId = userPoolId;
         this.clientId = clientId;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
@@ -78,6 +78,7 @@ public class CognitoUserPool {
     private static final Log logger = LogFactory.getLog(CognitoUserPool.class);
 
     private static final int USER_POOL_ID_MAX_LENGTH = 55;
+    private static final String USER_POOL_ID_PATTERN = "^[\\w-]+_[0-9a-zA-Z]+$";
 
     /**
      * Cognito Your Identity Pool ID
@@ -275,7 +276,7 @@ public class CognitoUserPool {
         if (userPoolId.isEmpty() || clientId.isEmpty()) {
             throw new IllegalArgumentException("Both UserPoolId and ClientId are required. ");
         }
-        if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches("[\\w-]+_[0-9a-zA-Z]+", userPoolId)) {
+        if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches(USER_POOL_ID_PATTERN, userPoolId)) {
             throw new IllegalArgumentException("Invalid userPoolId format. ");
         }
         this.userPoolId = userPoolId;
@@ -335,7 +336,7 @@ public class CognitoUserPool {
         if (userPoolId.isEmpty() || clientId.isEmpty()) {
             throw new IllegalArgumentException("Both UserPoolId and ClientId are required. ");
         }
-        if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches("[\\w-]+_[0-9a-zA-Z]+", userPoolId)) {
+        if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches(USER_POOL_ID_PATTERN, userPoolId)) {
             throw new IllegalArgumentException("Invalid userPoolId format. ");
         }
         this.userPoolId = userPoolId;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
@@ -188,11 +188,7 @@ public class CognitoUserPool {
 
             final JSONObject userPoolConfiguration = awsConfiguration.optJsonObject("CognitoUserPool");
             this.context = context;
-            String userPoolId = userPoolConfiguration.getString("PoolId");
-            if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches("/^[\\w-]+_[0-9a-zA-Z]+$/", userPoolId)) {
-                throw new IllegalArgumentException("Invalid userPoolId format.");
-            }
-            this.userPoolId = userPoolId;
+            this.userPoolId = userPoolConfiguration.getString("PoolId");
             this.clientId = userPoolConfiguration.getString("AppClientId");
             this.clientSecret = userPoolConfiguration.optString("AppClientSecret");
             this.pinpointEndpointId = CognitoPinpointSharedContext.getPinpointEndpoint(context, userPoolConfiguration.optString("PinpointAppId"));
@@ -276,6 +272,12 @@ public class CognitoUserPool {
     public CognitoUserPool(Context context, String userPoolId, String clientId, String clientSecret, ClientConfiguration clientConfiguration, Regions region, String pinpointAppId) {
         initialize(context);
         this.context = context;
+        if (userPoolId.isEmpty() || clientId.isEmpty()) {
+            throw new IllegalArgumentException("Both UserPoolId and ClientId are required. ");
+        }
+        if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches("[\\w-]+_[0-9a-zA-Z]+", userPoolId)) {
+            throw new IllegalArgumentException("Invalid userPoolId format. ");
+        }
         this.userPoolId = userPoolId;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
@@ -330,6 +332,12 @@ public class CognitoUserPool {
     public CognitoUserPool(Context context, String userPoolId, String clientId, String clientSecret, AmazonCognitoIdentityProvider client, String pinpointAppId, String cognitoUserPoolCustomEndpoint) {
         initialize(context);
         this.context = context;
+        if (userPoolId.isEmpty() || clientId.isEmpty()) {
+            throw new IllegalArgumentException("Both UserPoolId and ClientId are required. ");
+        }
+        if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches("[\\w-]+_[0-9a-zA-Z]+", userPoolId)) {
+            throw new IllegalArgumentException("Invalid userPoolId format. ");
+        }
         this.userPoolId = userPoolId;
         this.clientId = clientId;
         this.clientSecret = clientSecret;

--- a/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPool.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * This represents a user-pool in a Cognito identity provider account. The user-pools are called as
@@ -75,6 +76,9 @@ import java.util.Map;
 public class CognitoUserPool {
 
     private static final Log logger = LogFactory.getLog(CognitoUserPool.class);
+
+    private static final int USER_POOL_ID_MAX_LENGTH = 55;
+
     /**
      * Cognito Your Identity Pool ID
      */
@@ -184,7 +188,11 @@ public class CognitoUserPool {
 
             final JSONObject userPoolConfiguration = awsConfiguration.optJsonObject("CognitoUserPool");
             this.context = context;
-            this.userPoolId = userPoolConfiguration.getString("PoolId");
+            String userPoolId = userPoolConfiguration.getString("PoolId");
+            if (userPoolId.length() > USER_POOL_ID_MAX_LENGTH || !Pattern.matches("/^[\\w-]+_[0-9a-zA-Z]+$/", userPoolId)) {
+                throw new IllegalArgumentException("Invalid userPoolId format.");
+            }
+            this.userPoolId = userPoolId;
             this.clientId = userPoolConfiguration.getString("AppClientId");
             this.clientSecret = userPoolConfiguration.optString("AppClientSecret");
             this.pinpointEndpointId = CognitoPinpointSharedContext.getPinpointEndpoint(context, userPoolConfiguration.optString("PinpointAppId"));

--- a/aws-android-sdk-cognitoidentityprovider/src/test/java/CognitoIdentityProviderCustomEndPointTest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/test/java/CognitoIdentityProviderCustomEndPointTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 public class CognitoIdentityProviderCustomEndPointTest {
 
     private CognitoUserPool testPool;
-    public static final String TEST_USER_POOL           = "DummyUserPool";
+    public static final String TEST_USER_POOL           = "us-east-1_xxxxx";
     public static final String TEST_CLIENT_ID           = "DummyClientId";
     public static final String TEST_CLIENT_SECRET       = "DummyClientSecret";
     public static final String TEST_PINPOINT_APP_ID     = "DummyPinpointAppId";

--- a/aws-android-sdk-cognitoidentityprovider/src/test/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPoolTest.java
+++ b/aws-android-sdk-cognitoidentityprovider/src/test/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUserPoolTest.java
@@ -61,7 +61,7 @@ public class CognitoUserPoolTest {
     public void setup() {
         ShadowLog.stream = System.out;
         mockProvider = mock(AmazonCognitoIdentityProvider.class);
-        cognitoUserPool = new CognitoUserPool(getApplicationContext(), "us_east_1_xxxxx", "dummyclientid", "dummysecret", Regions.US_EAST_1);
+        cognitoUserPool = new CognitoUserPool(getApplicationContext(), "us-east-1_xxxxx", "dummyclientid", "dummysecret", Regions.US_EAST_1);
         cognitoUserPool.setAdvancedSecurityDataCollectionFlag(false);
         cognitoUserPool.setIdentityProvider(mockProvider);
     }


### PR DESCRIPTION
*Description of changes:*
- Check the User Pool ID for a max length of 55 (as per https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html#CognitoUserPools-Type-UserPoolType-Id)
- Fix the regex used to validate the User Pool ID to remove the backtracking (see: https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)
- Replace the hard-coded userPoolId with the one with ideal format in unit tests.

Reference: [Amplify JS fix PR](https://github.com/aws-amplify/amplify-js/pull/8915)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
