### PR TITLE
Actually attach Javadocs jar files to build

### DIFF
--- a/publishing.gradle
+++ b/publishing.gradle
@@ -224,6 +224,7 @@ afterEvaluate { project ->
         if (project.getPlugins().hasPlugin('com.android.application') ||
             project.getPlugins().hasPlugin('com.android.library')) {
             archives androidSourcesJar
+            archives androidJavadocsJar
         } else {
             archives sourcesJar
         }

--- a/scripts/maven-release-publisher.yml
+++ b/scripts/maven-release-publisher.yml
@@ -13,7 +13,6 @@ phases:
       - echo 'Build phase starting.'
       - |
         JAVA_HOME=$JDK_8_HOME ./gradlew clean build
-        ./gradlew androidJavadocsJar
         for task_name in $(./gradlew tasks --all | grep uploadArchives | cut -d " " -f 1); do
           echo "Gradle task $task_name"
           JAVA_HOME=$JDK_8_HOME ./gradlew $task_name;


### PR DESCRIPTION
Followup to #2971.  `maven-release-publisher.yml` change was suspicious because Gradle should be able to determine that it's a dependency.  This indicated that perhaps `androidJavadocsJar` was not a dependency after all.

Testing strategy: similar to #2971 but with dry build being done off of this branch instead of after merging to main, thanks @sdhuka!

![image](https://user-images.githubusercontent.com/9170787/185714270-90b9798b-cbe4-4115-b56c-c51ef4f3b6bb.png)

Followups -- [looks like](https://repo1.maven.org/maven2/com/amplifyframework/core/1.37.2/) Amplify isn't releasing Javadocs either despite [adding Dokka](https://github.com/aws-amplify/amplify-android/pull/1645).  Also adding Javadocs HTML to docs website, and fixing errors/warnings as mentioned in #2971.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
