### PR TITLE
fix(cognitoauth): forward lambda trigger exception for social sign in

### DIFF
--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -93,6 +93,11 @@ public class AuthClient {
     private static final long REDIRECT_TIMEOUT_SECONDS = 10;
 
     /**
+     * Message returned for a bad request.
+     */
+    private static final String BAD_REQUEST_ERROR = "invalid_request";
+
+    /**
      * Android application context.
      */
     private final Context context;
@@ -450,10 +455,17 @@ public class AuthClient {
                             uri.getQueryParameter(ClientConstants.DOMAIN_QUERY_PARAM_ERROR);
 
                     if (errorText != null) {
+                        final String errorDescription = uri.getQueryParameter(ClientConstants.DOMAIN_QUERY_PARAM_ERROR_DESCRIPTION);
+                        final String errorMessage;
+                        if (errorText.equals(BAD_REQUEST_ERROR) && errorDescription != null) {
+                            errorMessage = errorDescription.trim();
+                        } else {
+                            errorMessage = errorText;
+                        }
                         returnCallback = new Runnable() {
                             @Override
                             public void run() {
-                                callback.onFailure(new AuthServiceException(errorText));
+                                callback.onFailure(new AuthServiceException(errorMessage));
                             }
                         };
                     } else {

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/ClientConstants.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/util/ClientConstants.java
@@ -38,6 +38,7 @@ public abstract class ClientConstants {
     public static final String DOMAIN_QUERY_PARAM_CODE_CHALLENGE_METHOD_SHA256 = "S256";
     public static final String DOMAIN_QUERY_PARAM_CODE_VERIFIER = "code_verifier";
     public static final String DOMAIN_QUERY_PARAM_ERROR = "error";
+    public static final String DOMAIN_QUERY_PARAM_ERROR_DESCRIPTION = "error_description";
     public static final String DOMAIN_QUERY_PARAM_REDIRECT_URI = "redirect_uri";
     public static final String DOMAIN_QUERY_PARAM_LOGOUT_URI = "logout_uri";
     public static final String DOMAIN_QUERY_PARAM_RESPONSE_TYPE = "response_type";


### PR DESCRIPTION
*Issue #, if available:* #2255, [1649](https://github.com/aws-amplify/amplify-android/issues/1649)

*Description of changes:* When an exception is caused by a lambda trigger for social sign in, the resulting URI contains an "error" parameter equal to "invalid_request" and an "error_description" parameter that contains the actual error message from the exception thrown in the lambda. The message for the exception returned to the onError for social sign in is currently "invalid_request" (the value of the "error" parameter), so this PR changes the message to be the "error_description" instead when the error is "invalid_request".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
