### PR TITLE
Fix: API 30+ fix for opening Pinpoint push notification links

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -818,7 +818,7 @@ abstract class NotificationClientBase {
         try {
             pinpointContext.getApplicationContext().startActivity(intent);
         } catch (ActivityNotFoundException e) {
-            log.error("Couldn't find an app to open ACTION_VIEW Intent.");
+            log.error("Couldn't find an app to open ACTION_VIEW Intent.", e);
         }
     }
 

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -18,6 +18,7 @@ package com.amazonaws.mobileconnectors.pinpoint.targeting.notification;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -812,8 +813,12 @@ abstract class NotificationClientBase {
         final Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(validatedUrl));
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if (intent.resolveActivity(pinpointContext.getApplicationContext().getPackageManager()) != null) {
+
+        // Querying packages now requires query manifest flag, so we instead try/catch the attempt
+        try {
             pinpointContext.getApplicationContext().startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            log.error("Couldn't find an app to open ACTION_VIEW Intent.");
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
Android 30+ no longer allows you to query packages without adding a query tag in the manifest. Rather than add that tag, a more simple approach is to go ahead and try to start an activity and catch the exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
