### PR TITLE
feat(auth): Remove support for setting query parameters for the tokens endpoint

### DIFF
--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/AWSMobileClient.java
@@ -3359,18 +3359,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         return;
                     }
                 }
-                if (hostedUIOptions.getTokenQueryParameters() != null) {
-                    try {
-                    JSONObject tokenParams = new JSONObject();
-                    for (Map.Entry<String, String> e : hostedUIOptions.getTokenQueryParameters().entrySet()) {
-                            tokenParams.put(e.getKey(), e.getValue());
-                    }
-                    hostedUIJSON.put("TokenQueryParameters", tokenParams);
-                    } catch (JSONException e1) {
-                        callback.onError(new Exception("Failed to construct token query parameters", e1));
-                        return;
-                    }
-                }
 
                 mStore.set(HOSTED_UI_KEY, hostedUIJSON.toString());
 
@@ -3389,21 +3377,15 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                     throw new RuntimeException("Failed to construct authorization url for OAuth", e);
                 }
 
-                Uri.Builder tokensUriBuilder;
+                final Uri tokensUri;
                 final Map<String, String> tokensBody = new HashMap<String, String>();
                 try {
-                    tokensUriBuilder = Uri.parse(hostedUIJSON.getString("TokenURI")).buildUpon();
-                    if (hostedUIOptions.getTokenQueryParameters() != null) {
-                        for (Map.Entry<String, String> e : hostedUIOptions.getTokenQueryParameters().entrySet()) {
-                            tokensUriBuilder.appendQueryParameter(e.getKey(), e.getValue());
-                        }
-                    }
+                    tokensUri = Uri.parse(hostedUIJSON.getString("TokenURI"));
                     tokensBody.put("client_id", hostedUIJSON.getString("AppClientId"));
                     tokensBody.put("redirect_uri", hostedUIJSON.getString("SignInRedirectURI"));
                 } catch (Exception e) {
                     throw new RuntimeException("Failed to construct tokens url for OAuth", e);
                 }
-                final Uri tokensUri = tokensUriBuilder.build();
 
                 mOAuth2Client.authorize(authorizeUriBuilder.build(), new Callback<AuthorizeResponse>() {
                     @Override
@@ -3489,18 +3471,6 @@ public final class AWSMobileClient implements AWSCredentialsProvider {
                         hostedUIJSON.put("SignOutQueryParameters", signOutParams);
                     } catch (JSONException e1) {
                         callback.onError(new Exception("Failed to construct sign-out query parameters", e1));
-                        return;
-                    }
-                }
-                if (hostedUIOptions.getTokenQueryParameters() != null) {
-                    try {
-                        JSONObject tokenParams = new JSONObject();
-                        for (Map.Entry<String, String> e : hostedUIOptions.getTokenQueryParameters().entrySet()) {
-                            tokenParams.put(e.getKey(), e.getValue());
-                        }
-                        hostedUIJSON.put("TokenQueryParameters", tokenParams);
-                    } catch (JSONException e1) {
-                        callback.onError(new Exception("Failed to construct token query parameters", e1));
                         return;
                     }
                 }

--- a/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/HostedUIOptions.java
+++ b/aws-android-sdk-mobile-client/src/main/java/com/amazonaws/mobile/client/HostedUIOptions.java
@@ -38,10 +38,6 @@ public class HostedUIOptions {
         return builder.signOutQueryParameters;
     }
 
-    public Map<String, String> getTokenQueryParameters() {
-        return builder.tokenQueryParameters;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -54,7 +50,6 @@ public class HostedUIOptions {
         private String federationProviderName;
         private Map<String, String> signInQueryParameters;
         private Map<String, String> signOutQueryParameters;
-        private Map<String, String> tokenQueryParameters;
 
         public Builder() { }
 
@@ -65,11 +60,6 @@ public class HostedUIOptions {
 
         public Builder signOutQueryParameters(final Map<String, String> signOutQueryParameters) {
             this.signOutQueryParameters = signOutQueryParameters;
-            return this;
-        }
-
-        public Builder tokenQueryParameters(final Map<String, String> tokenQueryParameters) {
-            this.tokenQueryParameters = tokenQueryParameters;
             return this;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove support to set query parameters in requests to the token endpoint. This was a violation of the OAuth spec and Cognito has been updated to reject requests with parameters appended.

See: https://github.com/aws-amplify/aws-sdk-ios/pull/5519

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
