### PR TITLE
feat(auth): Provide a clear message during getTokens that there are no valid tokens on device

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -91,6 +91,7 @@ import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.Cogn
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.ForgotPasswordContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.MultiFactorAuthenticationContinuation;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.continuations.NewPasswordContinuation;
+import com.amazonaws.mobileconnectors.cognitoidentityprovider.exceptions.CognitoNotAuthorizedException;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.AuthenticationHandler;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.ForgotPasswordHandler;
 import com.amazonaws.mobileconnectors.cognitoidentityprovider.handlers.GenericHandler;
@@ -2045,7 +2046,7 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
 
                             @Override
                             public void getAuthenticationDetails(AuthenticationContinuation authenticationContinuation, String userId) {
-                                signalTokensNotAvailable(null);
+                                signalTokensNotAvailable(new CognitoNotAuthorizedException("No valid tokens on device."));
                             }
 
                             @Override

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -2051,12 +2051,16 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
 
                             @Override
                             public void getMFACode(MultiFactorAuthenticationContinuation continuation) {
-                                signalTokensNotAvailable(null);
+                                signalTokensNotAvailable(
+                                        new Exception("MFA code requested during token refresh.")
+                                );
                             }
 
                             @Override
                             public void authenticationChallenge(ChallengeContinuation continuation) {
-                                signalTokensNotAvailable(null);
+                                signalTokensNotAvailable(
+                                        new Exception("Authentication challenge requested during token refresh.")
+                                );
                             }
 
                             @Override
@@ -2065,8 +2069,14 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                             }
 
                             private void signalTokensNotAvailable(final Exception e) {
+                                Exception exception;
+                                if (e == null) {
+                                    exception = new Exception(("Unknown error occurred during token refresh."));
+                                } else {
+                                    exception = e;
+                                }
                                 Log.w(TAG, "signalTokensNotAvailable");
-                                callback.onError(new Exception("No cached session.", e));
+                                callback.onError(new Exception("No cached session.", exception));
                             }
                         }
                     );


### PR DESCRIPTION
*Issue #, if available:*
N/A

We received a report that it is difficult to detect why the token refresh process fails, and if it is recoverable or not. This information is critical for a customer to understand whether or not the customer should log the user out.

We were able to identify that when a customer saw `Exception("No cached session.")` and there was an exception attached, such as `UnknownHostException`, these errors should be transient.

However, there are cases where the user only sees `Exception("No cached session.", null)` which leaves further questions on whether or not it is due to an invalid token, or some other transient issue.

*Description of changes:*

`getAuthenticationDetails` documentation states: "Call out to the dev to get the credentials for a user.". We can't do this during refresh flow, however, if we see this message, we understand that the Cognito service has stated that the refresh token is no longer valid.

The customer will now see ``Exception("No cached session.", new CognitoNotAuthorizedException("No valid tokens on device."))` and be able to act on this information.

I've added logging in additional places that are not expected to be hit, such as `getMFACode`, to make sure that we always provide better descriptions on refresh failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
