### PR TITLE
Updated README to be more precise. Provided context about Amplify in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@
 [![GitHub release](https://img.shields.io/github/release/aws-amplify/aws-sdk-android.svg)](https://github.com/aws-amplify/aws-sdk-android/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.amazonaws/aws-android-sdk-core.svg)](https://search.maven.org/search?q=a:aws-android-sdk-core)
 
-For existing customers planning to migrate to the new Amplify Android v2, we recommend reviewing our [migration guide](https://github.com/aws-amplify/amplify-android/blob/main/documents/MobileSDK_To_AmplifyAndroid.md).
-
-For new projects, we recommend using the latest v2 version of [AWS Amplify Library for Android](https://docs.amplify.aws/android/start/quickstart/) to quickly implement common app use cases like Authentication, Storage, Push Notifications and more.
-
-Note: v2 of Amplify Library for Android (currently GA) is built on top of [the AWS SDK for Kotlin](https://aws.amazon.com/sdk-for-kotlin/). You can access this underlying SDK via [the Escape Hatch from AWS Amplify](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/android/#escape-hatches).
-
-You can also use AWS Amplify with [your existing AWS cloud resources](https://docs.amplify.aws/android/start/connect-existing-aws-resources/). If you are unable to find features you are looking for in Amplify, please open an issue in [the Amplify Library for Android GitHub repo](https://github.com/aws-amplify/amplify-android/issues/new/choose) and we will be happy to consider you request.
-
-If you still wish to use the AWS SDK for Android directly, you can refer to [the AWS SDK Documentation here](https://docs.amplify.aws/sdk/q/platform/android/) and follow the installation instructions below.
+> ### Note
+>
+> AWS Amplify Library for Android is new opinionated solution/implementation to complex problems faced in developing mobile application. It is recommended one for new app development.
+> 
+> For existing customers planning to migrate to the new Amplify Android v2, we recommend reviewing our [migration guide](https://github.com/aws-amplify/amplify-android/blob/main/documents/MobileSDK_To_AmplifyAndroid.md).
+>
+> For new projects, we recommend using the latest v2 version of [AWS Amplify Library for Android](https://docs.amplify.aws/android/start/quickstart/) to quickly implement common app use cases like Authentication, Storage, Push Notifications and more.
+>
+> Note: v2 of Amplify Library for Android (currently GA) is built on top of [the AWS SDK for Kotlin](https://aws.amazon.com/sdk-for-kotlin/). You can access this underlying SDK via [the Escape Hatch from AWS Amplify](https://docs.amplify.aws/lib/project-setup/upgrade-guide/q/platform/android/#escape-hatches).
+>
+> You can also use AWS Amplify with [your existing AWS cloud resources](https://docs.amplify.aws/android/start/connect-existing-aws-resources/). If you are unable to find features you are looking for in Amplify, please open an issue in [the Amplify Library for Android GitHub repo](https://github.com/aws-amplify/amplify-android/issues/new/choose) and we will be happy to consider you request.
+>
+> If you still wish to use the AWS SDK for Android directly, you can refer to [the AWS SDK Documentation here](https://docs.amplify.aws/sdk/q/platform/android/) and follow the installation instructions below.
+>
+> This repo will continue be maintained with bug fixes and security updates.
 
 The AWS SDK for Android is a collection of low-level libraries for direct interaction with AWS backend services. For use cases not covered by the Amplify Framework, you may directly integrate these clients into your Android app.
 


### PR DESCRIPTION
*Issue #, if available: #3637*

*Description of changes:*

## Problem Statement

- Currently README starts with providing Migration Guide for Amplify V2, which can be mis-interpreted as if this Repo is Amplify itself and sounds like new version of Amplify is released which is breaking change and here it is pointing to migration guide.
- I am not sure about how many people will get confused with this and raise questions like here.
  - #3637
- I am a new developer trying to create Android app for AWS services and this will make a good case to see this problem and PR reasonable to avoid unnecessary questions from beginners.
- It also looks like this not the recommended one for new app development, though it is not deprecated now, it is unlikely that this will be added/updated with new features from AWS making it one more reason to be more precise about it in README.

## Solution

- Changed it to markdown `Blockquotes` format to show separation from Amplify and this repo.
- Added info on what is Amplify library actually and it is recommended one.
 - Added info saying that this repo will be updated with security and bug fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
