### PR TITLE
Deprecating Facebook Login support on Android WebViews

### DIFF
--- a/aws-android-sdk-auth-facebook/build.gradle
+++ b/aws-android-sdk-auth-facebook/build.gradle
@@ -12,7 +12,7 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-auth-core')
-    api 'com.facebook.android:facebook-android-sdk:4.1.0'
+    api 'com.facebook.android:facebook-login:11.2.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 }
 


### PR DESCRIPTION

*Description of changes:*
Upgrade Facebook dependency to latest to resolve "Deprecating Facebook Login support on Android WebViews"
https://developers.facebook.com/docs/facebook-login/android/deprecating-webviews

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
