### PR TITLE
fix(pinpoint): If event collection is disabled, _opening_ a notification will also cause a crash

### DIFF
--- a/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
+++ b/aws-android-sdk-pinpoint/src/main/java/com/amazonaws/mobileconnectors/pinpoint/targeting/notification/NotificationClientBase.java
@@ -844,12 +844,15 @@ abstract class NotificationClientBase {
             if (this.pinpointContext.getSessionClient() != null) {
                 this.pinpointContext.getSessionClient().stopSession();
             }
-            this.pinpointContext.getAnalyticsClient().updateEventSourceGlobally(eventSourceAttributes);
 
-            String eventType = eventSourceType.getEventTypeOpenend();
-            final AnalyticsEvent pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventType);
-            this.pinpointContext.getAnalyticsClient().recordEvent(pushEvent);
-            this.pinpointContext.getAnalyticsClient().submitEvents();
+            if (this.pinpointContext.getAnalyticsClient() != null) {
+                this.pinpointContext.getAnalyticsClient().updateEventSourceGlobally(eventSourceAttributes);
+
+                String eventType = eventSourceType.getEventTypeOpenend();
+                final AnalyticsEvent pushEvent = this.pinpointContext.getAnalyticsClient().createEvent(eventType);
+                this.pinpointContext.getAnalyticsClient().recordEvent(pushEvent);
+                this.pinpointContext.getAnalyticsClient().submitEvents();
+            }
 
             final String url = data.getString(EVENT_SOURCE_URL_PUSH_KEY);
             if (url != null) {


### PR DESCRIPTION
following up on #3117 -- somehow I only tested sending the notification, not opening it.  attempting to send the 'open' event when Pinpoint analytics is disabled also causes this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
