### PR TITLE
Upgrade Ruby version to 3.0 for release-pr worrkflow

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
       with:
-        ruby-version: 2.7
+        ruby-version: "3.0"
     - name: Install dependencies
       run: |
         cd build-support


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes failing release-pr workflow by upgrading Ruby version to 3.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
