### PR TITLE
fix: revert change to synchronously do part upload from #2447

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferThreadPool.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferThreadPool.java
@@ -26,7 +26,7 @@ import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
 
 class TransferThreadPool {
-    
+
     private static final Log LOGGER = LogFactory.getLog(TransferService.class);
 
     private static ExecutorService executorMainTask;
@@ -34,15 +34,14 @@ class TransferThreadPool {
 
     static synchronized void init(final int transferThreadPoolSize) {
         LOGGER.debug("Initializing the thread pool of size: " + transferThreadPoolSize);
-        
+
         final int poolSize = Math.max((int) (Math.ceil((double) transferThreadPoolSize / 2)), 1);
-        
+
         if (executorMainTask == null) {
             executorMainTask = buildExecutor(poolSize);
         }
         if (executorPartTask == null) {
-            // Upload individual parts serially
-            executorPartTask = buildExecutor(1);
+            executorPartTask = buildExecutor(poolSize);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change was made as part of #2447 to synchronously do part upload to prevent timeout errors, this change is no longer required as exponential retries were added to part uploads as part of #2504 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
