### PR TITLE
chore: pin github actions by commit hash

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -14,12 +14,12 @@ jobs:
         sudo add-apt-repository -y ppa:git-core/ppa
         sudo apt-get update
         sudo apt-get install git -y
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         ref: ${{ env.BASE_BRANCH }}
         fetch-depth: 0
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@b8d447ba7506ac7e0c8fbc50762276fb3b7df731 # v1
       with:
         ruby-version: 2.7
     - name: Install dependencies

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           role-to-assume: ${{ secrets.SNAPSHOT_PUBLISHER_ROLE }}
           aws-region: us-east-1
       - name: Start Snapshot Release
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@f202c327329cbbebd13f986f74af162a8539b5fd # v1
         with:
           project-name: AndroidSDK-SnapshotRelease


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Pin gitHub actions by commit-hash instead of tags


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
