### PR TITLE
fix(aws-android-sdk-core): modify region parsing for endpoints in vpc

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/util/AwsHostNameUtils.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/util/AwsHostNameUtils.java
@@ -32,6 +32,8 @@ public class AwsHostNameUtils {
 
     private static final Pattern S3_ENDPOINT_PATTERN =
             Pattern.compile("^(?:.+\\.)?s3[.-]([a-z0-9-]+)$");
+    
+    private static final String VPC_NAME = "vpce";
 
     /**
      * @deprecated in favor of {@link #parseRegionName(String, String)}.
@@ -117,8 +119,18 @@ public class AwsHostNameUtils {
             return "us-east-1";
         }
 
-        // host was 'service.[region].amazonaws.com'.
+        // host was 'service.[region].amazonaws.com'. or 'service.[region].vpce.amazonaws.com'
         String region = fragment.substring(index + 1);
+        if (region.equals(VPC_NAME)) {
+            String[] partsOfFragment = fragment.split("\\.");
+            if (partsOfFragment.length >= 2) {
+                // host was 'service.[region].vpce.amazonaws.com'
+                region = partsOfFragment[partsOfFragment.length - 2];
+            } else {
+                // guess us-east-1 for lack of a better option
+                return "us-east-1";
+            }
+        }
 
         // Special case for iam.us-gov.amazonaws.com, which is actually
         // us-gov-west-1.

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/util/AwsHostNameUtilsTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/util/AwsHostNameUtilsTest.java
@@ -95,6 +95,12 @@ public class AwsHostNameUtilsTest {
     }
 
     @Test
+    public void testVpceEndpoint() {
+        assertEquals("eu-central-1", AwsHostNameUtils.parseRegionName(
+                "bucket.vpce-0415caba8c0-i1xu.s3.eu-central-1.vpce.amazonaws.com", "s3"));
+    }
+
+    @Test
     public void testBJS() {
         // Verify that BJS endpoints parse correctly even though they're
         // non-standard.

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/util/AwsHostNameUtilsTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/util/AwsHostNameUtilsTest.java
@@ -95,9 +95,9 @@ public class AwsHostNameUtilsTest {
     }
 
     @Test
-    public void testVpceEndpoint() {
-        assertEquals("eu-central-1", AwsHostNameUtils.parseRegionName(
-                "bucket.vpce-0415caba8c0-i1xu.s3.eu-central-1.vpce.amazonaws.com", "s3"));
+    public void testVpcEndpoint() {
+        assertEquals("us-west-2", AwsHostNameUtils.parseRegionName(
+                "bucket.vpce-1234.s3.us-west-2.vpce.amazonaws.com", "s3"));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* #3018

*Description of changes:* When parsing an endpoint in VPC to retrieve the region, the existing region parsing logic would determine the region in an endpoint such as "bucket.vpce-1234.s3.us-west-2.vpce.amazonaws.com" is "vpce" but it should be "us-west-2". This PR modifies the region parsing logic to check the case when the endpoint is in VPC.

To test these changes, I added a new test for parsing an endpoint in VPC and verified that all existing tests in AwsHostNameUtilsTest.java still pass.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
