### PR TITLE
Customize upload part size (for client apps)

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
@@ -773,7 +773,8 @@ public class TransferUtility {
         long remainingLenth = file.length();
         double partSize = (double) remainingLenth / (double) MAXIMUM_UPLOAD_PARTS;
         partSize = Math.ceil(partSize);
-        final long optimalPartSize = (long) Math.max(partSize, MINIMUM_UPLOAD_PART_SIZE);
+        final long optimalPartSize = (long) Math.max(partSize,
+                transferUtilityOptions.getMinimumUploadPartSize());
         long fileOffset = 0;
         int partNumber = 1;
 
@@ -986,7 +987,7 @@ public class TransferUtility {
     }
 
     private boolean shouldUploadInMultipart(File file) {
-        return (file != null && file.length() > MINIMUM_UPLOAD_PART_SIZE);
+        return (file != null && file.length() > transferUtilityOptions.getMinimumUploadPartSize());
     }
 
     static <X extends AmazonWebServiceRequest> X appendTransferServiceUserAgentString(final X request) {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.mobileconnectors.s3.transferutility;
 
+import static com.amazonaws.mobileconnectors.s3.transferutility.TransferUtility.MINIMUM_UPLOAD_PART_SIZE;
+import static com.amazonaws.services.s3.internal.Constants.MB;
+
 import java.io.Serializable;
 
 /**
@@ -65,6 +68,12 @@ public class TransferUtilityOptions implements Serializable {
     private int transferThreadPoolSize;
 
     /**
+     * Minimum part size for upload parts. Anything below this will use a
+     * single upload
+     */
+    private int minimumUploadPartSize;
+
+    /**
      * Type of connection to use for transfers.
      */
     protected TransferNetworkConnectionType transferNetworkConnectionType;
@@ -78,6 +87,7 @@ public class TransferUtilityOptions implements Serializable {
         this.transferServiceCheckTimeInterval = getDefaultCheckTimeInterval();
         this.transferThreadPoolSize = getDefaultThreadPoolSize();
         this.transferNetworkConnectionType = getDefaultTransferNetworkConnectionType();
+        this.minimumUploadPartSize = MINIMUM_UPLOAD_PART_SIZE;
     }
 
     /**
@@ -93,6 +103,7 @@ public class TransferUtilityOptions implements Serializable {
         this.transferServiceCheckTimeInterval = getDefaultCheckTimeInterval();
         this.transferThreadPoolSize = transferThreadPoolSize;
         this.transferNetworkConnectionType = transferNetworkConnectionType;
+        this.minimumUploadPartSize = MINIMUM_UPLOAD_PART_SIZE;
     }
 
     /**
@@ -160,6 +171,23 @@ public class TransferUtilityOptions implements Serializable {
      */
     static int getDefaultThreadPoolSize() {
         return 2 * (Runtime.getRuntime().availableProcessors() + 1);
+    }
+
+    /**
+     * Retrieve minimum part size for upload parts.
+     * @return the minimum upload part size
+     */
+    public int getMinimumUploadPartSize() {
+        return minimumUploadPartSize;
+    }
+
+    /**
+     * Set the minimum part size for upload parts.
+     * @param minimumUploadPartSize the minimum part size to set. Anything below this value
+     *                              use a single upload
+     */
+    public void setMinimumUploadPartSize(final int minimumUploadPartSize) {
+        this.minimumUploadPartSize = Math.max(minimumUploadPartSize, MINIMUM_UPLOAD_PART_SIZE);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-android/issues/3015
https://github.com/aws-amplify/aws-sdk-android/issues/3016

*Description of changes:*
Currently, SDK does not expose any APIs for customizing part size or upload type (like to opt single file upload based on file size). This PR is for adding the features in the above 2 tickets - which will enable the client apps to configure part size.

Note: Opened this change after discussing with AWS SDK team (Please check with **Zlatan Dzinic** for more details)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
