### PR TITLE
fix commit hash for setup-ruby in release pr workflow

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -19,7 +19,7 @@ jobs:
         ref: ${{ env.BASE_BRANCH }}
         fetch-depth: 0
     - name: Set up Ruby
-      uses: ruby/setup-ruby@b8d447ba7506ac7e0c8fbc50762276fb3b7df731 # v1
+      uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
       with:
         ruby-version: 2.7
     - name: Install dependencies


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
release_pr workflow fails with Unexpected HTTP response: 404. The PR updates ruby version to correct commit hash for v1.161.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
