### PR TITLE
fix(storage): Stop transfer service if all transfers complete

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
@@ -49,14 +49,19 @@ public class TransferService extends Service {
     static TransferNetworkLossHandler transferNetworkLossHandler;
 
     /**
-     * A flag indicates whether the service is started the first time.
+     * A flag indicates whether or not the receiver has is started the first time.
      */
     boolean isReceiverNotRegistered = true;
 
     /**
+     * A flag that indicates whether or not the Foreground notification started
+     */
+    boolean hasNotificationShown = false;
+
+    /**
      * The identifier used for the notification.
      */
-    private int ongoingNotificationId = 1;
+    private int ongoingNotificationId = 3462;
 
     /**
      * This flag determines if the notification needs to be removed
@@ -137,7 +142,8 @@ public class TransferService extends Service {
          * b) An identifier for the ongoing notification c) Flag that determines if the notification
          * needs to be removed when the service is moved out of the foreground state.
          */
-        if (Build.VERSION.SDK_INT >= ANDROID_OREO) {
+        if (Build.VERSION.SDK_INT >= ANDROID_OREO && !hasNotificationShown) {
+            hasNotificationShown = true;
             try {
                 synchronized (this) {
                     final Notification userProvidedNotification = (Notification) intent.getParcelableExtra(INTENT_KEY_NOTIFICATION);

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferState.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferState.java
@@ -127,4 +127,10 @@ public enum TransferState {
                 + " transfer will be have state set to UNKNOWN.");
         return UNKNOWN;
     }
+
+    protected static boolean isFinalState(TransferState transferState) {
+        return TransferState.COMPLETED.equals(transferState) ||
+                TransferState.FAILED.equals(transferState) ||
+                TransferState.CANCELED.equals(transferState);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
[Amplify 1803](https://github.com/aws-amplify/amplify-android/issues/1803)

*Description of changes:*
When a transfer completes, check to see if there are any other transfers in progress. If not, stop the ongoing TransferService

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
