### PR TITLE
Fix: Prevent startForeground crash and TransferService stopping while transfers ongoing

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
@@ -54,11 +54,6 @@ public class TransferService extends Service {
     boolean isReceiverNotRegistered = true;
 
     /**
-     * A flag that indicates whether or not the Foreground notification started
-     */
-    boolean hasNotificationShown = false;
-
-    /**
      * The identifier used for the notification.
      */
     private int ongoingNotificationId = 3462;
@@ -142,8 +137,7 @@ public class TransferService extends Service {
          * b) An identifier for the ongoing notification c) Flag that determines if the notification
          * needs to be removed when the service is moved out of the foreground state.
          */
-        if (Build.VERSION.SDK_INT >= ANDROID_OREO && !hasNotificationShown) {
-            hasNotificationShown = true;
+        if (Build.VERSION.SDK_INT >= ANDROID_OREO) {
             try {
                 synchronized (this) {
                     final Notification userProvidedNotification = (Notification) intent.getParcelableExtra(INTENT_KEY_NOTIFICATION);

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
@@ -251,8 +251,8 @@ class TransferStatusUpdater {
             if (!TransferState.isFinalState(record.state)) {
                 stopTransferService = false;
                 LOGGER.info("Transfers still pending, keeping TransferService running.");
+                break;
             }
-            break;
         }
         if (stopTransferService) {
             LOGGER.info("All transfers in final state. Stopping TransferService");

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferStatusUpdater.java
@@ -17,6 +17,7 @@ package com.amazonaws.mobileconnectors.s3.transferutility;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -246,17 +247,19 @@ class TransferStatusUpdater {
 
         // If all transfers in local map are completed,
         // stop TransferService to clear foreground notification
-        boolean stopTransferService = true;
-        for (TransferRecord record: transfers.values()) {
-            if (!TransferState.isFinalState(record.state)) {
-                stopTransferService = false;
-                LOGGER.info("Transfers still pending, keeping TransferService running.");
-                break;
+        if (Build.VERSION.SDK_INT >= 26) {
+            boolean stopTransferService = true;
+            for (TransferRecord record : transfers.values()) {
+                if (!TransferState.isFinalState(record.state)) {
+                    stopTransferService = false;
+                    LOGGER.info("Transfers still pending, keeping TransferService running.");
+                    break;
+                }
             }
-        }
-        if (stopTransferService) {
-            LOGGER.info("All transfers in final state. Stopping TransferService");
-            context.stopService(new Intent(context, TransferService.class));
+            if (stopTransferService) {
+                LOGGER.info("All transfers in final state. Stopping TransferService");
+                context.stopService(new Intent(context, TransferService.class));
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Seeing integration test issues that `Context.startForegroundService() did not then call Service.startForeground()`. The interesting thing about this is that the foreground service has already been started and made an initial call to `startForeground()`. What is not clear is if each call to `startForegroundService` needs to be followed with `startForeground()`. We have not observed any manual crashes due to this.

The check on `hasNotificationShown` was done to prevent continually overwriting the notification, but overwriting isn't a bad thing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
