### PR TITLE
Fix notification opt-out checking on Samsung devices

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -31,6 +31,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 import com.amazonaws.mobileconnectors.pinpoint.analytics.AnalyticsEvent;
 import com.amazonaws.mobileconnectors.pinpoint.internal.core.PinpointContext;
@@ -973,6 +974,10 @@ abstract class NotificationClientBase {
     boolean areAppNotificationsEnabledOnPlatform() {
         if (android.os.Build.VERSION.SDK_INT < ANDROID_KITKAT) {
             return true;
+        }
+
+        if (android.os.Build.VERSION.SDK_INT >= ANDROID_NOUGAT) {
+            return NotificationManagerCompat.from(pinpointContext.getApplicationContext()).areNotificationsEnabled();
         }
 
         final String appOpsServiceName;

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -959,7 +959,8 @@ abstract class NotificationClientBase {
      * above, so devices from API level 16 to 18 will return true from this
      * method even when local notifications have been disabled for the app.
      * Also, at API level 24 and higher, we use the more consistent API
-     * `areNotificationsAEnabled()` to fix an issue we were seeing with Samsung devices.
+     * `NotificationManagerCompat#areNotificationsEnabled()` to fix an issue we were
+     * seeing with Samsung devices.
      *
      * @return true if local notifications are enabled for this app, otherwise
      * false.

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -959,7 +959,7 @@ abstract class NotificationClientBase {
      * above, so devices from API level 16 to 18 will return true from this
      * method even when local notifications have been disabled for the app.
      * Also, at API level 24 and higher, we use the more consistent API
-     * `NotificationManagerCompat#areNotificationsEnabled()` to fix an issue we were
+     * {@link NotificationManagerCompat#areNotificationsEnabled()} to fix an issue we were
      * seeing with Samsung devices.
      *
      * @return true if local notifications are enabled for this app, otherwise

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -958,6 +958,8 @@ abstract class NotificationClientBase {
      * notifications was a feature added on devices supporting API Level 16 and
      * above, so devices from API level 16 to 18 will return true from this
      * method even when local notifications have been disabled for the app.
+     * Also, at API level 24 and higher, we use the more consistent API
+     * `areNotificationsAEnabled()` to fix an issue we were seeing with Samsung devices.
      *
      * @return true if local notifications are enabled for this app, otherwise
      * false.

--- a/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/EndpointProfileTest.java
+++ b/aws-android-sdk-pinpoint/src/test/java/com/amazonaws/mobileconnectors/pinpoint/targeting/EndpointProfileTest.java
@@ -38,6 +38,8 @@ import com.amazonaws.mobileconnectors.pinpoint.internal.core.util.DateUtil;
 import com.amazonaws.mobileconnectors.pinpoint.targeting.endpointProfile.EndpointProfile;
 import com.amazonaws.mobileconnectors.pinpoint.targeting.endpointProfile.EndpointProfileDemographic;
 import com.amazonaws.mobileconnectors.pinpoint.targeting.endpointProfile.EndpointProfileLocation;
+
+import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
 
@@ -280,6 +282,9 @@ public class EndpointProfileTest extends MobileAnalyticsTestBase {
         when(mockResources.getConfiguration()).thenReturn(mockConfiguration);
         when(mockApplicationContext.getResources()).thenReturn(mockResources);
         when(mockApplicationContext.getApplicationContext()).thenReturn(mockedContext);
+        NotificationManager notificationManager = mock(NotificationManager.class);
+        when(mockApplicationContext.getSystemService(Context.NOTIFICATION_SERVICE)).thenReturn(notificationManager);
+        when(notificationManager.areNotificationsEnabled()).thenReturn(true);
         when(mockContext.getApplicationContext()).thenReturn(mockApplicationContext);
 
         final TargetingClient targetingClient = new TargetingClient(mockContext, mock(ThreadPoolExecutor.class));


### PR DESCRIPTION
On Samsung devices running Android 12, there was a strange bug impacting uninstalling and then reinstalling an app using Pinpoint -- the library would report that push notifications were disabled when they weren't.  Using the more standard API `areNotificationsEnabled()` (supported under API versions 24 and up) as opposed to the existing workaround should fix the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
