### PR TITLE
Pin bundler to latest compatible version with Ruby 2.7

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd build-support
-        gem install bundler
+        gem install bundler -v 2.4.22 # Compatible with Ruby version 2.7
         bundle install
     - name: Configure git options
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses failing release_pr workflow. Latest version of bundler requires ruby>3.0.1. Since we are using ruby 2.7, this PR pins bundler to latest compatible version with Ruby 2.7. This ensures minimal changes to the workflow and avoids potential issues that might arise from updating Ruby.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
