### PR TITLE
fix(all): Don't return incorrect date format instance

### DIFF
--- a/aws-android-sdk-core/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
+++ b/aws-android-sdk-core/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
@@ -249,7 +249,7 @@ public class SimpleTypeJsonUnmarshallers {
      */
     public static class DateJsonUnmarshaller implements Unmarshaller<Date, JsonUnmarshallerContext> {
         private static final int DATE_MULTIPLIER = 1000;
-        private final TimestampFormat format;
+        final TimestampFormat format;
 
         private DateJsonUnmarshaller(TimestampFormat format) {
             this.format = format;
@@ -286,10 +286,7 @@ public class SimpleTypeJsonUnmarshallers {
          * @return the instance.
          */
         public static DateJsonUnmarshaller getInstance() {
-            if (instance == null) {
-                instance = new DateJsonUnmarshaller(TimestampFormat.UNIX_TIMESTAMP);
-            }
-            return instance;
+            return getInstance(TimestampFormat.UNIX_TIMESTAMP);
         }
 
         /**

--- a/aws-android-sdk-core/src/test/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallerTest.java
+++ b/aws-android-sdk-core/src/test/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallerTest.java
@@ -257,6 +257,15 @@ public class SimpleTypeJsonUnmarshallerTest {
     }
 
     @Test
+    public void defaultFunctionAlwaysReturnsUnixTimestampUnmarshaller() {
+        SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller first =
+                SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller.getInstance(TimestampFormat.ISO_8601);
+        SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller second =
+                SimpleTypeJsonUnmarshallers.DateJsonUnmarshaller.getInstance();
+        assertEquals(TimestampFormat.UNIX_TIMESTAMP, second.format);
+    }
+
+    @Test
     public void testDoubleJsonUnmarshaller() throws Exception {
         Double dub = new Double(5.5);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `DateJsonUnmarshaller.getInstance()` function is supposed to return an instance that can unmarshall `UNIX_TIMESTAMP` dates, but due to a logic error it if any other piece of code used a different format when calling `DateJsonUnmarshaller getInstance(format)` then that format would be returned instead.

This change ensures that the version without arguments always returns an unmarshaller for `UNIX_TIMESTAMP`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
