### PR TITLE
Fix 2634 : Adding the null guard when getTransferNetworkConnectionType is null

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
@@ -357,7 +357,7 @@ class TransferRecord {
      * @param connManager the android connectivity manager
      * @return true if the preferred network is available, false otherwise.
      */
-    private boolean checkPreferredNetworkAvailability(final TransferStatusUpdater updater,
+    protected boolean checkPreferredNetworkAvailability(final TransferStatusUpdater updater,
                                                       final ConnectivityManager connManager) {
 
         if (connManager == null) { 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferRecord.java
@@ -364,9 +364,8 @@ class TransferRecord {
             // Unable to get the details of the network, we will start the transfer.
             return true;
         }
-            
-        if (transferUtilityOptions != null &&
-            !transferUtilityOptions.getTransferNetworkConnectionType().isConnected(connManager)) {
+
+        if (transferUtilityOptions != null && transferUtilityOptions.getTransferNetworkConnectionType() != null && !transferUtilityOptions.getTransferNetworkConnectionType().isConnected(connManager)) {
             // the network that is configured in the TransferUtilityOptions is not available.
             // we will set the state to WAITING_FOR_NETWORK. The transfer will be started
             // when a future notification is received for the desired network.

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
@@ -67,7 +67,7 @@ public class TransferUtilityOptions implements Serializable {
     /**
      * Type of connection to use for transfers.
      */
-    private TransferNetworkConnectionType transferNetworkConnectionType;
+    protected TransferNetworkConnectionType transferNetworkConnectionType;
     
     /**
      * Constructor that sets the options to the

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadInputStreamTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadInputStreamTest.java
@@ -35,7 +35,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
@@ -47,8 +46,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import javax.annotation.meta.When;
 
 /**
  * Tests that new upload with input stream method calls

--- a/aws-android-sdk-s3/src/test/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadInputStreamTest.java
+++ b/aws-android-sdk-s3/src/test/java/com/amazonaws/mobileconnectors/s3/transferutility/UploadInputStreamTest.java
@@ -16,7 +16,9 @@
 package com.amazonaws.mobileconnectors.s3.transferutility;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
 import android.util.Log;
+
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -33,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
@@ -44,6 +47,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import javax.annotation.meta.When;
 
 /**
  * Tests that new upload with input stream method calls
@@ -82,6 +87,7 @@ public class UploadInputStreamTest {
     /**
      * Test that {@link TransferUtility#upload(String, InputStream)} calls the File based
      * upload method with all of the expected defaults.
+     *
      * @throws IOException if upload fails to read input file
      */
     @Test
@@ -101,6 +107,7 @@ public class UploadInputStreamTest {
     /**
      * Test that {@link TransferUtility#upload(String, InputStream, UploadOptions)} with
      * a default Builder calls the File based upload method with all of the expected defaults.
+     *
      * @throws IOException if upload fails to read input file
      */
     @Test
@@ -121,6 +128,7 @@ public class UploadInputStreamTest {
      * Test that {@link TransferUtility#upload(String, InputStream, UploadOptions)} with
      * all parameters specified calls the File based upload method with the same parameters
      * provided as input.
+     *
      * @throws IOException if upload fails to read input file
      */
     @Test
@@ -146,6 +154,7 @@ public class UploadInputStreamTest {
 
     /**
      * Verify that the File does in fact get deleted after the upload is complete.
+     *
      * @throws IOException if upload fails to read input file
      */
     @Test
@@ -169,6 +178,7 @@ public class UploadInputStreamTest {
 
     /**
      * Cleans up input stream
+     *
      * @throws IOException if input stream fails to close
      */
     @After
@@ -196,5 +206,32 @@ public class UploadInputStreamTest {
         public void onError(int id, Exception exception) {
             Log.e(TAG, "Error during upload: " + id, exception);
         }
+    }
+
+    @Test
+    public void testTransferRecordCheckPreferredNetworkAvailability() {
+        Context context = InstrumentationRegistry.getInstrumentation().getContext();
+        TransferStatusUpdater transferStatusUpdater = TransferStatusUpdater.getInstance(context);
+        ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        transferStatusUpdater.updateState(2342, TransferState.IN_PROGRESS);
+        transferStatusUpdater.addTransfer(new TransferRecord(34234));
+        for (TransferRecord record : transferStatusUpdater.getTransfers().values()) {
+            //When connectionManager is null - Base case
+            assertTrue(record.checkPreferredNetworkAvailability(transferStatusUpdater, null));
+
+            //When TransferUtilityOptions is null
+            record.transferUtilityOptions = null;
+            assertTrue(record.checkPreferredNetworkAvailability(transferStatusUpdater, connManager));
+
+            //When TransferNetworkConnectionType is null
+            record.transferUtilityOptions = new TransferUtilityOptions();
+            record.transferUtilityOptions.transferNetworkConnectionType = null;
+            assertTrue(record.checkPreferredNetworkAvailability(transferStatusUpdater, connManager));
+
+            //When TransferNetworkConnectionType is not null
+            record.transferUtilityOptions.transferNetworkConnectionType = TransferNetworkConnectionType.ANY;
+            assertTrue(record.checkPreferredNetworkAvailability(transferStatusUpdater, connManager));
+        }
+
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
2634

*Description of changes:*

Adding a null guard for when getTransferNetworkConnectionType is null

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
