### PR TITLE
fix(Pinpoint): Add Immutable flag to PendingIntent

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/ADMNotificationClient.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.targeting.notification;
 
+import static android.os.Build.*;
+
 import android.app.PendingIntent;
 import android.os.Bundle;
 
@@ -48,9 +50,15 @@ final class ADMNotificationClient extends NotificationClientBase {
                                                        final int requestId, final String intentAction) {
         PendingIntent contentIntent = null;
         if (intentAction.equals(NotificationClient.ADM_INTENT_ACTION)) {
+            int flags = PendingIntent.FLAG_ONE_SHOT;
+
+            if (VERSION.SDK_INT >= VERSION_CODES.M) {
+                flags |= PendingIntent.FLAG_IMMUTABLE;
+            }
+
             contentIntent = PendingIntent.getService(pinpointContext.getApplicationContext(), requestId,
                     this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.ADM_INTENT_ACTION,
-                            targetClass), PendingIntent.FLAG_ONE_SHOT);
+                            targetClass), flags);
         }
         return contentIntent;
 

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/BaiduNotificationClient.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.targeting.notification;
 
+import static android.os.Build.*;
+
 import android.app.PendingIntent;
 import android.os.Bundle;
 
@@ -40,9 +42,15 @@ final class BaiduNotificationClient extends NotificationClientBase {
     protected PendingIntent createOpenAppPendingIntent(Bundle pushBundle, Class<?> targetClass, String eventSourceId, int requestId, String intentAction) {
         PendingIntent contentIntent = null;
         if (NotificationClient.BAIDU_INTENT_ACTION.equals(intentAction)) {
+            int flags = PendingIntent.FLAG_ONE_SHOT;
+
+            if (VERSION.SDK_INT >= VERSION_CODES.M) {
+                flags |= PendingIntent.FLAG_IMMUTABLE;
+            }
+
             contentIntent = PendingIntent.getBroadcast(pinpointContext.getApplicationContext(), requestId,
                     this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.BAIDU_INTENT_ACTION,
-                            targetClass), PendingIntent.FLAG_ONE_SHOT);
+                            targetClass), flags);
             PinpointNotificationReceiver.setNotificationClient(this);
         }
         return contentIntent;

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/GCMNotificationClient.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.mobileconnectors.pinpoint.targeting.notification;
 
+import static android.os.Build.*;
+
 import android.app.PendingIntent;
 import android.os.Bundle;
 
@@ -44,15 +46,21 @@ final class GCMNotificationClient extends NotificationClientBase {
     @Override
     protected PendingIntent createOpenAppPendingIntent(final Bundle pushBundle, final Class<?> targetClass, final String eventSourceId,
                                                      final int requestId, final String intentAction) {
-        PendingIntent contentIntent = null;
+        PendingIntent contentIntent;
+        int flags = PendingIntent.FLAG_ONE_SHOT;
+
+        if (VERSION.SDK_INT >= VERSION_CODES.M) {
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+
         if (intentAction.equals(NotificationClient.GCM_INTENT_ACTION)) {
             contentIntent = PendingIntent.getService(pinpointContext.getApplicationContext(), requestId,
                     this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.GCM_INTENT_ACTION,
-                            targetClass), PendingIntent.FLAG_ONE_SHOT);
+                            targetClass), flags);
         } else {
             contentIntent = PendingIntent.getBroadcast(pinpointContext.getApplicationContext(), requestId,
                     this.notificationIntent(pushBundle, eventSourceId, requestId, NotificationClient.FCM_INTENT_ACTION,
-                            targetClass), PendingIntent.FLAG_ONE_SHOT);
+                            targetClass), flags);
             PinpointNotificationReceiver.setNotificationClient(this);
         }
         return contentIntent;


### PR DESCRIPTION
*Issue #, if available:*
#2695
*Description of changes:*
Starting from API 31, it is required to add [FLAG_IMMUTABLE](https://developer.android.com/reference/android/app/PendingIntent#FLAG_IMMUTABLE) or FLAG_MUTABLE (added in API 23) for PendingIntents. Missing one of these flags will cause to throw _IllegalArgumentException_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
