### PR TITLE
fix(Pinpoint): Add null check for endpoint response

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
@@ -51,6 +51,7 @@ import com.amazonaws.services.pinpoint.model.Event;
 import com.amazonaws.services.pinpoint.model.EventItemResponse;
 import com.amazonaws.services.pinpoint.model.EventsBatch;
 import com.amazonaws.services.pinpoint.model.EventsRequest;
+import com.amazonaws.services.pinpoint.model.ItemResponse;
 import com.amazonaws.services.pinpoint.model.PublicEndpoint;
 import com.amazonaws.services.pinpoint.model.PutEventsRequest;
 import com.amazonaws.services.pinpoint.model.PutEventsResult;
@@ -436,22 +437,26 @@ public class EventRecorder {
     }
 
     private void processEndpointResponse(EndpointProfile endpoint, PutEventsResult resultResponse) {
-        if (endpoint.getEndpointId().isEmpty()) {
-            log.error("EndpointId is missing.");
-        }
-        final EndpointItemResponse endpointItemResponse = resultResponse
+        final Map<String, ItemResponse> results = resultResponse
                 .getEventsResponse()
-                .getResults()
-                .get(endpoint.getEndpointId())
-                .getEndpointItemResponse();
-        if (endpointItemResponse == null) {
-            log.error("EndPointItemResponse is null!");
+                .getResults();
+        if (results.isEmpty()) {
+            log.error("PutEventsResult is empty!");
+        } else if (endpoint.getEndpointId().isEmpty()) {
+            log.error("EndpointId is missing.");
         } else {
-            if (202 == endpointItemResponse.getStatusCode()) {
-                log.info("EndpointProfile updated successfully.");
+            final EndpointItemResponse endpointItemResponse = results
+                    .get(endpoint.getEndpointId())
+                    .getEndpointItemResponse();
+            if (endpointItemResponse == null) {
+                log.error("EndPointItemResponse is null!");
             } else {
-                log.error("AmazonServiceException occurred during endpoint update: " +
-                        endpointItemResponse.getMessage());
+                if (202 == endpointItemResponse.getStatusCode()) {
+                    log.info("EndpointProfile updated successfully.");
+                } else {
+                    log.error("AmazonServiceException occurred during endpoint update: " +
+                            endpointItemResponse.getMessage());
+                }
             }
         }
     }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
@@ -436,16 +436,23 @@ public class EventRecorder {
     }
 
     private void processEndpointResponse(EndpointProfile endpoint, PutEventsResult resultResponse) {
+        if (endpoint.getEndpointId().isEmpty()) {
+            log.error("EndpointId is missing.");
+        }
         final EndpointItemResponse endpointItemResponse = resultResponse
                 .getEventsResponse()
                 .getResults()
                 .get(endpoint.getEndpointId())
                 .getEndpointItemResponse();
-        if(202 == endpointItemResponse.getStatusCode()) {
-            log.info("EndpointProfile updated successfully.");
+        if (endpointItemResponse == null) {
+            log.error("EndPointItemResponse is null!");
         } else {
-            log.error("AmazonServiceException occurred during endpoint update: " +
-                    endpointItemResponse.getMessage());
+            if (202 == endpointItemResponse.getStatusCode()) {
+                log.info("EndpointProfile updated successfully.");
+            } else {
+                log.error("AmazonServiceException occurred during endpoint update: " +
+                        endpointItemResponse.getMessage());
+            }
         }
     }
 

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/internal/event/EventRecorder.java
@@ -440,24 +440,29 @@ public class EventRecorder {
         final Map<String, ItemResponse> results = resultResponse
                 .getEventsResponse()
                 .getResults();
-        if (results.isEmpty()) {
+        if (results == null || results.isEmpty()) {
             log.error("PutEventsResult is empty!");
-        } else if (endpoint.getEndpointId().isEmpty()) {
-            log.error("EndpointId is missing.");
+            return;
+        }
+
+        if (endpoint.getEndpointId().isEmpty()) {
+            log.error("EndpointId is missing!");
+            return;
+        }
+
+        final EndpointItemResponse endpointItemResponse = results
+                .get(endpoint.getEndpointId())
+                .getEndpointItemResponse();
+        if (endpointItemResponse == null) {
+            log.error("EndPointItemResponse is null!");
+            return;
+        }
+
+        if (202 == endpointItemResponse.getStatusCode()) {
+            log.info("EndpointProfile updated successfully.");
         } else {
-            final EndpointItemResponse endpointItemResponse = results
-                    .get(endpoint.getEndpointId())
-                    .getEndpointItemResponse();
-            if (endpointItemResponse == null) {
-                log.error("EndPointItemResponse is null!");
-            } else {
-                if (202 == endpointItemResponse.getStatusCode()) {
-                    log.info("EndpointProfile updated successfully.");
-                } else {
-                    log.error("AmazonServiceException occurred during endpoint update: " +
-                            endpointItemResponse.getMessage());
-                }
-            }
+            log.error("AmazonServiceException occurred during endpoint update: " +
+                    endpointItemResponse.getMessage());
         }
     }
 


### PR DESCRIPTION
According to the [Pinpoint Documentation](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-events.html#apps-application-id-events-prop-eventsresponse-results), `Results` field of `EventsResponse` is not guaranteed to be present. The same assumption should also be made for the `.get(endpoint.getEndpointId())` call to avoid `NullPointerException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
