### PR TITLE
feat(storage): Customize minimum multipart upload size

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
@@ -777,7 +777,7 @@ public class TransferUtility {
         double partSize = (double) remainingLength / (double) MAXIMUM_UPLOAD_PARTS;
         partSize = Math.ceil(partSize);
         final long optimalPartSize = (long) Math.max(partSize,
-                transferUtilityOptions.getMinimumUploadPartSizeInMB());
+                transferUtilityOptions.getMinimumUploadPartSizeInBytes());
         long fileOffset = 0;
         int partNumber = 1;
 
@@ -992,7 +992,7 @@ public class TransferUtility {
     private boolean shouldUploadInMultipart(File file) {
         return (
                 file != null &&
-                file.length() > transferUtilityOptions.getMinimumUploadPartSizeInMB()
+                file.length() > transferUtilityOptions.getMinimumUploadPartSizeInBytes()
         );
     }
 

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
@@ -43,6 +43,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.amazonaws.services.s3.internal.Constants.GB;
 import static com.amazonaws.services.s3.internal.Constants.MAXIMUM_UPLOAD_PARTS;
 import static com.amazonaws.services.s3.internal.Constants.MB;
 
@@ -141,7 +142,9 @@ public class TransferUtility {
      * Default minimum part size for upload parts. Anything below this will use a
      * single upload
      */
-    static final int MINIMUM_UPLOAD_PART_SIZE = 5 * MB;
+    static final int DEFAULT_MINIMUM_UPLOAD_PART_SIZE_IN_BYTES = 5 * MB;
+    static final int MINIMUM_SUPPORTED_UPLOAD_PART_SIZE_IN_BYTES = 5 * MB;
+    static final long MAXIMUM_SUPPORTED_UPLOAD_PART_SIZE_IN_BYTES = 5 * GB;
 
     private static String userAgentFromConfig = "";
 
@@ -770,16 +773,16 @@ public class TransferUtility {
      */
     private int createMultipartUploadRecords(String bucket, String key, File file, ObjectMetadata metadata,
             CannedAccessControlList cannedAcl) {
-        long remainingLenth = file.length();
-        double partSize = (double) remainingLenth / (double) MAXIMUM_UPLOAD_PARTS;
+        long remainingLength = file.length();
+        double partSize = (double) remainingLength / (double) MAXIMUM_UPLOAD_PARTS;
         partSize = Math.ceil(partSize);
         final long optimalPartSize = (long) Math.max(partSize,
-                transferUtilityOptions.getMinimumUploadPartSize());
+                transferUtilityOptions.getMinimumUploadPartSizeInMB());
         long fileOffset = 0;
         int partNumber = 1;
 
         // the number of parts
-        final int partCount = (int) Math.ceil((double) remainingLenth / (double) optimalPartSize);
+        final int partCount = (int) Math.ceil((double) remainingLength / (double) optimalPartSize);
 
         /*
          * the size of valuesArray is partCount + 1, one for a multipart upload summary,
@@ -789,11 +792,11 @@ public class TransferUtility {
         valuesArray[0] = dbUtil.generateContentValuesForMultiPartUpload(bucket, key, file, fileOffset, 0, "",
                 file.length(), 0, metadata, cannedAcl, transferUtilityOptions);
         for (int i = 1; i < partCount + 1; i++) {
-            final long bytesForPart = Math.min(optimalPartSize, remainingLenth);
+            final long bytesForPart = Math.min(optimalPartSize, remainingLength);
             valuesArray[i] = dbUtil.generateContentValuesForMultiPartUpload(bucket, key, file, fileOffset, partNumber,
-                    "", bytesForPart, remainingLenth - optimalPartSize <= 0 ? 1 : 0, metadata, cannedAcl, transferUtilityOptions);
+                    "", bytesForPart, remainingLength - optimalPartSize <= 0 ? 1 : 0, metadata, cannedAcl, transferUtilityOptions);
             fileOffset += optimalPartSize;
-            remainingLenth -= optimalPartSize;
+            remainingLength -= optimalPartSize;
             partNumber++;
         }
         return dbUtil.bulkInsertTransferRecords(valuesArray);
@@ -987,7 +990,10 @@ public class TransferUtility {
     }
 
     private boolean shouldUploadInMultipart(File file) {
-        return (file != null && file.length() > transferUtilityOptions.getMinimumUploadPartSize());
+        return (
+                file != null &&
+                file.length() > transferUtilityOptions.getMinimumUploadPartSizeInMB()
+        );
     }
 
     static <X extends AmazonWebServiceRequest> X appendTransferServiceUserAgentString(final X request) {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtility.java
@@ -773,7 +773,8 @@ public class TransferUtility {
         long remainingLenth = file.length();
         double partSize = (double) remainingLenth / (double) MAXIMUM_UPLOAD_PARTS;
         partSize = Math.ceil(partSize);
-        final long optimalPartSize = (long) Math.max(partSize, MINIMUM_UPLOAD_PART_SIZE);
+        final long optimalPartSize = (long) Math.max(partSize,
+                transferUtilityOptions.getMinimumUploadPartSize());
         long fileOffset = 0;
         int partNumber = 1;
 
@@ -986,7 +987,7 @@ public class TransferUtility {
     }
 
     private boolean shouldUploadInMultipart(File file) {
-        return (file != null && file.length() > MINIMUM_UPLOAD_PART_SIZE);
+        return (file != null && file.length() > transferUtilityOptions.getMinimumUploadPartSize());
     }
 
     static <X extends AmazonWebServiceRequest> X appendTransferServiceUserAgentString(final X request) {

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
@@ -181,6 +181,14 @@ public class TransferUtilityOptions implements Serializable {
     }
 
     /**
+     * Retrieve minimum part size for upload parts in Bytes.
+     * @return the minimum upload part size in Bytes
+     */
+    protected long getMinimumUploadPartSizeInBytes() {
+        return minimumUploadPartSizeInBytes;
+    }
+
+    /**
      * Retrieve minimum part size for upload parts in MB.
      * @return the minimum upload part size in MB
      */

--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferUtilityOptions.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.mobileconnectors.s3.transferutility;
 
+import static com.amazonaws.mobileconnectors.s3.transferutility.TransferUtility.MINIMUM_UPLOAD_PART_SIZE;
+import static com.amazonaws.services.s3.internal.Constants.MB;
+
 import java.io.Serializable;
 
 /**
@@ -65,6 +68,12 @@ public class TransferUtilityOptions implements Serializable {
     private int transferThreadPoolSize;
 
     /**
+     * Minimum part size for upload parts. Anything below this will use a
+     * single upload
+     */
+    private int minimumUploadPartSize;
+
+    /**
      * Type of connection to use for transfers.
      */
     protected TransferNetworkConnectionType transferNetworkConnectionType;
@@ -78,6 +87,7 @@ public class TransferUtilityOptions implements Serializable {
         this.transferServiceCheckTimeInterval = getDefaultCheckTimeInterval();
         this.transferThreadPoolSize = getDefaultThreadPoolSize();
         this.transferNetworkConnectionType = getDefaultTransferNetworkConnectionType();
+        this.minimumUploadPartSize = MINIMUM_UPLOAD_PART_SIZE;
     }
 
     /**
@@ -93,6 +103,7 @@ public class TransferUtilityOptions implements Serializable {
         this.transferServiceCheckTimeInterval = getDefaultCheckTimeInterval();
         this.transferThreadPoolSize = transferThreadPoolSize;
         this.transferNetworkConnectionType = transferNetworkConnectionType;
+        this.minimumUploadPartSize = MINIMUM_UPLOAD_PART_SIZE;
     }
 
     /**
@@ -160,6 +171,23 @@ public class TransferUtilityOptions implements Serializable {
      */
     static int getDefaultThreadPoolSize() {
         return 2 * (Runtime.getRuntime().availableProcessors() + 1);
+    }
+
+    /**
+     * Retrieve minimum part size for upload parts.
+     * @return the minimum upload part size
+     */
+    public int getMinimumUploadPartSize() {
+        return minimumUploadPartSize;
+    }
+
+    /**
+     * Set the minimum part size for upload parts.
+     * @param minimumUploadPartSize the minimum part size to set. Anything below this value
+     *                              use a single upload
+     */
+    public void setMinimumUploadPartSize(final int minimumUploadPartSize) {
+        this.minimumUploadPartSize = Math.max(minimumUploadPartSize, MINIMUM_UPLOAD_PART_SIZE);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-android/issues/3015
https://github.com/aws-amplify/aws-sdk-android/issues/3016

Previous PR:
https://github.com/aws-amplify/aws-sdk-android/pull/3037

*Description of changes:*
Allows customer to set multipart upload size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
