### PR TITLE
chore: update POM license name to Apache 2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,8 +32,8 @@ POM_SCM_URL=https://github.com/aws/aws-sdk-android
 POM_SCM_CONNECTION=scm:git:git://github.com/aws/aws-sdk-android.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/aws/aws-sdk-android.git
 
-POM_LICENCE_NAME=Amazon Software License
-POM_LICENCE_URL=https://aws.amazon.com/asl/
+POM_LICENCE_NAME=Apache 2.0
+POM_LICENCE_URL=http://aws.amazon.com/apache2.0
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=amazonwebservices


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating license name to Apache 2.0 so that license in Maven repo matches with license in GitHub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
