### PR TITLE
Read version number from build instead of hardcoding it

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/util/VersionInfoUtils.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/util/VersionInfoUtils.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.util;
 
+import com.amazonaws.BuildConfig;
 import com.amazonaws.logging.Log;
 import com.amazonaws.logging.LogFactory;
 
@@ -26,7 +27,7 @@ public class VersionInfoUtils {
     private static final int DEFAULT_STRING_LENGTH = 128;
 
     /** SDK version info */
-    private static volatile String version = "2.22.6";
+    private static volatile String version = BuildConfig.VERSION_NAME;
                                                                 // changed build
                                                                 // logic
 

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/util/VersionInfoUtilsTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/util/VersionInfoUtilsTest.java
@@ -15,6 +15,7 @@
 
 package com.amazonaws.util;
 
+import com.amazonaws.BuildConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -24,7 +25,7 @@ public class VersionInfoUtilsTest {
 
     @Test
     public void getVersion() {
-        assertEquals("2.22.6", VersionInfoUtils.getVersion());
+        assertEquals(BuildConfig.VERSION_NAME, VersionInfoUtils.getVersion());
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@ org.gradle.jvmargs=-Xmx1536m
 
 # Disable Gradle Android plugin features.
 # Reference: https://developer.android.com/studio/releases/gradle-plugin#4-0-0-new
-android.defaults.buildfeatures.buildconfig=false
 android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false


### PR DESCRIPTION
*Issue #, if available:*
Metrics have been stuck at 2.22.6.  Presumably build process used to update this hardcoded value.

*Description of changes:*
Simply read from build config like all of our other libraries.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
