### PR TITLE
(chore): Fix typo in AWSMobileClient

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -3245,7 +3245,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                 return new Runnable() {
                     @Override
                     public void run() {
-                        callback.onError(new Exception("showSignIn called with HostedUI options in awsconfiguration.json"));
+                        callback.onError(new Exception("showSignIn called without HostedUI options in awsconfiguration.json"));
                     }
                 };
             }


### PR DESCRIPTION
From a customer conversation; I'm guessing that this should be `without HostedUI` because the if condition is `if (hostedUIJSON == null)`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
