### PR TITLE
fix(iot): wait for disconnect to finish before setting connection state to disconnected

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1277,7 +1277,8 @@ public class AWSIotMqttManager {
         if (null != mqttClient) {
             if (mqttClient.isConnected()) {
                 try {
-                    mqttClient.disconnect(0);
+                    IMqttToken token = mqttClient.disconnect(0);
+                    token.waitForCompletion();
                 } catch (final MqttException e) {
                     throw new AmazonClientException("Client error when disconnecting.", e);
                 }

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManagerTest.java
@@ -417,7 +417,7 @@ public class AWSIotMqttManagerTest {
     }
 
     @Test
-    public void testConnectDisconnectConnect() throws Exception {
+    public void testRepeatedConnectDisconnect() throws Exception {
         MockMqttClient mockClient = new MockMqttClient();
 
         AWSIotMqttManager testClient = new AWSIotMqttManager("test-client",
@@ -429,15 +429,16 @@ public class AWSIotMqttManagerTest {
 
         KeyStore testKeystore = AWSIotKeystoreHelper.getIotKeystore(CERT_ID, KEYSTORE_PATH,
                 KEYSTORE_NAME, KEYSTORE_PASSWORD);
-        testClient.connect(testKeystore, csb);
-        mockClient.mockConnectSuccess();
-        assertEquals(MqttManagerConnectionState.Connected, testClient.getConnectionState());
-        testClient.disconnect();
-        assertEquals(MqttManagerConnectionState.Disconnected, testClient.getConnectionState());
-        testClient.connect(testKeystore, csb);
-        mockClient.mockConnectSuccess();
+        int connectionAttempts = 3;
+        for (int i = 0; i < connectionAttempts; i++) {
+            testClient.connect(testKeystore, csb);
+            mockClient.mockConnectSuccess();
+            assertEquals(MqttManagerConnectionState.Connected, testClient.getConnectionState());
+            testClient.disconnect();
+            assertEquals(MqttManagerConnectionState.Disconnected, testClient.getConnectionState());
+        }
 
-        assertEquals(2, mockClient.connectCalls);
+        assertEquals(connectionAttempts, mockClient.connectCalls);
     }
 
     @Test

--- a/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/MockMqttClient.java
+++ b/aws-android-sdk-iot/src/test/java/com/amazonaws/mobileconnectors/iot/MockMqttClient.java
@@ -2,6 +2,7 @@
 package com.amazonaws.mobileconnectors.iot;
 
 import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.internal.Token;
 
 import java.util.HashMap;
 
@@ -31,7 +32,7 @@ public class MockMqttClient extends MqttAsyncClient {
 
     public HashMap<String, Integer> mockSubscriptions;
 
-    IMqttToken testToken = new MqttToken("unit-test");
+    IMqttToken testToken = new TestMqttToken("unit-test");
     IMqttDeliveryToken testDeliveryToken = new MqttDeliveryToken();
 
     MockMqttClient() throws MqttException {
@@ -145,5 +146,22 @@ public class MockMqttClient extends MqttAsyncClient {
     public void mockDisconnect() {
         isConnected = false;
         mockCallback.connectionLost(new Exception("disconnect"));
+    }
+
+    private class TestToken extends Token {
+
+        public TestToken(String logContext) {
+            super(logContext);
+        }
+
+        @Override
+        public void waitForCompletion(long timeout) throws MqttException {}
+    }
+
+    private class TestMqttToken extends MqttToken {
+
+        public TestMqttToken(String logContext) {
+            internalTok = new TestToken(logContext);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #3036

*Description of changes:* When `AWSIotMqttManager.disconnect()` is called, wait for underlying Paho MqttClient to fully disconnect before changing the connection state to disconnected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
