### PR TITLE
fix(aws-android-sdk-auth-userpools): Check actual password requirements in drop-in UI

### DIFF
--- a/aws-android-sdk-auth-userpools/src/main/java/com/amazonaws/mobile/auth/userpools/SignUpActivity.java
+++ b/aws-android-sdk-auth-userpools/src/main/java/com/amazonaws/mobile/auth/userpools/SignUpActivity.java
@@ -101,7 +101,7 @@ public class SignUpActivity extends Activity {
         Log.d(LOG_TAG, "phone = " + phone);
 
 
-        final Integer minimumPasswordLength = getMinimumPasswordLength();
+        final Integer minimumPasswordLength = CognitoUserPoolsSignInProvider.getMinimumPasswordLength(configuration);
 
         if (username.isEmpty()) {
             showError(getString(R.string.sign_up_username_missing));
@@ -154,14 +154,5 @@ public class SignUpActivity extends Activity {
         ViewHelper.showDialog(this,
                 getString(R.string.title_activity_sign_up),
                 getString(R.string.sign_up_failed) + " " + msg);
-    }
-
-    @Nullable
-    private Integer getMinimumPasswordLength() {
-        JSONObject auth = configuration.optJsonObject("Auth");
-        if (auth == null) return null;
-        JSONObject passwordSettings = auth.optJSONObject("passwordProtectionSettings");
-        if (passwordSettings == null) return null;
-        return passwordSettings.optInt("passwordPolicyMinLength");
     }
 }

--- a/aws-android-sdk-auth-userpools/src/main/java/com/amazonaws/mobile/auth/userpools/SignUpActivity.java
+++ b/aws-android-sdk-auth-userpools/src/main/java/com/amazonaws/mobile/auth/userpools/SignUpActivity.java
@@ -38,6 +38,10 @@ import com.amazonaws.services.cognitoidentityprovider.model.SignUpResult;
 import static com.amazonaws.mobile.auth.userpools.CognitoUserPoolsSignInProvider.AttributeKeys.*;
 import static com.amazonaws.mobile.auth.userpools.CognitoUserPoolsSignInProvider.getErrorMessageFromException;
 
+import androidx.annotation.Nullable;
+
+import org.json.JSONObject;
+
 /**
  * Activity to prompt for account sign up information.
  */
@@ -47,6 +51,7 @@ public class SignUpActivity extends Activity {
 
     private SignUpView signUpView;
     private CognitoUserPool mUserPool;
+    private AWSConfiguration configuration;
 
     /**
      * Starts a {@link SignUpActivity}
@@ -67,7 +72,8 @@ public class SignUpActivity extends Activity {
         signUpView = (SignUpView) findViewById(R.id.signup_view);
 
         Context appContext = getApplicationContext();
-        mUserPool = new CognitoUserPool(appContext, new AWSConfiguration(appContext));
+        configuration = new AWSConfiguration(appContext);
+        mUserPool = new CognitoUserPool(appContext, configuration);
 
         InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY);
@@ -94,13 +100,16 @@ public class SignUpActivity extends Activity {
         Log.d(LOG_TAG, "email = " + email);
         Log.d(LOG_TAG, "phone = " + phone);
 
+
+        final Integer minimumPasswordLength = getMinimumPasswordLength();
+
         if (username.isEmpty()) {
             showError(getString(R.string.sign_up_username_missing));
             return;
         }
 
-        if (password.length() < 6) {
-            showError(getString(R.string.password_length_validation_failed));
+        if (minimumPasswordLength != null && password.length() < minimumPasswordLength) {
+            showError(getString(R.string.password_length_validation_failed_variable, minimumPasswordLength));
             return;
         }
 
@@ -145,5 +154,14 @@ public class SignUpActivity extends Activity {
         ViewHelper.showDialog(this,
                 getString(R.string.title_activity_sign_up),
                 getString(R.string.sign_up_failed) + " " + msg);
+    }
+
+    @Nullable
+    private Integer getMinimumPasswordLength() {
+        JSONObject auth = configuration.optJsonObject("Auth");
+        if (auth == null) return null;
+        JSONObject passwordSettings = auth.optJSONObject("passwordProtectionSettings");
+        if (passwordSettings == null) return null;
+        return passwordSettings.optInt("passwordPolicyMinLength");
     }
 }

--- a/aws-android-sdk-auth-userpools/src/main/res/values/strings.xml
+++ b/aws-android-sdk-auth-userpools/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="mfa_code_empty">MFA Code is empty.</string>
     <string name="mfa_failed">MFA Failed.</string>
     <string name="password_length_validation_failed">Password should have 6 or more characters.</string>
+    <string name="password_length_validation_failed_variable">Password should have %d or more characters.</string>
     <string name="sign_up_username_missing">Missing username.</string>
     <string name="sign_up_confirm_code_missing">Sign Up Confirmation code is missing.</string>
     <string name="sign_up_in_progress">Sign up in progress</string>


### PR DESCRIPTION
*Issue #, if available:* #2370

*Description of changes:*
Don't hardcode the minimum password length to six. Instead, check the `passwordProtectionSettings` defined in `awsconfiguration.json` and use those for client-side validation.

![Screenshot_20240605_153943](https://github.com/aws-amplify/aws-sdk-android/assets/2781254/bc5ba658-5532-4ae7-bdab-4de39dded7ff)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
