### PR TITLE
Fix race condition when IoT message arrives immediately after subscribe

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1477,6 +1477,9 @@ public class AWSIotMqttManager {
 
         if (null != mqttClient) {
             try {
+                final AWSIotMqttTopic topicModel = new AWSIotMqttTopic(topic, qos, callback);
+                topicListeners.put(topic, topicModel);
+
                 if (subscriptionStatusCallback != null) {
                     mqttClient.subscribe(topic, qos.asInt(), null, new IMqttActionListener() {
                         @Override
@@ -1495,14 +1498,14 @@ public class AWSIotMqttManager {
                     mqttClient.subscribe(topic, qos.asInt());
                 }
             } catch (final MqttException e) {
-                if(subscriptionStatusCallback != null) {
+                topicListeners.remove(topic);
+
+                if (subscriptionStatusCallback != null) {
                     subscriptionStatusCallback.onFailure(e);
                 } else {
                     throw new AmazonClientException("Client error when subscribing.", e);
                 }
             }
-            final AWSIotMqttTopic topicModel = new AWSIotMqttTopic(topic, qos, callback);
-            topicListeners.put(topic, topicModel);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When a IoT/MQTT message arrives immediately after subscribing to a topic it could be missed, because the `topicListeners` are added **after** the subscription happened. To avoid this first add the listener and then subscribe to the topic.

In general that should not be a big problem, because the behavior is the same as if you would have subscribed just a little bit later. But it could lead to issues when you rely on [retained messages](https://aws.amazon.com/blogs/iot/getting-started-mqtt-retained-messages-aws-iot-core/) which are delivered immediately after subscription.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
