### PR TITLE
chore: update package cognitoidentityprovider license to Amazon

### DIFF
--- a/aws-android-sdk-cognitoidentityprovider/gradle.properties
+++ b/aws-android-sdk-cognitoidentityprovider/gradle.properties
@@ -2,3 +2,5 @@ POM_ARTIFACT_ID=aws-android-sdk-cognitoidentityprovider
 POM_DESCRIPTION=The AWS Android SDK for Amazon Cognito Identity Provider module holds the client classes that are used for communicating with Amazon Cognito Identity Provider Service
 POM_NAME=AWS SDK for Android - Amazon Cognito Identity Provider
 POM_PACKAGING=aar
+POM_LICENCE_NAME=Amazon Software License
+POM_LICENCE_URL=https://aws.amazon.com/asl/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As stated in the [license file](https://github.com/aws-amplify/aws-sdk-android/blob/main/LICENSE.txt), the `cognitoidentityprovider` package is specifically listed under the Amazon Software License.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
