### PR TITLE
feat: Add support for DXB region

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/regions/RegionDefaults.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/regions/RegionDefaults.java
@@ -542,6 +542,33 @@ class RegionDefaults {
         updateRegion(region, "sqs", "sqs.ap-southeast-3.amazonaws.com", false, true);
         updateRegion(region, "sts", "sts.ap-southeast-3.amazonaws.com", false, true);
 
+        // Support for Middle East(UAE) `me-central-1` region
+        region = new Region("me-central-1", "amazonaws.com");
+        ret.add(region);
+        updateRegion(region, "autoscaling", "autoscaling.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "cognito-identity", "cognito-identity.me-central-1.amazonaws.com",
+                false, true);
+        updateRegion(region, "cognito-idp", "cognito-idp.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "cognito-sync", "cognito-sync.me-central-1.amazonaws.com", false,
+                true);
+        updateRegion(region, "data.iot", "data.iot.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "dynamodb", "dynamodb.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "ec2", "ec2.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "elasticloadbalancing",
+                "elasticloadbalancing.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "firehose", "firehose.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "iot", "iot.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "kinesis", "kinesis.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "kms", "kms.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "lambda", "lambda.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "logs", "logs.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "polly", "polly.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "s3", "s3.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "sdb", "sdb.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "sns", "sns.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "sqs", "sqs.me-central-1.amazonaws.com", false, true);
+        updateRegion(region, "sts", "sts.me-central-1.amazonaws.com", false, true);
+
         return ret;
     }
 

--- a/aws-android-sdk-core/src/main/java/com/amazonaws/regions/Regions.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/regions/Regions.java
@@ -93,7 +93,10 @@ public enum Regions {
     AF_SOUTH_1("af-south-1"),
 
     /** ap-southeast-3. */
-    AP_SOUTHEAST_3("ap-southeast-3");
+    AP_SOUTHEAST_3("ap-southeast-3"),
+
+    /** me-central-1. */
+    ME_CENTRAL_1("me-central-1");
 
     /**
      * The default region that new customers in the US are encouraged to use

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/regions/RegionUtilsTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/regions/RegionUtilsTest.java
@@ -46,7 +46,7 @@ public class RegionUtilsTest {
     @Test
     public void testGetRegionsForService() {
         List<Region> regions = RegionUtils.getRegionsForService(ServiceAbbreviations.SimpleDB);
-        assertEquals(regions.size(), 10);
+        assertEquals(regions.size(), 11);
         boolean usEast1 = false;
         boolean usWest1 = false;
         for (Region curr : regions) {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/model/Region.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/model/Region.java
@@ -326,7 +326,19 @@ public enum Region {
      * bucket in this region.
      * </p>
      */
-    AP_Jakarta("ap-southeast-3");
+    AP_Jakarta("ap-southeast-3"),
+
+    /**
+     * The Middle East (UAE) Region. This region uses Amazon S3 servers
+     * located in UAE.
+     * <p>
+     * When using buckets in this region, set the client endpoint to
+     * <code>s3-me-central-1.amazonaws.com</code> on all requests to these buckets
+     * to reduce any latency experienced after the first hour of creating a
+     * bucket in this region.
+     * </p>
+     */
+    ME_UAE("me-central-1");
 
     /**
      * Used to extract the S3 regional id from an S3 end point. Note this


### PR DESCRIPTION
[Previous release](https://github.com/aws-amplify/aws-sdk-android/pull/2709)

Adds support for `me-central-1`.  Tested via integration tests hitting correct endpoints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
