### PR TITLE
chore: revert guava

### DIFF
--- a/aws-android-sdk-ddb-document/build.gradle
+++ b/aws-android-sdk-ddb-document/build.gradle
@@ -13,6 +13,6 @@ android {
 dependencies {
     api project(':aws-android-sdk-core')
     implementation project(':aws-android-sdk-ddb')
-    implementation 'com.google.guava:guava:32.0.1-android'
+    implementation 'com.google.guava:guava:29.0-android'
 }
 

--- a/aws-android-sdk-lex/build.gradle
+++ b/aws-android-sdk-lex/build.gradle
@@ -12,6 +12,6 @@ android {
 
 dependencies {
     api project(':aws-android-sdk-core')
-    implementation 'com.google.guava:guava:32.0.1-android'
+    implementation 'com.google.guava:guava:29.0-android'
 }
 


### PR DESCRIPTION
Reverts aws-amplify/aws-sdk-android#3344

No FileBackedOutputStream or Files.createTempDir() in use.