### PR TITLE
fix(core): Add Signer classes to consumer proguard rules

### DIFF
--- a/aws-android-sdk-core/consumer-proguard-rules.pro
+++ b/aws-android-sdk-core/consumer-proguard-rules.pro
@@ -17,3 +17,9 @@
 # The SDK has several references of Apache HTTP client
 -dontwarn com.amazonaws.http.**
 -dontwarn com.amazonaws.metrics.**
+
+# AGP 8 enables R8 full-mode optimization, which will remove constructors of classes that are only
+# instantiated via reflection. These classes are instantiated via reflection in the SignerFactory.
+-keep class com.amazonaws.auth.AWS4Signer { *; }
+-keep class com.amazonaws.auth.QueryStringSigner { *; }
+-keep class com.amazonaws.auth.NoOpSigner { *; }


### PR DESCRIPTION
*Issue #, if available:* 3302

*Description of changes:* Add rules to the consumer proguard file to keep the various Signer classes instantiated by SignerFactory. AGP 8 enables R8 full-mode optimization, which normally removes unreferenced constructors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
