### PR TITLE
fix(misc): Add rexml dependency

### DIFF
--- a/build-support/Gemfile.lock
+++ b/build-support/Gemfile.lock
@@ -224,4 +224,4 @@ DEPENDENCIES
   fastlane-plugin-semantic_release
 
 BUNDLED WITH
-   2.1.4
+   2.1.2

--- a/build-support/Gemfile.lock
+++ b/build-support/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rexml (3.2.8)
-      strscan
+      strscan (>= 3.0.9)
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)

--- a/build-support/Gemfile.lock
+++ b/build-support/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rexml (3.2.8)
+      strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -185,6 +186,7 @@ GEM
     simctl (1.6.8)
       CFPropertyList
       naturally
+    strscan (3.1.0)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -222,4 +224,4 @@ DEPENDENCIES
   fastlane-plugin-semantic_release
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
There was a build issue when preparing the new release because the updated rexml version revealed new dependencies that weren't added to the Gemfile.lock file. Ran `bundle update rexml` which added the dependency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
