### PR TITLE
Fix: Ensure initial TransferState is reported on setting TransferListener

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferObserver.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferObserver.java
@@ -245,10 +245,10 @@ public class TransferObserver {
                 TransferStatusUpdater.unregisterListener(id, transferListener);
                 transferListener = null;
             }
-//            if (statusListener != null) {
-//                TransferStatusUpdater.unregisterListener(id, statusListener);
-//                statusListener = null;
-//            }
+            if (statusListener != null) {
+                TransferStatusUpdater.unregisterListener(id, statusListener);
+                statusListener = null;
+            }
         }
     }
 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferObserver.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferObserver.java
@@ -154,18 +154,22 @@ public class TransferObserver {
      * @param listener A TransferListener used to receive notification.
      */
     public void setTransferListener(TransferListener listener) {
-        if (listener != null) {
             synchronized (this) {
                 // Remove previous listener.
                 cleanTransferListener();
 
                 // One additional listener is attached so that the basic transfer
                 // info gets updated along side.
-                statusListener = new TransferStatusListener();
-                TransferStatusUpdater.registerListener(id, statusListener);
-                transferListener = listener;
-                TransferStatusUpdater.registerListener(id, transferListener);
-            }
+                if (statusListener == null) {
+                    statusListener = new TransferStatusListener();
+                    TransferStatusUpdater.registerListener(id, statusListener);
+                }
+
+                if (listener != null) {
+                    transferListener = listener;
+                    transferListener.onStateChanged(id, transferState);
+                    TransferStatusUpdater.registerListener(id, transferListener);
+                }
         }
     }
 
@@ -241,17 +245,17 @@ public class TransferObserver {
                 TransferStatusUpdater.unregisterListener(id, transferListener);
                 transferListener = null;
             }
-            if (statusListener != null) {
-                TransferStatusUpdater.unregisterListener(id, statusListener);
-                statusListener = null;
-            }
+//            if (statusListener != null) {
+//                TransferStatusUpdater.unregisterListener(id, statusListener);
+//                statusListener = null;
+//            }
         }
     }
 
     /**
      * A listener that can update the {@link TransferObserver}.
      */
-    private class TransferStatusListener implements TransferListener {
+    protected class TransferStatusListener implements TransferListener {
 
         @Override
         @SuppressWarnings("checkstyle:hiddenfield")

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
@@ -218,12 +218,18 @@ class TransferStatusUpdater {
 
             // invoke TransferListener callback on main thread
             for (final TransferListener l : list) {
-                mainHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        l.onStateChanged(id, newState);
-                    }
-                });
+                // If instance is TransferStatusListener, post immediately.
+                // Posting to main thread can cause a missed status.
+                if (l instanceof TransferObserver.TransferStatusListener) {
+                    l.onStateChanged(id, newState);
+                } else {
+                    mainHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            l.onStateChanged(id, newState);
+                        }
+                    });
+                }
             }
 
             // remove all LISTENERS when the transfer is in a final state so


### PR DESCRIPTION
*Issue [#1333](https://github.com/aws-amplify/aws-sdk-android/issues/1333)*

*Description of changes:*
If a TransferListener is set after a TransferUtility upload is called, the initial TransferState is never reported. As an example, the attached issue reported that setting a TransferListener while in airplane mode would result in no status updates until airplane mode was toggled off.

This could be determined to be working as intended, because at the time the TransferListener was set, the status was already in airplane mode. 

Instead, the user could call the full upload method and provide a listener from the start. 
```java 
TransferObserver upload(
    String bucket, 
    String key, 
    File file, 
    ObjectMetadata metadata, 
    CannedAccessControlList cannedAcl, 
    TransferListener listener
)
```

In reality, I think the better experience would be to provide the initial state to the user immediately in `onStateChanged` immediately after calling `setTransferListener`.

Here are a few example logs to show the change and the new calls to the attached `TransferListener`

Scenario 1: Device has network
> onStateChanged: WAITING, 46 <--- This line is new!
onStateChanged: IN_PROGRESS, 46
ID:46 bytesCurrent: 12 bytesTotal: 12 100%
ID:46 bytesCurrent: 12 bytesTotal: 12 100%
onStateChanged: COMPLETED, 46

Scenario 2: Device is in airplane mode
> onStateChanged: WAITING_FOR_NETWORK, 47 <--- This line is new!
<--- **Airplane mode toggled off** --->
onStateChanged: IN_PROGRESS, 47
ID:47 bytesCurrent: 12 bytesTotal: 12 100%
ID:47 bytesCurrent: 12 bytesTotal: 12 100%
onStateChanged: COMPLETED, 47

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
