### PR TITLE
fix(pinpoint):  Remove GCM service as target class usage as it is no longer allowed in Android 12.

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClient.java
@@ -183,8 +183,7 @@ public class NotificationClient {
      *
      * @param from         the from string received by the GCM service
      * @param data         the bundle received from the GCM service
-     * @param serviceClass the class extending GCMListenerService that handles
-     *                     receiving GCM messages.
+     * @param serviceClass No longer used due to Android 12 restrictions
      * @return {@link PushResult}.
      *
      * @deprecated Use {@link #handleCampaignPush(NotificationDetails)} instead.
@@ -195,7 +194,6 @@ public class NotificationClient {
                 NotificationDetails.builder()
                 .from(from)
                 .bundle(data)
-                .serviceClass(serviceClass)
                 .intentAction(GCM_INTENT_ACTION);
         return handleCampaignPush(notificationDetailsBuilder.build());
     }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationDetails.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationDetails.java
@@ -229,7 +229,7 @@ public class NotificationDetails {
             if (NotificationClient.GCM_INTENT_ACTION.equals(intentAction)) {
                 notificationDetails.setFrom(from);
                 notificationDetails.setBundle(bundle);
-                notificationDetails.setTargetClass(serviceClass);
+                notificationDetails.setTargetClass(PinpointNotificationActivity.class);
                 notificationDetails.setIntentAction(intentAction);
                 notificationDetails.setNotificationChannelId(notificationChannelId);
             }

--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationDetails.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationDetails.java
@@ -97,7 +97,6 @@ public class NotificationDetails {
      * new NotificationDetails.builder()
      *      .from(from)
      *      .bundle(bundle)
-     *      .serviceClass(serviceClass)
      *      .intentAction(NotificationClient.GCM_INTENT_ACTION)
      *      .build();
      *
@@ -111,7 +110,6 @@ public class NotificationDetails {
      * ADM example:
      *  new NotificationDetails.builder()
      *      .intent(intent)
-     *      .serviceClass(serviceClass)
      *      .intentAction(NotificationClient.ADM_INTENT_ACTION)
      *      .build();
      *
@@ -123,7 +121,6 @@ public class NotificationDetails {
     public static class NotificationDetailsBuilder {
         private String from;
         private Bundle bundle;
-        private Class<? extends Service> serviceClass;
         private String intentAction;
         private Map<String, String> mapData;
         private Intent intent;
@@ -156,11 +153,12 @@ public class NotificationDetails {
         /**
          * The Android Service class that received the push notification.
          * @param serviceClass Android service class that received the push notification
+         * @deprecated The set value is no longer used due to Android 12 restrictions
          * @return {@link NotificationDetailsBuilder}
          */
         @SuppressWarnings("checkstyle:hiddenfield")
+        @Deprecated
         public NotificationDetailsBuilder serviceClass(Class<? extends Service> serviceClass) {
-            this.serviceClass = serviceClass;
             return this;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
