### PR TITLE
fix(auth): Dismiss custom tab on signout for all browsers

### DIFF
--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -24,6 +24,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
     api project(':aws-android-sdk-cognitoidentityprovider-asf')
-    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.browser:browser:1.3.0'
 }
 

--- a/aws-android-sdk-cognitoauth/build.gradle
+++ b/aws-android-sdk-cognitoauth/build.gradle
@@ -24,6 +24,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
     api project(':aws-android-sdk-cognitoidentityprovider-asf')
-    implementation 'androidx.browser:browser:1.3.0'
+    implementation 'androidx.browser:browser:1.4.0'
 }
 

--- a/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
+++ b/aws-android-sdk-cognitoauth/src/main/java/com/amazonaws/mobileconnectors/cognitoauth/AuthClient.java
@@ -828,7 +828,7 @@ public class AuthClient {
                 );
             } else {
                 Intent startIntent = CustomTabsManagerActivity.createStartIntent(context, mCustomTabsIntent.intent);
-                startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_NO_HISTORY);
+                startIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 context.startActivity(startIntent);
             }
     	} catch (final Exception e) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-android/issues/1968

*Description of changes:*
This change ensures that the custom tab dismisses on signOut. The `Intent.FLAG_ACTIVITY_NO_HISTORY` flag was preventing dismissal in Firefox.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
