### PR TITLE
Set the ForegroundServiceType for TransferService

### DIFF
--- a/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
+++ b/aws-android-sdk-s3/src/main/java/com/amazonaws/mobileconnectors/s3/transferutility/TransferService.java
@@ -20,6 +20,7 @@ import android.app.Service;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.ServiceInfo;
 import android.net.ConnectivityManager;
 import android.os.Build;
 import android.os.IBinder;
@@ -144,13 +145,18 @@ public class TransferService extends Service {
                     if (userProvidedNotification != null) {
                         // Get the notification Id from the intent, if it's null, the default notification Id will be returned.
                         ongoingNotificationId = (int) intent.getIntExtra(INTENT_KEY_NOTIFICATION_ID, ongoingNotificationId);
-                        
+
                         // Get removeNotification from the intent, if it's null, removeNotification will be returned.
                         removeNotification = (boolean) intent.getBooleanExtra(INTENT_KEY_REMOVE_NOTIFICATION, removeNotification);
 
                         // Put the service in foreground state
                         LOGGER.info("Putting the service in Foreground state.");
-                        startForeground(ongoingNotificationId, userProvidedNotification);
+                        if (Build.VERSION.SDK_INT >= 34 /* UPSIDE_DOWN_CAKE */) {
+                            // We must provide a service type flag when application is targeting sdk >= 34
+                            startForeground(ongoingNotificationId, userProvidedNotification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+                        } else {
+                            startForeground(ongoingNotificationId, userProvidedNotification);
+                        }
                     } else {
                         LOGGER.error("No notification is passed in the intent. "
                             + "Unable to transition to foreground.");


### PR DESCRIPTION
*Issue #, if available:*
#3617

*Description of changes:*
Starting on API 34, foreground services must supply a foreground service type. Our service type is `data sync`, which corresponds to a service that uploads or downloads data.

In addition to supplying this type in code, customers must make some changes to their application manifest:

- Add the service type permission
- Add the service type to the service declaration

The manifest should look something like this:

```xml
    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>

    <application>
        <service
            android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService"
            android:foregroundServiceType="dataSync" />

    </application>
```

A corresponding docs PR is [here](https://github.com/aws-amplify/docs/pull/7853).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
