### PR TITLE
downgrade androidx:browser dependency to 1.3.0

### DIFF
--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     api (project(':aws-android-sdk-core')) {
         exclude group: 'com.google.android', module: 'android'
     }
-    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.browser:browser:1.3.0'
     implementation 'com.amazonaws:aws-android-sdk-cognitoidentityprovider-asf:1.0.0'
 }
 

--- a/aws-android-sdk-mobile-client/build.gradle
+++ b/aws-android-sdk-mobile-client/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compileOnly project(':aws-android-sdk-auth-google')
     compileOnly project(':aws-android-sdk-auth-userpools')
     compileOnly project(':aws-android-sdk-cognitoauth')
-    compileOnly 'androidx.browser:browser:1.4.0'
+    compileOnly 'androidx.browser:browser:1.3.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.2.4'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
v1.4.0 of androidx browser forces requirement of minCompileSDK to 31. Downgrade the ver to 1.3.0 such that the hard requirements is removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
